### PR TITLE
[junit5] Sanity checking fixes

### DIFF
--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextSanityCheckingTest.java
@@ -17,8 +17,6 @@ public class BundleContextExtension_BundleContextSanityCheckingTest {
 		void myTest() {}
 	}
 
-	protected String					testMethodName;
-
 	@ExtendWith(BundleContextExtension.class)
 	static class IncorrectParameterType {
 		@SuppressWarnings("unused")

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_InstallBundleSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_InstallBundleSanityCheckingTest.java
@@ -2,9 +2,7 @@ package org.osgi.test.junit5.context;
 
 import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -17,15 +15,6 @@ public class BundleContextExtension_InstallBundleSanityCheckingTest {
 	static class TestBase {
 		@Test
 		void myTest() {}
-	}
-
-	protected String					testMethodName;
-
-	@BeforeEach
-	public void beforeEach(TestInfo testInfo) {
-		testMethodName = testInfo.getTestMethod()
-			.get()
-			.getName();
 	}
 
 	@ExtendWith(BundleContextExtension.class)
@@ -88,8 +77,7 @@ public class BundleContextExtension_InstallBundleSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsFinal_throwsException() {
 		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"@InjectInstallBundle field [bc] must not be final");
+			.hasMessageMatching("@InjectInstallBundle field \\[bc\\] must not be .*final.*");
 	}
 
 	static class FinalField extends TestBase {
@@ -104,7 +92,36 @@ public class BundleContextExtension_InstallBundleSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"@InjectInstallBundle field [bc] must not be final");
+			.hasMessageMatching("@InjectInstallBundle field \\[bc\\] must not be .*final.*");
+	}
+
+	static class PrivateStaticField extends TestBase {
+		@InjectInstallBundle
+		static final InstallBundle bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedStaticField_thatIsPrivate_throwsException() {
+		assertThatTest(PrivateStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessageMatching("@InjectInstallBundle field \\[bc\\] must not be .*private.*");
+	}
+
+	static class PrivateField extends TestBase {
+		@InjectInstallBundle
+		final InstallBundle bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_thatIsPrivate_throwsException() {
+		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessageMatching("@InjectInstallBundle field \\[bc\\] must not be .*private.*");
 	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtension_SanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtension_SanityCheckingTest.java
@@ -1,0 +1,104 @@
+package org.osgi.test.junit5.service;
+
+import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.service.ServiceAware;
+
+public class ServiceExtension_SanityCheckingTest {
+
+	static class MyService {}
+
+	@ExtendWith(ServiceExtension.class)
+	static class TestBase {
+		@Test
+		void myTest() {}
+	}
+
+	@ExtendWith(ServiceExtension.class)
+	static class NonRawParameterType {
+		@SuppressWarnings("unused")
+		@Test
+		void myParameterTest(@InjectService AtomicReference<?> param) {}
+	}
+
+	@ExtendWith(ServiceExtension.class)
+	static class ListOfNonRawParameterType {
+		@SuppressWarnings("unused")
+		@Test
+		void myParameterTest(@InjectService List<AtomicReference<?>> param) {}
+	}
+
+	@ExtendWith(ServiceExtension.class)
+	static class ServiceAwareOfNonRawParameterType {
+		@SuppressWarnings("unused")
+		@Test
+		void myParameterTest(@InjectService ServiceAware<AtomicReference<?>> param) {}
+	}
+
+	@ParameterizedTest
+	@ValueSource(classes = {
+		NonRawParameterType.class, ListOfNonRawParameterType.class, ServiceAwareOfNonRawParameterType.class
+	})
+	void annotatedParameter_withNonRawType_throwsException(Class<?> test) {
+		assertThatTest(test).isInstanceOf(ParameterResolutionException.class)
+			.hasMessageEndingWith(
+				"Can only resolve @InjectService parameter for services with non-generic types, service type was: "
+					+ AtomicReference.class.getName() + "<?>");
+	}
+
+	static class FinalField extends TestBase {
+		@InjectService
+		final Date bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_thatIsFinal_throwsException() {
+		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessageMatching("@InjectService field \\[bc\\] must not be.*final.*");
+	}
+
+	static class StaticField extends TestBase {
+		@InjectService
+		static Date bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_thatIsStatic_throwsException() {
+		assertThatTest(StaticField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessageMatching("@InjectService field \\[bc\\] must not be.*static.*");
+	}
+
+	static class PrivateField extends TestBase {
+		@InjectService
+		private Date bc = null;
+
+		@Override
+		@Test
+		void myTest() {}
+	}
+
+	@Test
+	void annotatedField_thatIsPrivate_throwsException() {
+		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
+			.hasMessageMatching("@InjectService field \\[bc\\] must not be.*private.*");
+	}
+}

--- a/org.osgi.test.junit5/test.bndrun
+++ b/org.osgi.test.junit5/test.bndrun
@@ -24,6 +24,7 @@
 	org.osgi.service.http.port=*,\
 	org.osgi.framework.bootdelegation=sun.reflect,\
 	osgi.console=
+	
 -runsystempackages: \
 	org.slf4j;version=1.7.25,\
 	org.slf4j.helpers;version=1.7.25,\

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
 						</execution>
 					</executions>
 				</plugin>
+				<!-- Disable baseline validation until we are at version > 1.0.0 
 				<plugin>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>bnd-baseline-maven-plugin</artifactId>
@@ -139,6 +140,7 @@
 						</execution>
 					</executions>
 				</plugin>
+				-->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Factored out some sanity checking functions into `common`.
Added sanity checking tests for `ServiceExtension`.
Removed useless `public String NAMESPACE` from `BundleContextExtension`.

Signed-off-by: Fr Jeremy Krieg <fr.jkrieg@greekwelfaresa.org.au>