### PR TITLE
[assertj] AssertJ 3.16 updates

### DIFF
--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/AbstractBundleAssert.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/AbstractBundleAssert.java
@@ -106,7 +106,8 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasSymbolicName(String expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getSymbolicName(), expected)) {
-			failWithMessage("%nExpecting%n  <%s>%nto have symbolic name:%n  <%s>%n but was:%n  <%s>", actual, expected,
+			failWithActualExpectedAndMessage(actual.getSymbolicName(), expected,
+				"%nExpecting%n  <%s>%nto have symbolic name:%n  <%s>%n but was:%n  <%s>", actual, expected,
 				actual.getSymbolicName());
 		}
 		return myself;
@@ -121,7 +122,8 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasLocation(String expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getLocation(), expected)) {
-			failWithMessage("%nExpecting%n  <%s>%nto have location:%n  <%s>%n but was:%n  <%s>", actual, expected,
+			failWithActualExpectedAndMessage(actual.getLocation(), expected,
+				"%nExpecting%n  <%s>%nto have location:%n  <%s>%n but was:%n  <%s>", actual, expected,
 				actual.getLocation());
 		}
 		return myself;
@@ -172,7 +174,8 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasBundleId(long expected) {
 		isNotNull();
 		if (actual.getBundleId() != expected) {
-			failWithMessage("%nExpecting%n  <%s>%nto have bundle ID:%n  <%d>%n but was:%n  <%d>", actual, expected,
+			failWithActualExpectedAndMessage(actual.getBundleId(), expected,
+				"%nExpecting%n  <%s>%nto have bundle ID:%n  <%d>%n but was:%n  <%d>", actual, expected,
 				actual.getBundleId());
 		}
 		return myself;
@@ -202,7 +205,8 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		isNotNull();
 		Version expectedVersion = getVersion(expected);
 		if (!Objects.equals(actual.getVersion(), expectedVersion)) {
-			failWithMessage("%nExpecting%n  <%s>%nto have version:%n  <%s>%n but was:%n  <%s>", actual, expected,
+			failWithActualExpectedAndMessage(actual.getVersion(), expected,
+				"%nExpecting%n  <%s>%nto have version:%n  <%s>%n but was:%n  <%s>", actual, expected,
 				actual.getVersion());
 		}
 		return myself;
@@ -297,7 +301,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		return myself;
 	}
 
-	private static final int[] STATES = {
+	private static final int[]	STATES			= {
 		UNINSTALLED, INSTALLED, RESOLVED, STARTING, STOPPING, ACTIVE
 	};
 

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/AbstractBundleAssert.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/bundle/AbstractBundleAssert.java
@@ -39,9 +39,7 @@ import org.assertj.core.api.AbstractDateAssert;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.DateAssert;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.api.ObjectAssert;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
 import org.osgi.framework.wiring.BundleRevision;
@@ -49,19 +47,6 @@ import org.osgi.test.assertj.version.VersionAssert;
 
 public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SELF, ACTUAL>, ACTUAL extends Bundle>
 	extends AbstractAssert<SELF, ACTUAL> {
-
-	private static final InstanceOfAssertFactory<Bundle, ObjectAssert<Bundle>> BUNDLE_OBJECT = InstanceOfAssertFactories
-		.type(Bundle.class);
-
-	// TODO: when AssertJ 3.16 becomes available, get rid of this method and
-	// BUNDLE_OBJECT as it's only used for exposing extracting()
-	ObjectAssert<ACTUAL> asObjectAssert() {
-		@SuppressWarnings({
-			"unchecked", "rawtypes"
-		})
-		ObjectAssert<ACTUAL> objectAssert = (ObjectAssert) asInstanceOf(BUNDLE_OBJECT);
-		return objectAssert;
-	}
 
 	protected AbstractBundleAssert(ACTUAL actual, Class<SELF> selfType) {
 		super(actual, selfType);
@@ -114,8 +99,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	}
 
 	public AbstractStringAssert<?> hasSymbolicNameThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Bundle::getSymbolicName, STRING)
+		return isNotNull().extracting(Bundle::getSymbolicName, STRING)
 			.as(actual + ".symbolicName");
 	}
 
@@ -130,8 +114,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	}
 
 	public AbstractStringAssert<?> hasLocationThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Bundle::getLocation, STRING)
+		return isNotNull().extracting(Bundle::getLocation, STRING)
 			.as(actual + ".location");
 	}
 
