### PR TITLE
Build.cleanup

### DIFF
--- a/org.osgi.test.junit4/pom.xml
+++ b/org.osgi.test.junit4/pom.xml
@@ -81,28 +81,23 @@
 				<executions>
 					<!-- Integration Test Configuration -->
 					<execution>
-						<id>bnd-process-test</id>
+						<id>bnd-process-tests</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>bnd-process</goal>
+							<goal>bnd-process-tests</goal>
 						</goals>
 						<configuration>
+							<artifactFragment>true</artifactFragment>
 							<bnd><![CDATA[
 								p = org.osgi.test.junit4
-								Bundle-SymbolicName: ${project.artifactId}-test
-								Bundle-Name: ${project.groupId}:${project.artifactId}-test
-								Export-Package: !${p}.tb*,${p}.*
-								Fragment-Host: ${project.artifactId}
-								Test-Cases: ${classes;CONCRETE;ANNOTATED;org.junit.Test}
-								-fixupmessages: "Host ${project.artifactId}=...";is:=ignore
+								Export-Package: !${p}.tb*,${p}.*;-split-package:=first
+								-fixupmessages: "Export-Package duplicate package name..."
 								-make: (*).(jar); type=bnd; recipe="${.}/bnd/$1.bnd"
 								-includeresource:\
 									tb1.jar,\
 									foo/tbfoo.jar=tb1.jar
 							]]></bnd>
-							<classesDir>${project.build.testOutputDirectory}</classesDir>
-							<outputDir>${project.build.testOutputDirectory}</outputDir>
-							<manifestPath>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestPath>
+							<testCases>junit4</testCases>
 							<includeClassesDir>false</includeClassesDir>
 						</configuration>
 					</execution>
@@ -126,7 +121,7 @@
 								<bndrun>test.bndrun</bndrun>
 							</bndruns>
 							<bundles>
-								<bundle>target/${project.build.finalName}-test.jar</bundle>
+								<bundle>target/${project.build.finalName}-tests.jar</bundle>
 							</bundles>
 							<failOnChanges>false</failOnChanges>
 							<includeDependencyManagement>true</includeDependencyManagement>
@@ -156,7 +151,7 @@
 								<bndrun>test.bndrun</bndrun>
 							</bndruns>
 							<bundles>
-								<bundle>target/${project.build.finalName}-test.jar</bundle>
+								<bundle>target/${project.build.finalName}-tests.jar</bundle>
 							</bundles>
 							<failOnChanges>false</failOnChanges>
 							<includeDependencyManagement>true</includeDependencyManagement>
@@ -177,11 +172,9 @@
 						<id>test-jar</id>
 						<phase>package</phase>
 						<goals>
-							<goal>jar</goal>
+							<goal>test-jar</goal>
 						</goals>
 						<configuration>
-							<classifier>test</classifier>
-							<classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
 							<archive>
 								<manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 							</archive>

--- a/org.osgi.test.junit4/test.bndrun
+++ b/org.osgi.test.junit4/test.bndrun
@@ -30,10 +30,10 @@
 	ch.qos.logback.core,\
 	org.apache.felix.logback,\
 	slf4j.api
--runrequires: bnd.identity;id='${project.artifactId}-test'
+-runrequires: bnd.identity;id='${project.artifactId}-tests'
 -runbundles: \
 	assertj-core;version='[3.15.0,3.15.1)',\
 	org.apache.servicemix.bundles.junit;version='[4.12.0,4.12.1)',\
 	org.osgi.test.common;version='[1.0.0,1.0.1)',\
-	org.osgi.test.junit4-test;version='[1.0.0,1.0.1)',\
+	org.osgi.test.junit4-tests;version='[1.0.0,1.0.1)',\
 	org.osgi.test.junit4;version='[1.0.0,1.0.1)'

--- a/org.osgi.test.junit5/pom.xml
+++ b/org.osgi.test.junit5/pom.xml
@@ -132,28 +132,22 @@
 				<executions>
 					<!-- Integration Test Configuration -->
 					<execution>
-						<id>bnd-process-test</id>
+						<id>bnd-process-tests</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>bnd-process</goal>
+							<goal>bnd-process-tests</goal>
 						</goals>
 						<configuration>
