### PR TITLE
services: Sort lists of service/ServiceReference

### DIFF
--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/AbstractBundleAssert.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/AbstractBundleAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2019). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2019, 2020). All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/BundleAssert.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/BundleAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2019). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2019, 2020). All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/BundleSoftAssertions.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/BundleSoftAssertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2019). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2019, 2020). All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/AbstractVersionAssert.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/AbstractVersionAssert.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.version;
 
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/VersionAssert.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/VersionAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2019). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/package-info.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2019, 2020). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 @org.osgi.annotation.bundle.Export
 @org.osgi.annotation.versioning.Version("1.0.0")
-package org.osgi.test.assertj.bundle;
+package org.osgi.test.assertj.version;


### PR DESCRIPTION
Like DS, we return lists of service or ServiceReference sorted by the natural order of ServiceReference.