@@ -196,8 +179,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	}
 
 	public VersionAssert hasVersionThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Bundle::getVersion, VERSION)
+		return isNotNull().extracting(Bundle::getVersion, VERSION)
 			.as(actual + ".version");
 	}
 
@@ -223,8 +205,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	}
 
 	public AbstractLongAssert<?> hasLastModifiedLongThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Bundle::getLastModified, LONG)
+		return isNotNull().extracting(Bundle::getLastModified, LONG)
 			.as(actual + ".lastModified");
 	}
 
@@ -232,8 +213,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		date -> new DateAssert(new Date(date)));
 
 	public AbstractDateAssert<?> hasLastModifiedDateThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Bundle::getLastModified, LONG_AS_DATE)
+		return isNotNull().extracting(Bundle::getLastModified, LONG_AS_DATE)
 			.as(actual + ".lastModified");
 	}
 

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/promise/PromiseSoftAssertions.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/promise/PromiseSoftAssertions.java
@@ -22,17 +22,4 @@ import org.osgi.util.promise.Promise;
 /**
  * Soft assertions for {@link Promise}s.
  */
-public class PromiseSoftAssertions extends SoftAssertions {
-	/**
-	 * Create a soft assertion for a {@link Promise}.
-	 *
-	 * @param actual The {@link Promise}.
-	 * @param <T> The type of the value contained in the {@link Promise}.
-	 * @return The created soft assertion.
-	 */
-	public <T> PromiseAssert<T> assertThat(Promise<? extends T> actual) {
-		@SuppressWarnings("unchecked")
-		PromiseAssert<T> softly = proxy(PromiseAssert.class, Promise.class, actual);
-		return softly;
-	}
-}
+public class PromiseSoftAssertions extends SoftAssertions implements PromiseSoftAssertionsProvider {}

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/promise/PromiseSoftAssertionsProvider.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/promise/PromiseSoftAssertionsProvider.java
@@ -14,19 +14,25 @@
  * limitations under the License.
  */
 
-package org.osgi.test.assertj.bundle;
+package org.osgi.test.assertj.promise;
 
 import org.assertj.core.api.SoftAssertionsProvider;
-import org.osgi.framework.Bundle;
+import org.osgi.util.promise.Promise;
 
-public interface BundleSoftAssertions extends SoftAssertionsProvider {
+/**
+ * Soft assertions for {@link Promise}s.
+ */
+public interface PromiseSoftAssertionsProvider extends SoftAssertionsProvider {
 	/**
-	 * Create assertion for {@link org.osgi.framework.Bundle}.
+	 * Create a soft assertion for a {@link Promise}.
 	 *
-	 * @param actual the actual value.
-	 * @return the created assertion object.
+	 * @param actual The {@link Promise}.
+	 * @param <T> The type of the value contained in the {@link Promise}.
+	 * @return The created soft assertion.
 	 */
-	default BundleAssert assertThat(Bundle actual) {
-		return proxy(BundleAssert.class, Bundle.class, actual);
+	default <T> PromiseAssert<T> assertThat(Promise<? extends T> actual) {
+		@SuppressWarnings("unchecked")
+		PromiseAssert<T> softly = proxy(PromiseAssert.class, Promise.class, actual);
+		return softly;
 	}
 }

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/AbstractVersionAssert.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/AbstractVersionAssert.java
@@ -25,9 +25,6 @@ import org.assertj.core.api.AbstractComparableAssert;
 import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.ComparableAssert;
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.api.ObjectAssert;
 import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
 
@@ -38,22 +35,8 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		super(actual, selfType);
 	}
 
-	private static final InstanceOfAssertFactory<Version, ObjectAssert<Version>> VERSION_OBJECT = InstanceOfAssertFactories
-		.type(Version.class);
-
-	// TODO: when AssertJ 3.16 becomes available, get rid of this method and
-	// VERSION_OBJECT as it's only used for exposing extracting()
-	ObjectAssert<ACTUAL> asObjectAssert() {
-		@SuppressWarnings({
-			"unchecked", "rawtypes"
-		})
-		ObjectAssert<ACTUAL> objectAssert = (ObjectAssert) asInstanceOf(VERSION_OBJECT);
-		return objectAssert;
-	}
-
 	public AbstractIntegerAssert<?> hasMajorThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Version::getMajor, INTEGER);
