### PR TITLE
Provide ArgumentSources for ParameterizedTests

### DIFF
--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/bundle/BundleArgumentsProvider.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/bundle/BundleArgumentsProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.junit5.bundle;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.test.junit5.context.BundleContextExtension;
+
+public class BundleArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<BundleSource> {
+
+	private BundleSource bundleSource;
+
+	@Override
+	public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+
+		BundleContext bundleContext = BundleContextExtension.getBundleContext(context);
+
+		return filterBundleByAnnotation(bundleContext, bundleSource);
+	}
+
+	static Stream<Arguments> filterBundleByAnnotation(BundleContext bundleContext, BundleSource annotation)
+		throws InvalidSyntaxException {
+
+		String headerFilter = annotation.headerFilter();
+		Filter filter = headerFilter.isEmpty() ? null : bundleContext.createFilter(headerFilter);
+		Bundle[] bundles = bundleContext.getBundles();
+
+		return Arrays.stream(bundles)
+			.filter(Objects::nonNull)
+			.filter((Bundle bundle) -> {
+				if (annotation.symbolicNamePattern().length == 0) {
+					return true;
+				}
+				return Arrays.stream(annotation.symbolicNamePattern())
+					.anyMatch((symbolicNamePattern) -> bundle.getSymbolicName()
+						.matches(symbolicNamePattern));
+			})
+			.filter((bundle) -> {
+				return (bundle.getState() & annotation.stateMask()) != 0;
+			})
+			.filter((bundle) -> {
+				if (filter == null) {
+					return true;
+				}
+				return filter.match(bundle.getHeaders());
+			})
+			.map(Arguments::of);
+	}
+
+	@Override
+	public void accept(BundleSource annotation) {
+		this.bundleSource = annotation;
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/bundle/BundleSource.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/bundle/BundleSource.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.junit5.bundle;
+
+import static org.osgi.framework.Bundle.ACTIVE;
+import static org.osgi.framework.Bundle.INSTALLED;
+import static org.osgi.framework.Bundle.RESOLVED;
+import static org.osgi.framework.Bundle.STARTING;
+import static org.osgi.framework.Bundle.STOPPING;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@Target({
+	ElementType.ANNOTATION_TYPE, ElementType.METHOD
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ArgumentsSource(BundleArgumentsProvider.class)
+public @interface BundleSource {
+
+	/**
+	 * Optional SymbolicNameFilter used to filter Bundles by SymbolicName using
+	 * regular expression pattern.
+	 *
+	 * @return The symbolicNamePattern Strings.
+	 */
+	String[] symbolicNamePattern() default {};
+
+	/**
+	 * Optional bit mask of the Bundle states used to filter Bundles.
+	 *
+	 * @return The bit mask of the bundle state.
+	 */
+	int stateMask() default INSTALLED | RESOLVED | STARTING | STOPPING | ACTIVE;
+
+	/**
+	 * Filter string used to target a bundle by filtering the Bundle-Headers
+	 * Must use valid OSGi filter syntax.
+	 *
+	 * @return The filter string.
+	 */
+	String headerFilter() default "";
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceArgumentsProvider.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceArgumentsProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.junit5.service;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.common.inject.TargetType;
+import org.osgi.test.common.service.ServiceConfiguration;
+import org.osgi.test.junit5.context.BundleContextExtension;
+
+public class ServiceArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<ServiceSource> {
+
+	private ServiceSource serviceSource;
+
+	@SuppressWarnings("resource")
+	@Override
+	public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+
+		BundleContext bundleContext = BundleContextExtension.getBundleContext(context);
+
+		ServiceConfiguration<?> sc = ServiceExtension.getServiceConfiguration(serviceSource.serviceType(),
+			serviceSource.filter(), serviceSource.filterArguments(), 0, serviceSource.timeout(), context);
+
+		Stream<Arguments> stream = sc.getServiceReferences()
+			.stream()
+			.filter(Objects::nonNull)
+			.map((sr) -> {
+
+				List<Object> list = new ArrayList<>();
+				Optional<AnnotatedElement> oElement = context.getElement();
+				if (oElement.isPresent()) {
+					if (oElement.get() instanceof Method) {
+						Method method = (Method) oElement.get();
+						for (Parameter param : method.getParameters()) {
+
+							TargetType targetType = TargetType.of(param);
+							if (targetType.matches(serviceSource.serviceType())) {
+								Object service = sc.getTracked()
+									.get(sr);
+								list.add(service);
+								continue;
+							}
+
+							if (targetType.matches(ServiceReference.class, serviceSource.serviceType())) {
+								list.add(sr);
+								continue;
+							}
+
+							if (targetType.matches(Dictionary.class, String.class, Object.class)) {
+								Dictionary<String, Object> dict = new Hashtable<>();
+								for (String key : sr.getPropertyKeys()) {
+									dict.put(key, sr.getProperty(key));
+								}
+								list.add(dict);
+								continue;
+							}
+
+							if (targetType.matches(Map.class, String.class, Object.class)) {
+								Map<String, Object> map = new HashMap<>();
+								for (String key : sr.getPropertyKeys()) {
+									map.put(key, sr.getProperty(key));
+								}
+								list.add(map);
+								continue;
+							}
+
+						}
+					}
+				}
+
+				return Arguments.of(list.toArray());
+			});
+
+		return stream;
+
+	}
+
+	@Override
+	public void accept(ServiceSource annotation) {
+		this.serviceSource = annotation;
+
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceSource.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceSource.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.junit5.service;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@Target({
+	ElementType.ANNOTATION_TYPE, ElementType.METHOD
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ArgumentsSource(ServiceArgumentsProvider.class)
+public @interface ServiceSource {
+
+	static long DEFAULT_TIMEOUT = 200l;
+
+	Class<?> serviceType() default Object.class;
+
+	/**
+	 * Filter string used to target more specific services using the
+	 * {@code String.format} pattern. Must use valid OSGi filter syntax.
+	 *
+	 * @return The filter string.
+	 */
+	String filter() default "";
+
+	/**
+	 * Optional arguments to the format string provided by {@link #filter()}.
+	 *
+	 * @return The filter arguments.
+	 */
+	String[] filterArguments() default {};
+
+	/**
+	 * Indicate require services must arrive within the specified timeout.
+	 *
+	 * @return The timeout.
+	 */
+	long timeout() default DEFAULT_TIMEOUT;
+}

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/bundle/BundleArgumentsProviderTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/bundle/BundleArgumentsProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.junit5.bundle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.osgi.framework.Bundle;
+import org.osgi.test.assertj.bundle.BundleAssert;
+import org.osgi.test.assertj.dictionary.DictionaryAssert;
+import org.osgi.test.common.annotation.InjectInstallBundle;
+import org.osgi.test.common.install.InstallBundle;
+import org.osgi.test.junit5.context.BundleContextExtension;
+
+@ExtendWith(BundleContextExtension.class)
+public class BundleArgumentsProviderTest {
+
+	static Bundle bundleInstalled;
+
+	@BeforeAll
+	static void beforeAll(@InjectInstallBundle InstallBundle installBundle) {
+		bundleInstalled = installBundle.installBundle("tb1.jar", false);
+	}
+
+	@ParameterizedTest
+	@BundleSource(stateMask = Bundle.INSTALLED)
+	public void testParamInstalled(Bundle bundle) throws Exception {
+
+		BundleAssert.assertThat(bundle)
+			.isInState(Bundle.INSTALLED)
+			.isSameAs(bundleInstalled);
+
+	}
+
+	@ParameterizedTest
+	@BundleSource(stateMask = Bundle.ACTIVE)
+	public void testParamActive(Bundle bundle) throws Exception {
+		BundleAssert.assertThat(bundle)
+			.isInState(Bundle.ACTIVE);
+	}
+
+	@ParameterizedTest
+	@BundleSource(stateMask = Bundle.RESOLVED)
+	public void testParamResolved(Bundle bundle) throws Exception {
+		BundleAssert.assertThat(bundle)
+			.isInState(Bundle.RESOLVED);
+	}
+
+	@ParameterizedTest
+	@BundleSource(headerFilter = "(Bundle-Vendor=OSGi Alliance)")
+	public void testHeader(Bundle bundle) throws Exception {
+		DictionaryAssert.assertThat(bundle.getHeaders())
+			.containsEntry("Bundle-Vendor", "OSGi Alliance");
+	}
+
+	static final String pattern = ".*\\.junit5";
+
+	@ParameterizedTest
+	@BundleSource(symbolicNamePattern = pattern)
+	public void testSymbolicNamePattern(Bundle bundle) throws Exception {
+		assertThat(bundle.getSymbolicName()).matches(pattern);
+	}
+
+}

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceArgumentsProviderTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceArgumentsProviderTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.junit5.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.common.dictionary.Dictionaries;
+import org.osgi.test.junit5.context.BundleContextExtension;
+import org.osgi.test.junit5.types.Foo;
+
+@ExtendWith(BundleContextExtension.class)
+public class ServiceArgumentsProviderTest {
+
+	@InjectBundleContext
+	static BundleContext			classLevelContext;
+	static ServiceRegistration<Foo>	sr1;
+	static ServiceRegistration<Foo>	sr2;
+	static ServiceRegistration<Foo>	sr3;
+
+	static final List<String>		counter	= new ArrayList<>();
+
+	@BeforeAll
+	public static void before(@InjectBundleContext BundleContext bundleContext) {
+
+		sr1 = bundleContext.registerService(Foo.class, new Foo() {}, Dictionaries.dictionaryOf("1", "2"));
+		sr2 = bundleContext.registerService(Foo.class, new Foo() {}, Dictionaries.dictionaryOf("1", "3"));
+		sr3 = bundleContext.registerService(Foo.class, new Foo() {}, Dictionaries.dictionaryOf("1", "4"));
+
+	}
+
+	@ParameterizedTest
+	@ServiceSource(serviceType = Foo.class)
+	public void testAllOrder1(Foo foo, ServiceReference<Foo> sr, Map<String, Object> map, TestInfo testInfo)
+		throws Exception {
+		assertThat(foo).isNotNull();
+		assertThat(sr).isNotNull();
+		assertThat(map).isNotNull();
+		testInfo.getTestMethod()
+			.ifPresent(name -> counter.add(name.getName()));
+	}
+
+	@ParameterizedTest
+	@ServiceSource(serviceType = Foo.class)
+	public void testAllOrder2(ServiceReference<Foo> sr, Map<String, Object> map, Foo foo, TestInfo testInfo)
+		throws Exception {
+		assertThat(foo).isNotNull();
+		assertThat(sr).isNotNull();
+		assertThat(map).isNotNull();
+		testInfo.getTestMethod()
+			.ifPresent(name -> counter.add(name.getName()));
+	}
+
+	@ParameterizedTest
+	@ServiceSource(serviceType = Foo.class)
+	public void testAllOrder3(Map<String, Object> map, Foo foo, ServiceReference<Foo> sr, TestInfo testInfo)
+		throws Exception {
+		assertThat(foo).isNotNull();
+		assertThat(sr).isNotNull();
+		assertThat(map).isNotNull();
+		testInfo.getTestMethod()
+			.ifPresent(name -> counter.add(name.getName()));
+	}
+
+	@ParameterizedTest
+	@ServiceSource(serviceType = Foo.class)
+	public void testOnlyMap(Map<String, Object> map, TestInfo testInfo) throws Exception {
+		assertThat(map).isNotNull();
+		testInfo.getTestMethod()
+			.ifPresent(name -> counter.add(name.getName()));
+	}
+
+	@ParameterizedTest
+	@ServiceSource(serviceType = Foo.class)
+	public void testOnlyService(Foo foo, TestInfo testInfo) throws Exception {
+		assertThat(foo).isNotNull();
+		testInfo.getTestMethod()
+			.ifPresent(name -> counter.add(name.getName()));
+	}
+
+	@ParameterizedTest
+	@ServiceSource(serviceType = Foo.class)
+	public void testOnlyServiceRef(ServiceReference<Foo> sr, TestInfo testInfo) throws Exception {
+		assertThat(sr).isNotNull();
+		testInfo.getTestMethod()
+			.ifPresent(name -> counter.add(name.getName()));
+	}
+
+	@ParameterizedTest
+	@ServiceSource(serviceType = Foo.class, filter = "(%s=%s)", filterArguments = {
+		"1", "*"
+	})
+	public void testfilterArgumentsWildcard(ServiceReference<Foo> sr, TestInfo testInfo) throws Exception {
+		assertThat(sr).isNotNull();
+		testInfo.getTestMethod()
+			.ifPresent(name -> counter.add(name.getName()));
+	}
+
+	@ParameterizedTest
+	@ServiceSource(serviceType = Foo.class, filter = "(%s=%s)", filterArguments = {
+		"1", "2"
+	})
+	public void testfilterArgumentsFix(ServiceReference<Foo> sr, TestInfo testInfo) throws Exception {
+		assertThat(sr).isNotNull();
+		testInfo.getTestMethod()
+			.ifPresent(name -> counter.add(name.getName()));
+	}
+
+	@AfterAll
+	public static void afterAll() {
+		testCount("testOnlyMap", 3);
+		testCount("testOnlyServiceRef", 3);
+		testCount("testOnlyService", 3);
+		testCount("testfilterArgumentsWildcard", 3);
+		testCount("testAllOrder1", 3);
+		testCount("testAllOrder2", 3);
+		testCount("testAllOrder3", 3);
+		testCount("testfilterArgumentsFix", 1);
+
+		sr1.unregister();
+		sr2.unregister();
+		sr3.unregister();
+	}
+
+	private static void testCount(String testName, long i) {
+		long count = counter.stream()
+			.filter(s -> s.equals(testName))
+			.count();
+		assertThat(count).as("Wrong test-execution-count on : %s", testName)
+			.isEqualTo(i);
+	}
+}


### PR DESCRIPTION
Use 
```
@ParameterizedTest
@ServiceSource(serviceType = Foo.class)
```
to execute the testMethod with multiple parameters wich can be filtered using the `@ServiceSource` annotation.

It will inject 
* Services
* ServiceReferences
* Map of ServiceProperties
into MethofParameters

`method(Foo foo, ServiceReference<Foo> sr, Map<String, Object> map)`

---
the Annotation `@BundleSource` can be used to inject Bundles
