### PR TITLE
dictionary: Handle maps which do not support null keys or values

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/dictionary/Dictionaries.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/dictionary/Dictionaries.java
@@ -313,10 +313,22 @@ public class Dictionaries {
 		@SuppressWarnings("unchecked")
 		MapAsDictionary(Map<? extends K, ? extends V> map) {
 			this.map = (Map<K, V>) requireNonNull(map);
-			if (map.containsKey(null)) {
+			boolean nullKey;
+			try {
+				nullKey = map.containsKey(null);
+			} catch (NullPointerException e) {
+				nullKey = false; // map does not allow null key
+			}
+			if (nullKey) {
 				throw new NullPointerException("a Dictionary cannot contain a null key");
 			}
-			if (map.containsValue(null)) {
+			boolean nullValue;
+			try {
+				nullValue = map.containsValue(null);
+			} catch (NullPointerException e) {
+				nullValue = false; // map does not allow null value
+			}
+			if (nullValue) {
 				throw new NullPointerException("a Dictionary cannot contain a null value");
 			}
 		}

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/dictionary/DictionariesTestCase.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/dictionary/DictionariesTestCase.java
@@ -17,6 +17,7 @@
 package org.osgi.test.common.dictionary;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -253,7 +255,20 @@ public class DictionariesTestCase {
 		assertThatNullPointerException().isThrownBy(() -> {
 			entry.setValue(null);
 		});
+	}
 
+	@Test
+	public void no_null_key_or_value_map() {
+		Map<String, String> noNullKeyValueMap = new ConcurrentHashMap<>();
+		assertThatNullPointerException().isThrownBy(() -> {
+			noNullKeyValueMap.containsKey(null);
+		});
+		assertThatNullPointerException().isThrownBy(() -> {
+			noNullKeyValueMap.containsValue(null);
+		});
+		assertThatCode(() -> {
+			Dictionaries.asDictionary(noNullKeyValueMap);
+		}).doesNotThrowAnyException();
 	}
 
 	@Test


### PR DESCRIPTION
Maps may throw NullPointerException when tested for null key or null
value. For example, ConcurrentHashMap and Java 9's Map.of maps. So we
must handle such Map implementations.