### PR TITLE
Make BundleContextExtension usable without an instance

### DIFF
--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
@@ -41,12 +41,11 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.test.common.context.CloseableBundleContext;
 import org.osgi.test.common.install.InstallBundle;
 
-public class BundleContextExtension
-	implements AfterEachCallback, BeforeEachCallback, ParameterResolver {
+public class BundleContextExtension implements AfterEachCallback, BeforeEachCallback, ParameterResolver {
 
-	public static final String		BUNDLE_CONTEXT_KEY		= "bundle.context";
-	public static final String		INSTALL_BUNLDE_KEY		= "install.bundle";
-	public static final Namespace	NAMESPACE	= Namespace.create(BundleContextExtension.class);
+	public static final String		BUNDLE_CONTEXT_KEY	= "bundle.context";
+	public static final String		INSTALL_BUNDLE_KEY	= "install.bundle";
+	public static final Namespace	NAMESPACE			= Namespace.create(BundleContextExtension.class);
 
 	@Override
 	public void beforeEach(ExtensionContext extensionContext) throws Exception {
@@ -55,8 +54,12 @@ public class BundleContextExtension
 
 	@Override
 	public void afterEach(ExtensionContext extensionContext) throws Exception {
+		cleanup(extensionContext);
+	}
+
+	public static void cleanup(ExtensionContext extensionContext) throws Exception {
 		extensionContext.getStore(NAMESPACE)
-			.remove(INSTALL_BUNLDE_KEY, ExtensionInstallBundle.class);
+			.remove(INSTALL_BUNDLE_KEY, ExtensionInstallBundle.class);
 		CloseableResourceBundleContext closeableResourceBundleContext = extensionContext.getStore(NAMESPACE)
 			.remove(BUNDLE_CONTEXT_KEY, CloseableResourceBundleContext.class);
 		if (closeableResourceBundleContext != null) {
@@ -119,22 +122,22 @@ public class BundleContextExtension
 		}
 	}
 
-	public BundleContext getBundleContext(ExtensionContext extensionContext) {
+	public static BundleContext getBundleContext(ExtensionContext extensionContext) {
 		BundleContext bundleContext = extensionContext.getStore(NAMESPACE)
 			.getOrComputeIfAbsent(BUNDLE_CONTEXT_KEY,
 				key -> new CloseableResourceBundleContext(extensionContext.getRequiredTestClass(),
 					FrameworkUtil.getBundle(extensionContext.getRequiredTestClass())
-					.getBundleContext()),
+						.getBundleContext()),
 				CloseableResourceBundleContext.class)
 			.get();
 
 		return bundleContext;
 	}
 
-	public InstallBundle getInstallbundle(ExtensionContext extensionContext) {
+	public static InstallBundle getInstallbundle(ExtensionContext extensionContext) {
 		return extensionContext.getStore(NAMESPACE)
-			.getOrComputeIfAbsent(INSTALL_BUNLDE_KEY, key -> new ExtensionInstallBundle(getBundleContext(extensionContext)),
-				ExtensionInstallBundle.class);
+			.getOrComputeIfAbsent(INSTALL_BUNDLE_KEY,
+				key -> new ExtensionInstallBundle(getBundleContext(extensionContext)), ExtensionInstallBundle.class);
 	}
 
 	private void injectFields(ExtensionContext extensionContext, Object testInstance, Predicate<Field> predicate) {

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtensionExampleTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtensionExampleTest.java
@@ -33,7 +33,8 @@ public class BundleContextExtensionExampleTest {
 
 	@Test
 	public void testBundleContext1(@BundleContextParameter BundleContext bundleContext1) {
-		assertThat(bundleContext1).isNotNull();
+		assertThat(bundleContext1).isNotNull()
+			.isSameAs(bundleContext2);
 	}
 
 	// OR
@@ -50,7 +51,8 @@ public class BundleContextExtensionExampleTest {
 
 	@Test
 	public void testInstallBundle(@InstallBundleParameter InstallBundle installBundle1) {
-		assertThat(installBundle1).isNotNull();
+		assertThat(installBundle1).isNotNull()
+			.isSameAs(installBundle2);
 	}
 
 	// OR

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtensionTest.java
@@ -63,7 +63,7 @@ public class BundleContextExtensionTest {
 		Bundle bundle = null;
 
 		try (WithBundleContextExtension it = new WithBundleContextExtension(extensionContext)) {
-			bundle = it.getExtension()
+			bundle = BundleContextExtension
 				.getInstallbundle(extensionContext)
 				.installBundle("foo/tbfoo.jar", false);
 
@@ -80,7 +80,7 @@ public class BundleContextExtensionTest {
 		Bundle bundle = null;
 
 		try (WithBundleContextExtension it = new WithBundleContextExtension(extensionContext)) {
-			bundle = it.getExtension()
+			bundle = BundleContextExtension
 				.getInstallbundle(extensionContext)
 				.installBundle("tb1.jar", false);
 

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/WithBundleContextExtension.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/WithBundleContextExtension.java
@@ -35,7 +35,7 @@ public class WithBundleContextExtension implements AutoCloseable {
 	}
 
 	BundleContext getBundleContext() {
-		return bundleContextExtension.getBundleContext(extensionContext);
+		return BundleContextExtension.getBundleContext(extensionContext);
 	}
 
 	public BundleContextExtension getExtension() {

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceUseExtensionLoggerFactoryTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceUseExtensionLoggerFactoryTest.java
@@ -26,11 +26,10 @@ import org.osgi.test.junit5.context.BundleContextExtension;
 public class ServiceUseExtensionLoggerFactoryTest {
 
 	@RegisterExtension
-	public BundleContextExtension		bundleContextExtension	= new BundleContextExtension();
+	public BundleContextExtension				bundleContextExtension	= new BundleContextExtension();
 	@RegisterExtension
-	public ServiceUseExtension<LoggerFactory>	loggerFactoryExtension			= new ServiceUseExtension.Builder<>(	//
-		LoggerFactory.class, bundleContextExtension)
-			.build();
+	public ServiceUseExtension<LoggerFactory>	loggerFactoryExtension	= new ServiceUseExtension.Builder<>(	//
+		LoggerFactory.class).build();
 
 	@Test
 	public void test(@ServiceUseParameter LoggerFactory loggerFactory) throws Exception {

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceUseExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceUseExtensionTest.java
@@ -80,7 +80,6 @@ public class ServiceUseExtensionTest {
 		try (WithServiceUseExtension<Foo> it = new WithServiceUseExtension<Foo>(extensionContext, //
 			Foo.class, null, 0, TrackServices.DEFAULT_TIMEOUT)) {
 
-			it.bceInit();
 			it.init();
 
 			SoftAssertions softly = new SoftAssertions();
@@ -109,7 +108,6 @@ public class ServiceUseExtensionTest {
 				try (WithServiceUseExtension<Foo> it = new WithServiceUseExtension<Foo>(extensionContext, //
 					Foo.class, null, 1, TrackServices.DEFAULT_TIMEOUT)) {
 
-					it.bceInit();
 					it.init();
 				}
 			})
@@ -123,7 +121,6 @@ public class ServiceUseExtensionTest {
 				try (WithServiceUseExtension<Foo> it = new WithServiceUseExtension<Foo>(extensionContext, //
 					Foo.class, null, 1, 50)) {
 
-					it.bceInit();
 					it.init();
 				}
 			})
@@ -134,8 +131,6 @@ public class ServiceUseExtensionTest {
 	public void successWhenService() throws Exception {
 		try (WithServiceUseExtension<Foo> it = new WithServiceUseExtension<Foo>(extensionContext, //
 			Foo.class, null, 1, TrackServices.DEFAULT_TIMEOUT)) {
-
-			it.bceInit();
 
 			final Foo afoo = new Foo() {};
 
@@ -174,8 +169,6 @@ public class ServiceUseExtensionTest {
 	public void successWhenServiceWithTimeout() throws Exception {
 		try (WithServiceUseExtension<Foo> it = new WithServiceUseExtension<Foo>(extensionContext, //
 			Foo.class, null, 1, 1000)) {
-
-			it.bceInit();
 
 			final Foo afoo = new Foo() {};
 
@@ -243,8 +236,6 @@ public class ServiceUseExtensionTest {
 		try (WithServiceUseExtension<Foo> it = new WithServiceUseExtension<Foo>(extensionContext, //
 			Foo.class, "(foo=bar)", 1, TrackServices.DEFAULT_TIMEOUT)) {
 
-			it.bceInit();
-
 			final Foo afoo = new Foo() {};
 
 			ScheduledFuture<ServiceRegistration<?>> scheduledFuture = executor.schedule(() -> it.getBundleContext()
@@ -310,8 +301,6 @@ public class ServiceUseExtensionTest {
 	public void matchMultiple() throws Exception {
 		try (WithServiceUseExtension<Foo> it = new WithServiceUseExtension<Foo>(extensionContext, //
 			Foo.class, null, 2, TrackServices.DEFAULT_TIMEOUT)) {
-
-			it.bceInit();
 
 			Foo s1 = new Foo() {}, s2 = new Foo() {};
 			ScheduledFuture<ServiceRegistration<?>> scheduledFuture1 = executor.schedule(() -> it.getBundleContext()
@@ -383,8 +372,6 @@ public class ServiceUseExtensionTest {
 			.isThrownBy(() -> {
 				try (WithServiceUseExtension<Foo> it = new WithServiceUseExtension<Foo>(extensionContext, //
 					Foo.class, "(foo=baz)", 1, TrackServices.DEFAULT_TIMEOUT)) {
-
-					it.bceInit();
 
 					final Foo afoo = new Foo() {};
 

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/WithServiceUseExtension.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/WithServiceUseExtension.java
@@ -25,7 +25,6 @@ import org.osgi.test.junit5.context.BundleContextExtension;
 
 class WithServiceUseExtension<T> implements AutoCloseable {
 	private final ExtensionContext	extensionContext;
-	final BundleContextExtension	bundleContextExtension;
 	final ServiceUseExtension<T>	serviceUseExtension;
 
 	public WithServiceUseExtension(ExtensionContext extensionContext, Class<T> serviceType, String filterString,
@@ -33,17 +32,12 @@ class WithServiceUseExtension<T> implements AutoCloseable {
 		throws Exception {
 
 		this.extensionContext = extensionContext;
-		this.bundleContextExtension = new BundleContextExtension();
 
 		Filter filter = (filterString == null) ? format("(objectClass=%s)", serviceType.getName())
 			: format("(&(objectClass=%s)%s)", serviceType.getName(), filterString);
 
-		this.serviceUseExtension = new ServiceUseExtension<>(serviceType, bundleContextExtension,
+		this.serviceUseExtension = new ServiceUseExtension<>(serviceType,
 			filter, cardinality, timeout);
-	}
-
-	public void bceInit() throws Exception {
-		this.bundleContextExtension.beforeEach(extensionContext);
 	}
 
 	public void init() throws Exception {
@@ -56,7 +50,7 @@ class WithServiceUseExtension<T> implements AutoCloseable {
 	}
 
 	public BundleContext getBundleContext() {
-		return bundleContextExtension.getBundleContext(extensionContext);
+		return BundleContextExtension.getBundleContext(extensionContext);
 	}
 
 	public ServiceUseExtension<T> getExtension() {


### PR DESCRIPTION
Generally speaking, Jupiter extensions should ~not~ be stateless - they should store their state in the engine's "Store". By using a well-known namespace, this means that they can be accessible to other extensions (like `ServiceUseExtension`).

The core of this PR is to make `BundleContextExtension.getBundleContext(ExecutionContext)` a static method. This is possible because the extension class doesn't store any state in its instance, but in the Store - so you don't actually need an instance of the class to fetch its state (like the proxied `BundleContext`). Being static, it can be called directly from (eg) `ServiceUseExtension` without needing a live `BundleContextExtension` instance.

Because `BundleContextExtension` also accesses the proxied `BundleContext` instance through the Store using the same method, it will get the same instance. The call to `getOrComputeIfAbsent()` takes care of any necessary synchronization or ordering issues - whoever calls it first transparently creates the instance, and whoever calls it subsequently for the same `ExecutionContext` will get the same instance.