### PR TITLE
ci: Only use settings.xml for publishing

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-./mvnw --version --settings settings.xml
-./mvnw --no-transfer-progress --settings settings.xml install "$@"
+./mvnw --batch-mode --version
+./mvnw --batch-mode --no-transfer-progress install "$@"

--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./mvnw --settings settings.xml deploy "$@"
+./mvnw --batch-mode --settings settings.xml deploy "$@"

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -40,6 +40,27 @@ jobs:
       continue-on-error: ${{ matrix.experimental }}
       run: |
         ./.github/scripts/build.sh ${{ matrix.mavenopts }}
+    - name: Import GPG key
+      id: import_gpg
+      if: (matrix.canonical && (steps.build.outcome == 'success'))
+      uses: crazy-max/ghaction-import-gpg@v2
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    - name: GPG key information
+      if: (steps.import_gpg.outcome == 'success')
+      run: |
+        echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
+        echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
+        echo "name:        ${{ steps.import_gpg.outputs.name }}"
+        echo "email:       ${{ steps.import_gpg.outputs.email }}"
+    - name: Publish
+      if: (steps.import_gpg.outcome == 'success')
+      run: |
+        ./.github/scripts/publish.sh -Possrh
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
     - name: Upload "assertj.framework" coverage to Codecov
       if: (matrix.codecov)
       uses: codecov/codecov-action@v1.0.7
@@ -70,24 +91,3 @@ jobs:
       with:
         file: ./org.osgi.test.junit5/target/site/jacoco-it/jacoco.xml
         name: junit5
-    - name: Import GPG key
-      id: import_gpg
-      if: (matrix.canonical)
-      uses: crazy-max/ghaction-import-gpg@v2
-      env:
-        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-    - name: GPG key information
-      if: (steps.import_gpg.outcome == 'success')
-      run: |
-        echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
-        echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
-        echo "name:        ${{ steps.import_gpg.outputs.name }}"
-        echo "email:       ${{ steps.import_gpg.outputs.email }}"
-    - name: Publish
-      if: (matrix.canonical && (steps.build.outcome == 'success'))
-      run: |
-        ./.github/scripts/publish.sh -Possrh
-      env:
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/settings.xml
+++ b/settings.xml
@@ -1,6 +1,5 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <interactiveMode>false</interactiveMode>
   <servers>
     <server>
       <id>ossrh</id>


### PR DESCRIPTION
This avoids any issue with a settings for ossrh having invalid
credentials on a branch or fork build.
