### PR TITLE
[junit5] Added tests for the BundleContextExtension sanity checks

### DIFF
--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
@@ -81,7 +81,7 @@ public class BundleContextExtension
 			m -> Modifier.isStatic(m.getModifiers()));
 
 		fields.forEach(field -> {
-			// assertFieldIsBundleContext(field);
+			assertFieldIsBundleContext(field);
 			setField(field, null, getBundleContext(extensionContext));
 		});
 
@@ -89,9 +89,8 @@ public class BundleContextExtension
 			m -> Modifier.isStatic(m.getModifiers()));
 
 		fields.forEach(field -> {
-			// assertFieldIsInstallBundle(field);
-			setField(field, null, getInstallbundle(
-				extensionContext));
+			assertFieldIsInstallBundle(field);
+			setField(field, null, getInstallbundle(extensionContext));
 		});
 	}
 
@@ -124,9 +123,7 @@ public class BundleContextExtension
 	}
 
 	public static void cleanup(ExtensionContext extensionContext) throws Exception {
-		getStore(
-			extensionContext)
-			.remove(INSTALL_BUNDLE_KEY, InstallBundle.class);
+		getStore(extensionContext).remove(INSTALL_BUNDLE_KEY, InstallBundle.class);
 		CloseableResourceBundleContext closeableResourceBundleContext = getStore(extensionContext)
 			.remove(BUNDLE_CONTEXT_KEY, CloseableResourceBundleContext.class);
 		if (closeableResourceBundleContext != null) {
@@ -189,20 +186,32 @@ public class BundleContextExtension
 	}
 
 	private void assertFieldIsBundleContext(Field field) {
-		assertIsBundleContext("field", field.getType());
-		if (Modifier.isFinal(field.getModifiers()) || Modifier.isPrivate(field.getModifiers())
-			|| Modifier.isStatic(field.getModifiers())) {
+		if (field.getType() != BundleContext.class) {
 			throw new ExtensionConfigurationException(
-				InjectBundleContext.class.getName() + " field [" + field + "] must not be final, private or static.");
+				"[" + field.getName() + "] Can only resolve @" + InjectBundleContext.class.getSimpleName()
+					+ " field of type " + BundleContext.class.getName() + " but was: " + field.getType()
+						.getName());
+		}
+		if (Modifier.isFinal(field.getModifiers())) {
+			// Modifier.isPrivate(field.getModifiers())
+			throw new ExtensionConfigurationException(
+				'@' + InjectBundleContext.class.getSimpleName() + " field [" + field.getName() + "] must not be final");
+			// not be final, private or static.");
 		}
 	}
 
 	private void assertFieldIsInstallBundle(Field field) {
-		assertIsInstallBundle("field", field.getType());
-		if (Modifier.isFinal(field.getModifiers()) || Modifier.isPrivate(field.getModifiers())
-			|| Modifier.isStatic(field.getModifiers())) {
+		if (field.getType() != InstallBundle.class) {
 			throw new ExtensionConfigurationException(
-				InjectInstallBundle.class.getName() + " field [" + field + "] must not be final, private or static.");
+				"[" + field.getName() + "] Can only resolve @" + InjectInstallBundle.class.getSimpleName()
+					+ " field of type " + InstallBundle.class.getName() + " but was: " + field.getType()
+						.getName());
+		}
+		if (Modifier.isFinal(field.getModifiers())) {
+			// Modifier.isPrivate(field.getModifiers())
+			throw new ExtensionConfigurationException(
+				'@' + InjectInstallBundle.class.getSimpleName() + " field [" + field.getName() + "] must not be final");
+			// not be final, private or static.");
 		}
 	}
 
@@ -215,8 +224,7 @@ public class BundleContextExtension
 				.getBundleContext());
 
 		Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
-		BundleContext bundleContext = getStore(
-			extensionContext)
+		BundleContext bundleContext = getStore(extensionContext)
 			.getOrComputeIfAbsent(BUNDLE_CONTEXT_KEY,
 				key -> new CloseableResourceBundleContext(requiredTestClass, parentContext),
 				CloseableResourceBundleContext.class)
@@ -246,7 +254,6 @@ public class BundleContextExtension
 		public BundleContext get() {
 			return bundleContext;
 		}
-
 	}
 
 	@Override

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
@@ -166,7 +166,7 @@ public class BundleContextExtension
 		if ((annotatedBundleContextParameter || annotatedInstallBundleParameter)
 			&& (parameterContext.getDeclaringExecutable() instanceof Constructor)) {
 			throw new ParameterResolutionException(
-				"BundleContextExtension only supports field and parameter injection.");
+				"BundleContextExtension does not support parameter injection on constructors");
 		}
 		return annotatedBundleContextParameter || annotatedInstallBundleParameter;
 	}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