+							<artifactFragment>true</artifactFragment>
 							<bnd><![CDATA[
-                                        p = org.osgi.test.junit5
-                                        Bundle-SymbolicName: ${project.artifactId}-test
-                                        Bundle-Name: ${project.groupId}:${project.artifactId}-test
-                                        Export-Package: !${p}.tb*,${p}.*
-                                        Fragment-Host: ${project.artifactId}
-                                        Test-Cases: ${classes;CONCRETE;ANNOTATED;org.junit.jupiter.api.Test}
-                                        -fixupmessages: "Host ${project.artifactId}=...";is:=ignore
-                                        -make: (*).(jar); type=bnd; recipe="${.}/bnd/$1.bnd"
-                                        -includeresource:\
-                                            tb1.jar,\
-                                            foo/tbfoo.jar=tb1.jar
-                                    ]]></bnd>
-							<classesDir>${project.build.testOutputDirectory}</classesDir>
-							<outputDir>${project.build.testOutputDirectory}</outputDir>
-							<manifestPath>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestPath>
+								p = org.osgi.test.junit5
+								Export-Package: !${p}.tb*,${p}.*;-split-package:=first
+								-fixupmessages: "Export-Package duplicate package name..."
+								-make: (*).(jar); type=bnd; recipe="${.}/bnd/$1.bnd"
+								-includeresource:\
+									tb1.jar,\
+									foo/tbfoo.jar=tb1.jar
+							]]></bnd>
 							<includeClassesDir>false</includeClassesDir>
 						</configuration>
 					</execution>
@@ -183,7 +177,7 @@
 								<bndrun>test.bndrun</bndrun>
 							</bndruns>
 							<bundles>
-								<bundle>target/${project.build.finalName}-test.jar</bundle>
+								<bundle>target/${project.build.finalName}-tests.jar</bundle>
 							</bundles>
 							<failOnChanges>false</failOnChanges>
 							<includeDependencyManagement>true</includeDependencyManagement>
@@ -213,7 +207,7 @@
 								<bndrun>test.bndrun</bndrun>
 							</bndruns>
 							<bundles>
-								<bundle>target/${project.build.finalName}-test.jar</bundle>
+								<bundle>target/${project.build.finalName}-tests.jar</bundle>
 							</bundles>
 							<failOnChanges>false</failOnChanges>
 							<includeDependencyManagement>true</includeDependencyManagement>
@@ -234,11 +228,9 @@
 						<id>test-jar</id>
 						<phase>package</phase>
 						<goals>
-							<goal>jar</goal>
+							<goal>test-jar</goal>
 						</goals>
 						<configuration>
-							<classifier>test</classifier>
-							<classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
 							<archive>
 								<manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 							</archive>

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceUseExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceUseExtensionTest.java
@@ -206,6 +206,8 @@ public class ServiceUseExtensionTest {
 				.hasSize(1);
 			softly.assertThat(it.getExtension()
 				.getTrackingCount())
+				.as("Services %s", it.getExtension()
+					.getServiceReferences())
 				.isEqualTo(1);
 			softly.assertThat(it.getExtension()
 				.getCardinality())
@@ -264,6 +266,8 @@ public class ServiceUseExtensionTest {
 				.isNotEmpty();
 			softly.assertThat(it.getExtension()
 				.getTrackingCount())
+				.as("Services %s", it.getExtension()
+					.getServiceReferences())
 				.isEqualTo(1);
 			softly.assertThat(it.getExtension()
 				.getCardinality())

--- a/org.osgi.test.junit5/test.bndrun
+++ b/org.osgi.test.junit5/test.bndrun
@@ -37,22 +37,22 @@
 	org.apache.felix.logback,\
 	slf4j.api
 -runrequires: \
-	bnd.identity;id='${project.artifactId}-test',\
+	bnd.identity;id='${project.artifactId}-tests',\
 	bnd.identity;id='${junit-jupiter-engine.bsn}',\
 	bnd.identity;id='${junit-platform-launcher.bsn}'
 -runbundles: \
 	assertj-core;version='[3.15.0,3.15.1)',\
-	net.bytebuddy.byte-buddy;version='[1.10.5,1.10.6)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.10.5,1.10.6)',\
-	org.mockito.mockito-core;version='[3.2.4,3.2.5)',\
-	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.osgi.test.common;version='[1.0.0,1.0.1)',\
-	org.osgi.test.junit5;version='[1.0.0,1.0.1)',\
-	org.osgi.test.junit5-test;version='[1.0.0,1.0.1)',\
+	net.bytebuddy.byte-buddy;version='[1.10.5,1.10.6)',\
 	org.apiguardian;version='[1.0.0,1.0.1)',\
 	org.junit.jupiter.api;version='[5.3.1,5.3.2)',\
 	org.junit.jupiter.engine;version='[5.3.1,5.3.2)',\
 	org.junit.platform.commons;version='[1.3.1,1.3.2)',\
 	org.junit.platform.engine;version='[1.3.1,1.3.2)',\
 	org.junit.platform.launcher;version='[1.3.1,1.3.2)',\
-	org.opentest4j;version='[1.1.1,1.1.2)'
+	org.mockito.mockito-core;version='[3.3.0,3.3.1)',\
+	org.objenesis;version='[2.6.0,2.6.1)',\
+	org.opentest4j;version='[1.1.1,1.1.2)',\
+	org.osgi.test.common;version='[1.0.0,1.0.1)',\
+	org.osgi.test.junit5-tests;version='[1.0.0,1.0.1)',\
+	org.osgi.test.junit5;version='[1.0.0,1.0.1)'


### PR DESCRIPTION
This uses the new (in bnd 5.0.0) `bnd-process-tests` maven mojo to simplify integration test setup.