### PR TITLE
Change BundleContextExtensionTest to use BundleAssert

### DIFF
--- a/org.osgi.test.junit5/pom.xml
+++ b/org.osgi.test.junit5/pom.xml
@@ -73,6 +73,10 @@
 			<groupId>org.osgi</groupId>
 			<artifactId>osgi.core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.promise</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -86,6 +90,10 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.log</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.test.assertj</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtensionTest.java
@@ -22,11 +22,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.osgi.framework.Bundle.INSTALLED;
 import static org.osgi.framework.Bundle.UNINSTALLED;
+import static org.osgi.test.assertj.bundle.BundleAssert.assertThat;
 import static org.osgi.test.junit5.TestUtil.getBundle;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -67,12 +67,12 @@ public class BundleContextExtensionTest {
 				.getInstallbundle(extensionContext)
 				.installBundle("foo/tbfoo.jar", false);
 
-			assertThat(bundle).extracting(Bundle::getState)
-				.is(new Condition<Integer>(state -> (state & INSTALLED) == INSTALLED, "Installed"));
+			assertThat(bundle).as("during")
+				.isInState(INSTALLED);
 		}
 
-		assertThat(bundle).extracting(Bundle::getState)
-			.is(new Condition<Integer>(state -> (state & UNINSTALLED) == UNINSTALLED, "Uninstalled"));
+		assertThat(bundle).as("after")
+			.isInState(UNINSTALLED);
 	}
 
 	@Test
@@ -84,12 +84,12 @@ public class BundleContextExtensionTest {
 				.getInstallbundle(extensionContext)
 				.installBundle("tb1.jar", false);
 
-			assertThat(bundle).extracting(Bundle::getState)
-				.is(new Condition<Integer>(state -> (state & INSTALLED) == INSTALLED, "Installed"));
+			assertThat(bundle).as("during")
+				.isInState(INSTALLED);
 		}
 
-		assertThat(bundle).extracting(Bundle::getState)
-			.is(new Condition<Integer>(state -> (state & UNINSTALLED) == UNINSTALLED, "Uninstalled"));
+		assertThat(bundle).as("after")
+			.isInState(UNINSTALLED);
 	}
 
 	@Test
@@ -139,9 +139,7 @@ public class BundleContextExtensionTest {
 
 		assertThat(bundle.getBundleContext()
 			.getBundle(bundleId)).isNull();
-		assertThat(installedBundle).isNotNull()
-			.extracting(Bundle::getState)
-			.isEqualTo(Bundle.UNINSTALLED);
+		assertThat(installedBundle).isInState(UNINSTALLED);
 	}
 
 	@Test
@@ -170,9 +168,7 @@ public class BundleContextExtensionTest {
 				.isEqualTo(installedBundle);
 		}
 
-		assertThat(installedBundle).isNotNull()
-			.extracting(Bundle::getState)
-			.isEqualTo(Bundle.UNINSTALLED);
+		assertThat(installedBundle).isInState(UNINSTALLED);
 
 		// now reset the ref
 		ref.set(null);

--- a/org.osgi.test.junit5/test.bndrun
+++ b/org.osgi.test.junit5/test.bndrun
@@ -49,4 +49,6 @@
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.test.common;version='[0.9.0,0.9.1)',\
 	org.osgi.test.junit5-tests;version='[0.9.0,0.9.1)',\
-	org.osgi.test.junit5;version='[0.9.0,0.9.1)'
+	org.osgi.test.junit5;version='[0.9.0,0.9.1)',\
+	org.osgi.test.assertj;version='[0.9.0,0.9.1)',\
+	osgi.promise;version='[6.0.0,6.0.1)'

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,12 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>org.osgi.test.assertj</artifactId>
+				<version>${revision}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-api</artifactId>
 				<version>${junit-jupiter.version}</version>


### PR DESCRIPTION
As a bit of a test (and an application of the "eat your own produce" principle) I thought to update `BundleContextExtensionTest` to use `BundleAssert`. Seems to work nicely.

If you want to see what the diagnostics look like, try changing one of the expected states on one of the `isInState()` assertions to see what it looks like when the assertion fails.