### PR TITLE
promise: Make osgi.promise scope=compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
 				<groupId>org.osgi</groupId>
 				<artifactId>osgi.promise</artifactId>
 				<version>6.0.0</version>
-				<scope>provided</scope>
+				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>


### PR DESCRIPTION
For those projects which use Promises, they need to have a compile
scope dependency on osgi.promise. This will allow the resolver to
find osgi.promise for any references to the Promise API.

