### PR TITLE
[common] CloseableBundleContext handle common Object methods

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/osgi/CloseableBundleContext.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/osgi/CloseableBundleContext.java
@@ -84,6 +84,17 @@ public class CloseableBundleContext implements AutoCloseable, InvocationHandler 
 				return method.invoke(bundleContext, args);
 			}
 		}
+		if (method.getDeclaringClass()
+			.equals(Object.class)) {
+			switch (method.getName()) {
+				case "toString" :
+					return delegatedToString(proxy);
+				case "hashCode" :
+					return bundleContext.hashCode();
+				case "equals" :
+					return bundleContext.equals(args[0]);
+			}
+		}
 
 		throw new IllegalArgumentException();
 	}
@@ -101,6 +112,10 @@ public class CloseableBundleContext implements AutoCloseable, InvocationHandler 
 		bListeners.forEach(bundleContext::removeBundleListener);
 		sListeners.forEach(bundleContext::removeServiceListener);
 		fwListeners.forEach(bundleContext::removeFrameworkListener);
+	}
+
+	public String delegatedToString(Object proxy) {
+		return "CloseableBundleContext[" + System.identityHashCode(proxy) + "]:" + bundleContext.toString();
 	}
 
 	public Bundle installBundle(String location, InputStream input) throws BundleException {

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
 			<name>Ray Augé</name>
 			<email>raymond.auge@liferay.com</email>
 		</developer>
+		<developer>
+			<id>kriegfrj</id>
+			<name>Fr Jeremy Krieg</name>
+			<email>fr.jkrieg@greekwelfaresa.org.au</email>
+		</developer>
 	</developers>
 	<issueManagement>
 		<system>GitHub Issues</system>


### PR DESCRIPTION
Looking at all of the primitive methods in `Object`, there are quite a few (in particular, those that deal with synchronization) that open up a can of worms with regards to how to handle them. So I have elected to override the ones that are most commonly used (`toString()` for example is often used in testing/debugging), and leave the `IllegalArgumentException` as the default behaviour for the others.