### PR TITLE
[assertj] Export events package that forms part of public API through inheritance

### DIFF
--- a/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/event/package-info.java
+++ b/org.osgi.test.assertj/src/main/java/org/osgi/test/assertj/event/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("1.0.0")
+package org.osgi.test.assertj.event;


### PR DESCRIPTION
Fixes an issue pointed out by @bjhargrave:

Because `org.osgi.test.assertj.(service|bundle|framework)event` contain classes that have `org.osgi.test.assertj.event.AbstractBitmappedTypeEventAssert` as their superclass, and because a client bundle won't be able to resolve these classes unless they can also resolve the superclass, it is necessary to export `org.osgi.test.assertj.event` as well. Otherwise the client bundles (which will declare the `event` subpackage in their `Import-Package` declaration) will not be able to resolve.

Bnd warned about this during the build, both in Bndtools and in the Maven console, but because it was a warning it went unnoticed. I have queried @pkriens as to if there is a good reason why this was only a warning, as I think a strong case could be made for promoting the issue to a build error.