### PR TITLE
add missing constructor for parity with junit5 extension

### DIFF
--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/service/ServiceUseRule.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/service/ServiceUseRule.java
@@ -56,6 +56,13 @@ public class ServiceUseRule<T> extends BaseServiceUse<T>
 		/**
 		 * @param serviceType of the service
 		 */
+		public Builder(Class<T> serviceType) {
+			this(serviceType, new BundleContextRule());
+		}
+
+		/**
+		 * @param serviceType of the service
+		 */
 		public Builder(Class<T> serviceType, BundleContextRule bundleContextRule) {
 			this.serviceType = requireNonNull(serviceType);
 			this.bundleContextRule = requireNonNull(bundleContextRule);


### PR DESCRIPTION
Signed-off-by: Raymond Augé <raymond.auge@liferay.com>