### PR TITLE
ci: Replace maven-deploy-plugin with nexus-staging-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,6 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.8.2</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
 					<version>3.2.1</version>
 					<executions>
@@ -224,6 +219,12 @@
 							</goals>
 						</execution>
 					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.sonatype.plugins</groupId>
+					<artifactId>nexus-staging-maven-plugin</artifactId>
+					<version>1.6.8</version>
+					<extensions>true</extensions>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -350,10 +351,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -506,13 +503,24 @@
 			<id>ossrh</id>
 			<properties>
 				<skipTests>true</skipTests>
-				<invoker.skip>true</invoker.skip>
+				<maven.test.skip>true</maven.test.skip>
+				<bnd.baseline.skip>true</bnd.baseline.skip>
+				<bnd.resolve.skip>true</bnd.resolve.skip>
+				<jacoco.skip>true</jacoco.skip>
 			</properties>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<configuration>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>
@@ -521,10 +529,6 @@
 					<id>ossrh</id>
 					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 				</snapshotRepository>
-				<repository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-				</repository>
 			</distributionManagement>
 		</profile>
 	</profiles>


### PR DESCRIPTION
We set maven.test.skip in the ossrh profile which nicely stops
building the test jars resulting in them not being deployed.

We also skip bnd resolving and baselining as well as jacoco in the
ossrh profile for deploying.

https: //central.sonatype.org/pages/apache-maven.html#deploying-to-ossrh-with-apache-maven-introduction