@@ -192,11 +192,10 @@ public class BundleContextExtension
 					+ " field of type " + BundleContext.class.getName() + " but was: " + field.getType()
 						.getName());
 		}
-		if (Modifier.isFinal(field.getModifiers())) {
-			// Modifier.isPrivate(field.getModifiers())
+		if (Modifier.isFinal(field.getModifiers()) || Modifier.isPrivate(field.getModifiers())) {
 			throw new ExtensionConfigurationException(
-				'@' + InjectBundleContext.class.getSimpleName() + " field [" + field.getName() + "] must not be final");
-			// not be final, private or static.");
+				'@' + InjectBundleContext.class.getSimpleName() + " field [" + field.getName()
+					+ "] must not be private or final");
 		}
 	}
 

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextSanityCheckingTest.java
@@ -1,0 +1,101 @@
+package org.osgi.test.junit5.context;
+
+import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.osgi.framework.BundleContext;
+import org.osgi.test.common.annotation.InjectBundleContext;
+
+public class BundleContextExtension_BundleContextSanityCheckingTest {
+
+	@ExtendWith(BundleContextExtension.class)
+	static class TestBase {
+		@Test
+		void myTest() {}
+	}
+
+	protected String					testMethodName;
+
+	@ExtendWith(BundleContextExtension.class)
+	static class IncorrectParameterType {
+		@SuppressWarnings("unused")
+		@Test
+		void myParameterTest(@InjectBundleContext String param) {}
+	}
+
+	@Test
+	void annotatedParameter_withIncorrectType_throwsException() {
+		assertThatTest(IncorrectParameterType.class).isInstanceOf(ParameterResolutionException.class)
+			.hasMessageEndingWith(
+				"Can only resolve @InjectBundleContext parameter of type org.osgi.framework.BundleContext but was: java.lang.String");
+	}
+
+	static class IncorrectFieldType extends TestBase {
+
+		@InjectBundleContext
+		String myField;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_withIncorrectType_throwsException() {
+		assertThatTest(IncorrectFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessage(
+				"[myField] Can only resolve @InjectBundleContext field of type org.osgi.framework.BundleContext but was: java.lang.String");
+	}
+
+	static class IncorrectStaticFieldType extends TestBase {
+
+		@InjectBundleContext
+		static String myStaticField;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedStaticField_withIncorrectType_throwsException() {
+		assertThatTest(IncorrectStaticFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessage(
+				"[myStaticField] Can only resolve @InjectBundleContext field of type org.osgi.framework.BundleContext but was: java.lang.String");
+	}
+
+	static class FinalStaticField extends TestBase {
+		@InjectBundleContext
+		static final BundleContext bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedStaticField_thatIsFinal_throwsException() {
+		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessage(
+				"@InjectBundleContext field [bc] must not be final");
+	}
+
+	static class FinalField extends TestBase {
+		@InjectBundleContext
+		final BundleContext bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_thatIsFinal_throwsException() {
+		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessage(
+				"@InjectBundleContext field [bc] must not be final");
+	}
+}

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextSanityCheckingTest.java
@@ -126,4 +126,20 @@ public class BundleContextExtension_BundleContextSanityCheckingTest {
 		assertThatTest(StaticPrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
 			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*private.*");
 	}
+
+	static class AnnotatedConstructor extends TestBase {
+		AnnotatedConstructor(@InjectBundleContext BundleContext context) {
+
+		}
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedConstructor_throwsException() {
+		assertThatTest(AnnotatedConstructor.class).isInstanceOf(ParameterResolutionException.class)
+			.hasMessageMatching("BundleContextExtension does not support parameter injection on constructors");
+	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextSanityCheckingTest.java
@@ -79,8 +79,7 @@ public class BundleContextExtension_BundleContextSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsFinal_throwsException() {
 		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"@InjectBundleContext field [bc] must not be final");
+			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*final.*");
 	}
 
 	static class FinalField extends TestBase {
@@ -95,7 +94,36 @@ public class BundleContextExtension_BundleContextSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"@InjectBundleContext field [bc] must not be final");
+			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*final.*");
+	}
+
+	static class PrivateField extends TestBase {
+		@InjectBundleContext
+		private BundleContext bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_thatIsPrivate_throwsException() {
+		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*private.*");
+	}
+
+	static class StaticPrivateField extends TestBase {
+		@InjectBundleContext
+		static private BundleContext bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedStaticField_thatIsPrivate_throwsException() {
+		assertThatTest(StaticPrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*private.*");
 	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_CleanupTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_CleanupTest.java
@@ -76,7 +76,7 @@ import org.osgi.test.junit5.context.MultiLevelCleanupTest.CallbackPoint;
 import org.osgi.test.junit5.testutils.OSGiSoftAssertions;
 import org.osgi.test.junit5.types.Foo;
 
-public class BundleContextExtensionTest {
+public class BundleContextExtension_CleanupTest {
 
 	/**
 	 * This function runs the given concrete subclass of MultiLevelCleanupTest

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_InstallBundleSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_InstallBundleSanityCheckingTest.java
@@ -1,0 +1,110 @@
+package org.osgi.test.junit5.context;
+
+import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.osgi.test.common.annotation.InjectInstallBundle;
+import org.osgi.test.common.install.InstallBundle;
+
+public class BundleContextExtension_InstallBundleSanityCheckingTest {
+
+	@ExtendWith(BundleContextExtension.class)
+	static class TestBase {
+		@Test
+		void myTest() {}
+	}
+
+	protected String					testMethodName;
+
+	@BeforeEach
+	public void beforeEach(TestInfo testInfo) {
+		testMethodName = testInfo.getTestMethod()
+			.get()
+			.getName();
+	}
+
+	@ExtendWith(BundleContextExtension.class)
+	static class IncorrectParameterType {
+		@SuppressWarnings("unused")
+		@Test
+		void myParameterTest(@InjectInstallBundle String param) {}
+	}
+
+	@Test
+	void annotatedParameter_withIncorrectType_throwsException() {
+		assertThatTest(IncorrectParameterType.class).isInstanceOf(ParameterResolutionException.class)
+			.hasMessageEndingWith(
+				"Can only resolve @InjectInstallBundle parameter of type org.osgi.test.common.install.InstallBundle but was: java.lang.String");
+	}
+
+	static class IncorrectFieldType extends TestBase {
+
+		@InjectInstallBundle
+		String myField;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_withIncorrectType_throwsException() {
+		assertThatTest(IncorrectFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessage(
+				"[myField] Can only resolve @InjectInstallBundle field of type org.osgi.test.common.install.InstallBundle but was: java.lang.String");
+	}
+
+	static class IncorrectStaticFieldType extends TestBase {
+
+		@InjectInstallBundle
+		static String myStaticField;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedStaticField_withIncorrectType_throwsException() {
+		assertThatTest(IncorrectStaticFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessage(
+				"[myStaticField] Can only resolve @InjectInstallBundle field of type org.osgi.test.common.install.InstallBundle but was: java.lang.String");
+	}
+
+	static class FinalStaticField extends TestBase {
+		@InjectInstallBundle
+		static final InstallBundle bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedStaticField_thatIsFinal_throwsException() {
+		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessage(
+				"@InjectInstallBundle field [bc] must not be final");
+	}
+
+	static class FinalField extends TestBase {
+		@InjectInstallBundle
+		final InstallBundle bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_thatIsFinal_throwsException() {
+		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessage(
+				"@InjectInstallBundle field [bc] must not be final");
+	}
+}

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/InstallBundleMultiLevelCleanupTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/InstallBundleMultiLevelCleanupTest.java
@@ -9,7 +9,7 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.common.annotation.InjectInstallBundle;
 import org.osgi.test.common.install.InstallBundle;
-import org.osgi.test.junit5.context.BundleContextExtensionTest.BundleChecker;
+import org.osgi.test.junit5.context.BundleContextExtension_CleanupTest.BundleChecker;
 
 @ExtendWith(PreDestroyCallback.class)
 @ExtendWith(BundleContextExtension.class)

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AbstractServiceExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AbstractServiceExtensionTest.java
@@ -1,8 +1,8 @@
 package org.osgi.test.junit5.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
-import static org.junit.platform.testkit.engine.EventType.FINISHED;
+import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;
+import static org.osgi.test.junit5.testutils.TestKitUtils.checkClass;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -11,8 +11,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.junit.jupiter.api.AfterEach;
@@ -21,10 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.engine.JupiterTestEngine;
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.testkit.engine.EngineTestKit;
-import org.junit.platform.testkit.engine.Event;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
@@ -77,17 +71,6 @@ abstract class AbstractServiceExtensionTest {
 	protected BundleContext				bundleContext;
 	protected String					testMethodName;
 
-	protected static void checkClass(Class<?> testClass) {
-		// This is to protect against developer slip-ups that can be costly...
-		try {
-			testClass.getDeclaredConstructor();
-		} catch (NoSuchMethodException e) {
-			throw new IllegalStateException(
-				"Test class does not have a default constructor (did you accidentally use a non-static inner class?): "
-					+ testClass);
-		}
-	}
-
 	@BeforeEach
 	public void beforeEach(TestInfo testInfo) {
 		testMethodName = testInfo.getTestMethod()
@@ -116,38 +99,6 @@ abstract class AbstractServiceExtensionTest {
 				.get(delay + 200000, TimeUnit.MILLISECONDS);
 		} catch (InterruptedException | ExecutionException | TimeoutException e) {
 			throw Exceptions.duck(e);
-		}
-	}
-
-	protected static AbstractThrowableAssert<?, ? extends Throwable> assertThatTest(Class<?> testClass) {
-		checkClass(testClass);
-
-		Logger logger = Logger.getLogger("org.junit.jupiter");
-		Level oldLevel = logger.getLevel();
-		try {
-			// Suppress log output while the testkit is running (see issue
-			// #133).
-			logger.setLevel(Level.OFF);
-			Event testEvent = EngineTestKit.engine(new JupiterTestEngine())
-				.selectors(selectClass(testClass))
-				.execute()
-				.testEvents()
-				// .debug(
-				// System.err)
-				.filter(event -> event.getType()
-					.equals(FINISHED))
-				.findAny()
-				.orElseThrow(() -> new IllegalStateException("Test failed to run at all"));
-
-			TestExecutionResult result = testEvent.getPayload(TestExecutionResult.class)
-				.orElseThrow(() -> new IllegalStateException("Test result payload missing"));
-
-			return assertThat(result.getThrowable()
-				.orElse(null));
-		} finally {
-			// Restore the filter to what it was so that we do not interfere
-			// with the parent test
-			logger.setLevel(oldLevel);
 		}
 	}
 

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtensionTest.java
@@ -18,6 +18,7 @@ package org.osgi.test.junit5.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.osgi.test.common.annotation.InjectService.DEFAULT_TIMEOUT;
+import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;
 
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/testutils/TestKitUtils.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/testutils/TestKitUtils.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.testkit.engine.EventType.FINISHED;
 
+import java.lang.reflect.Modifier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -19,11 +20,9 @@ public class TestKitUtils {
 
 	public static void checkClass(Class<?> testClass) {
 		// This is to protect against developer slip-ups that can be costly...
-		try {
-			testClass.getDeclaredConstructor();
-		} catch (NoSuchMethodException e) {
+		if (!Modifier.isStatic(testClass.getModifiers())) {
 			throw new IllegalStateException(
-				"Test class does not have a default constructor (did you accidentally use a non-static inner class?): "
+				"Test class is not static: "
 					+ testClass);
 		}
 	}

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/testutils/TestKitUtils.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/testutils/TestKitUtils.java
@@ -1,0 +1,61 @@
+package org.osgi.test.junit5.testutils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventType.FINISHED;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.junit.jupiter.engine.JupiterTestEngine;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+public class TestKitUtils {
+
+	private TestKitUtils() {}
+
+	public static void checkClass(Class<?> testClass) {
+		// This is to protect against developer slip-ups that can be costly...
+		try {
+			testClass.getDeclaredConstructor();
+		} catch (NoSuchMethodException e) {
+			throw new IllegalStateException(
+				"Test class does not have a default constructor (did you accidentally use a non-static inner class?): "
+					+ testClass);
+		}
+	}
+
+	public static AbstractThrowableAssert<?, ? extends Throwable> assertThatTest(Class<?> testClass) {
+		checkClass(testClass);
+
+		Logger logger = Logger.getLogger("org.junit.jupiter");
+		Level oldLevel = logger.getLevel();
+		try {
+			// Suppress log output while the testkit is running (see issue
+			// #133).
+			logger.setLevel(Level.OFF);
+			Event testEvent = EngineTestKit.engine(new JupiterTestEngine())
+				.selectors(selectClass(testClass))
+				.execute()
+				.allEvents()
+				// .debug(System.err)
+				.filter(event -> event.getType()
+					.equals(FINISHED))
+				.findAny()
+				.orElseThrow(() -> new IllegalStateException("Test failed to run at all"));
+
+			TestExecutionResult result = testEvent.getPayload(TestExecutionResult.class)
+				.orElseThrow(() -> new IllegalStateException("Test result payload missing"));
+
+			return assertThat(result.getThrowable()
+				.orElse(null));
+		} finally {
+			// Restore the filter to what it was so that we do not interfere
+			// with the parent test
+			logger.setLevel(oldLevel);
+		}
+	}
+}


### PR DESCRIPTION
Includes re-enabling sanity checks for the static beforeAll/afterAll methods. This were disabled when the original hierarchical test handling was introduced.