### PR TITLE
[codecov] Added assertj.framework and promise bundles

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -40,12 +40,18 @@ jobs:
       continue-on-error: ${{ matrix.experimental }}
       run: |
         ./.github/scripts/build.sh ${{ matrix.mavenopts }}
-    - name: Upload "assertj" coverage to Codecov
+    - name: Upload "assertj.framework" coverage to Codecov
       if: (matrix.codecov)
       uses: codecov/codecov-action@v1.0.7
       with:
-        file: ./org.osgi.test.assertj/target/site/jacoco/jacoco.xml
-        name: assertj
+        file: ./org.osgi.test.assertj.framework/target/site/jacoco/jacoco.xml
+        name: assertj.framework
+    - name: Upload "assertj.promise" coverage to Codecov
+      if: (matrix.codecov)
+      uses: codecov/codecov-action@v1.0.7
+      with:
+        file: ./org.osgi.test.assertj.promise/target/site/jacoco/jacoco.xml
+        name: assertj.promise
     - name: Upload "common" coverage to Codecov
       if: (matrix.codecov)
       uses: codecov/codecov-action@v1.0.7


### PR DESCRIPTION
Our action file was still uploading the old unified bundle which no longer exists since #150 was merged.
