### PR TITLE
Change Bundle-Name for test bundles

### DIFF
--- a/org.osgi.test.junit4/pom.xml
+++ b/org.osgi.test.junit4/pom.xml
@@ -91,6 +91,7 @@
 							<bnd><![CDATA[
 								p = org.osgi.test.junit4
 								Bundle-SymbolicName: ${project.artifactId}-test
+								Bundle-Name: ${project.groupId}:${project.artifactId}-test
 								Export-Package: !${p}.tb*,${p}.*
 								Fragment-Host: ${project.artifactId}
 								Test-Cases: ${classes;CONCRETE;ANNOTATED;org.junit.Test}

--- a/org.osgi.test.junit5/pom.xml
+++ b/org.osgi.test.junit5/pom.xml
@@ -125,6 +125,7 @@
 									<bnd><![CDATA[
 										p = org.osgi.test.junit5
 										Bundle-SymbolicName: ${project.artifactId}-test
+										Bundle-Name: ${project.groupId}:${project.artifactId}-test
 										Export-Package: !${p}.tb*,${p}.*
 										Fragment-Host: ${project.artifactId}
 										Test-Cases: ${classes;CONCRETE;ANNOTATED;org.junit.jupiter.api.Test}


### PR DESCRIPTION
Previously, test bundles had the same Bundle-Name as the main project bundle which is confusing in test output.

Signed-off-by: Fr Jeremy Krieg <fr.jkrieg@greekwelfaresa.org.au>