+		return isNotNull().extracting(Version::getMajor, INTEGER);
 	}
 
 	public SELF hasMajor(int expected) {
@@ -61,15 +44,13 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		int a = actual.getMajor();
 		if (expected != a) {
 			failWithActualExpectedAndMessage(a, expected,
-				"%nExpecting%n <%s>%nto have major version:%n  <%d>%n but it was:%n  <%d>", actual,
-				expected, a);
+				"%nExpecting%n <%s>%nto have major version:%n  <%d>%n but it was:%n  <%d>", actual, expected, a);
 		}
 		return myself;
 	}
 
 	public AbstractIntegerAssert<?> hasMinorThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Version::getMinor, INTEGER);
+		return isNotNull().extracting(Version::getMinor, INTEGER);
 	}
 
 	public SELF hasMinor(int expected) {
@@ -77,15 +58,13 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		int a = actual.getMinor();
 		if (expected != a) {
 			failWithActualExpectedAndMessage(a, expected,
-				"%nExpecting%n <%s>%nto have minor version:%n  <%d>%n but it was:%n  <%d>", actual,
-				expected, a);
+				"%nExpecting%n <%s>%nto have minor version:%n  <%d>%n but it was:%n  <%d>", actual, expected, a);
 		}
 		return myself;
 	}
 
 	public AbstractIntegerAssert<?> hasMicroThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Version::getMicro, INTEGER);
+		return isNotNull().extracting(Version::getMicro, INTEGER);
 	}
 
 	public SELF hasMicro(int expected) {
@@ -93,15 +72,13 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		int a = actual.getMicro();
 		if (expected != a) {
 			failWithActualExpectedAndMessage(a, expected,
-				"%nExpecting%n <%s>%nto have micro version:%n <%d>%n but it was:%n <%d>", actual, expected,
-				a);
+				"%nExpecting%n <%s>%nto have micro version:%n <%d>%n but it was:%n <%d>", actual, expected, a);
 		}
 		return myself;
 	}
 
 	public AbstractStringAssert<?> hasQualifierThat() {
-		return isNotNull().asObjectAssert()
-			.extracting(Version::getQualifier, STRING);
+		return isNotNull().extracting(Version::getQualifier, STRING);
 	}
 
 	public SELF hasQualifier(String expected) {

--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/AbstractVersionAssert.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/version/AbstractVersionAssert.java
@@ -60,7 +60,8 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		isNotNull();
 		int a = actual.getMajor();
 		if (expected != a) {
-			failWithMessage("%nExpecting%n <%s>%nto have major version:%n  <%d>%n but it was:%n  <%d>", actual,
+			failWithActualExpectedAndMessage(a, expected,
+				"%nExpecting%n <%s>%nto have major version:%n  <%d>%n but it was:%n  <%d>", actual,
 				expected, a);
 		}
 		return myself;
@@ -75,7 +76,8 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		isNotNull();
 		int a = actual.getMinor();
 		if (expected != a) {
-			failWithMessage("%nExpecting%n <%s>%nto have minor version:%n  <%d>%n but it was:%n  <%d>", actual,
+			failWithActualExpectedAndMessage(a, expected,
+				"%nExpecting%n <%s>%nto have minor version:%n  <%d>%n but it was:%n  <%d>", actual,
 				expected, a);
 		}
 		return myself;
@@ -90,7 +92,8 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		isNotNull();
 		int a = actual.getMicro();
 		if (expected != a) {
-			failWithMessage("%nExpecting%n <%s>%nto have micro version:%n <%d>%n but it was:%n <%d>", actual, expected,
+			failWithActualExpectedAndMessage(a, expected,
+				"%nExpecting%n <%s>%nto have micro version:%n <%d>%n but it was:%n <%d>", actual, expected,
 				a);
 		}
 		return myself;
@@ -105,7 +108,8 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		isNotNull();
 		String a = actual.getQualifier();
 		if (!Objects.equals(a, expected)) {
-			failWithMessage("%nExpecting%n <%s>%nto have qualifier:%n <%s>%n but it was:%n <%s>", actual, expected, a);
+			failWithActualExpectedAndMessage(a, expected,
+				"%nExpecting%n <%s>%nto have qualifier:%n <%s>%n but it was:%n <%s>", actual, expected, a);
 		}
 		return myself;
 	}


### PR DESCRIPTION
Number of updates that leverage new features of AssertJ 3.16:

* Assertion classes now use `failWithActualExpectedAndMessage()` where appropriate.
* No need to use the shim `asObjectAssert()` as `extracting()` is now public.
* Composable soft assertions using `SoftAssertionsProvider` interface.