### PR TITLE
assertj: Enhance DictionaryAssert to provide additional methods

### DIFF
--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/AbstractDictionaryAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/AbstractDictionaryAssert.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.assertj.dictionary;
+
+import java.util.Dictionary;
+import java.util.Map;
+
+import org.assertj.core.api.AbstractMapAssert;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+public abstract class AbstractDictionaryAssert<SELF extends AbstractDictionaryAssert<SELF, ACTUAL, K, V>, ACTUAL extends Map<K, V>, K, V>
+	extends AbstractMapAssert<SELF, ACTUAL, K, V> {
+
+	protected AbstractDictionaryAssert(ACTUAL actual, Class<?> selfType) {
+		super(actual, selfType);
+	}
+
+	public SELF containsAllEntriesOf(Dictionary<? extends K, ? extends V> dictionary) {
+		return super.containsAllEntriesOf(Dictionaries.asMap(dictionary));
+	}
+
+	public SELF containsExactlyEntriesOf(Dictionary<? extends K, ? extends V> dictionary) {
+		return containsExactlyEntriesOf(Dictionaries.asMap(dictionary));
+	}
+
+	public SELF containsExactlyInAnyOrderEntriesOf(Dictionary<? extends K, ? extends V> dictionary) {
+		return containsExactlyInAnyOrderEntriesOf(Dictionaries.asMap(dictionary));
+	}
+
+	public SELF hasSameSizeAs(Dictionary<?, ?> dictionary) {
+		return hasSameSizeAs(Dictionaries.asMap(dictionary));
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/DictionaryAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/DictionaryAssert.java
@@ -16,23 +16,124 @@
 
 package org.osgi.test.assertj.dictionary;
 
-import java.util.Dictionary;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 
-import org.assertj.core.api.Assertions;
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.groups.Tuple;
 import org.osgi.test.common.dictionary.Dictionaries;
 
-public class DictionaryAssert {
-	@SuppressWarnings({
-		"rawtypes"
-	}) // rawtypes: using Class instance
-	public static final <K, V> InstanceOfAssertFactory<Dictionary, MapAssert<K, V>> dictionary(Class<K> keyType,
-		Class<V> valueType) {
-		return new InstanceOfAssertFactory<>(Dictionary.class, DictionaryAssert::<K, V> assertThat);
+public class DictionaryAssert<KEY, VALUE>
+	extends AbstractDictionaryAssert<DictionaryAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> {
+
+	public DictionaryAssert(Dictionary<KEY, VALUE> actual) {
+		this(Dictionaries.asMap(actual));
 	}
 
-	public static <K, V> MapAssert<K, V> assertThat(Dictionary<K, V> actual) {
-		return Assertions.assertThat(Dictionaries.asMap(actual));
+	protected DictionaryAssert(Map<KEY, VALUE> actual) {
+		super(actual, DictionaryAssert.class);
+	}
+
+	public static <K, V> DictionaryAssert<K, V> assertThat(Dictionary<K, V> actual) {
+		return new DictionaryAssert<>(actual);
+	}
+
+	public static final <ACTUAL extends Dictionary<K, V>, K, V> InstanceOfAssertFactory<ACTUAL, DictionaryAssert<K, V>> dictionary(
+		Class<K> keyType, Class<V> valueType) {
+		requireNonNull(keyType, shouldNotBeNull("keyType").create());
+		requireNonNull(valueType, shouldNotBeNull("valueType").create());
+		@SuppressWarnings({
+			"unchecked", "rawtypes"
+		})
+		Class<ACTUAL> type = (Class) Dictionary.class;
+		return new InstanceOfAssertFactory<>(type, DictionaryAssert::<K, V> assertThat);
+	}
+
+	// override methods to annotate them with @SafeVarargs, we unfortunately
+	// can't do that in AbstractMapAssert as it is
+	// used in soft assertions which need to be able to proxy method -
+	// @SafeVarargs requiring method to be final prevents
+	// using proxies.
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> contains(Map.Entry<? extends KEY, ? extends VALUE>... entries) {
+		return super.contains(entries);
+	}
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> containsAnyOf(Map.Entry<? extends KEY, ? extends VALUE>... entries) {
+		return super.containsAnyOf(entries);
+	}
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> containsOnly(Map.Entry<? extends KEY, ? extends VALUE>... entries) {
+		return super.containsOnly(entries);
+	}
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> containsExactly(Map.Entry<? extends KEY, ? extends VALUE>... entries) {
+		return super.containsExactly(entries);
+	}
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> containsKeys(KEY... keys) {
+		return super.containsKeys(keys);
+	}
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> containsOnlyKeys(KEY... keys) {
+		return super.containsOnlyKeys(keys);
+	}
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> containsValues(VALUE... values) {
+		return super.containsValues(values);
+	}
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> doesNotContainKeys(KEY... keys) {
+		return super.doesNotContainKeys(keys);
+	}
+
+	@SafeVarargs
+	@Override
+	public final DictionaryAssert<KEY, VALUE> doesNotContain(Map.Entry<? extends KEY, ? extends VALUE>... entries) {
+		return super.doesNotContain(entries);
+	}
+
+	@SafeVarargs
+	@Override
+	public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(
+		Function<? super Map<KEY, VALUE>, ?>... extractors) {
+		return super.extracting(extractors);
+	}
+
+	@SafeVarargs
+	@Override
+	public final AbstractListAssert<?, List<? extends VALUE>, VALUE, ObjectAssert<VALUE>> extractingByKeys(
+		KEY... keys) {
+		return super.extractingByKeys(keys);
+	}
+
+	@SafeVarargs
+	@Override
+	public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extractingFromEntries(
+		Function<? super Map.Entry<KEY, VALUE>, Object>... extractors) {
+		return super.extractingFromEntries(extractors);
 	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/DictionarySoftAssertions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/DictionarySoftAssertions.java
@@ -18,18 +18,9 @@ package org.osgi.test.assertj.dictionary;
 
 import java.util.Dictionary;
 
-import org.assertj.core.api.SoftAssertionsProvider;
+import org.assertj.core.api.SoftAssertions;
 
-public interface DictionarySoftAssertionsProvider extends SoftAssertionsProvider {
-	/**
-	 * Create soft assertion for {@link java.util.Dictionary}.
-	 *
-	 * @param actual the actual value.
-	 * @return the created assertion object.
-	 */
-	default <K, V> ProxyableDictionaryAssert<K, V> assertThat(Dictionary<K, V> actual) {
-		@SuppressWarnings("unchecked")
-		ProxyableDictionaryAssert<K, V> softly = proxy(ProxyableDictionaryAssert.class, Dictionary.class, actual);
-		return softly;
-	}
-}
+/**
+ * Soft assertions for {@link Dictionary}s.
+ */
+public class DictionarySoftAssertions extends SoftAssertions implements DictionarySoftAssertionsProvider {}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/ProxyableDictionaryAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/ProxyableDictionaryAssert.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.assertj.dictionary;
+
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ProxyableListAssert;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+public class ProxyableDictionaryAssert<KEY, VALUE>
+	extends AbstractDictionaryAssert<ProxyableDictionaryAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> {
+
+	public ProxyableDictionaryAssert(Dictionary<KEY, VALUE> actual) {
+		this(Dictionaries.asMap(actual));
+	}
+
+	protected ProxyableDictionaryAssert(Map<KEY, VALUE> actual) {
+		super(actual, ProxyableDictionaryAssert.class);
+	}
+
+	@Override
+	protected <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> newListAssertInstance(
+		List<? extends ELEMENT> newActual) {
+		return new ProxyableListAssert<>(newActual);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/dictionary/DictionaryAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/dictionary/DictionaryAssertTest.java
@@ -1,12 +1,14 @@
 package org.osgi.test.assertj.dictionary;
 
-import java.util.Hashtable;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assert;
-import org.assertj.core.api.ProxyableMapAssert;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,7 @@ public class DictionaryAssertTest {
 
 	@Test
 	public void keysAndValues_areTheRightWayAround(SoftAssertions softly) throws Exception {
-		Hashtable<Object, Object> sut = new Hashtable<>();
+		Dictionary<Object, Object> sut = new TestDictionary<>();
 		sut.put("key", "value");
 
 		softly.assertThatCode(() -> DictionaryAssert.assertThat(sut)
@@ -30,7 +32,7 @@ public class DictionaryAssertTest {
 
 	@Test
 	public void keysAndValues_areTheRightWayAround_forSoftAssertion(SoftAssertions softly) throws Exception {
-		Hashtable<Object, Object> sut = new Hashtable<>();
+		Dictionary<Object, Object> sut = new TestDictionary<>();
 		sut.put("key", "value");
 
 		AtomicReference<Object> actualRef = new AtomicReference<>();
@@ -45,7 +47,7 @@ public class DictionaryAssertTest {
 			public <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF proxy(Class<SELF> assertClass,
 				Class<ACTUAL> actualClass, ACTUAL actual) {
 				actualRef.set(actual);
-				retvalRef.set(new ProxyableMapAssert((Map) actual));
+				retvalRef.set(new ProxyableDictionaryAssert((Dictionary) actual));
 				return (SELF) retvalRef.get();
 			}
 
@@ -73,4 +75,186 @@ public class DictionaryAssertTest {
 			.as("equal")
 			.isEqualTo(sut);
 	}
+
+	@Test
+	public void instanceof_factory(SoftAssertions softly) throws Exception {
+		Dictionary<String, String> dict1 = new TestDictionary<>();
+		dict1.put("key1", "value1");
+		dict1.put("key2", "value2");
+		Dictionary<String, String> dict2 = new TestDictionary<>();
+		dict2.put("key1", "value1");
+		dict2.put("key2", "value2");
+
+		DictionaryAssert<CharSequence, CharSequence> charseqDictionaryAssert = softly.assertThatObject(dict1)
+			.asInstanceOf(DictionaryAssert.dictionary(CharSequence.class, CharSequence.class));
+		charseqDictionaryAssert.containsKeys("key1", "key2")
+			.containsValues("value1", "value2")
+			.containsExactlyInAnyOrderEntriesOf(dict2);
+
+		softly.assertThatCode(() -> DictionaryAssert.dictionary(CharSequence.class, null))
+			.isInstanceOf(NullPointerException.class);
+		softly.assertThatCode(() -> DictionaryAssert.dictionary(null, CharSequence.class))
+			.isInstanceOf(NullPointerException.class);
+		softly.assertThatCode(() -> DictionaryAssert.dictionary(null, null))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	public void containsAllEntriesOf(DictionarySoftAssertions softly) throws Exception {
+		Dictionary<String, String> dict1 = new TestDictionary<>();
+		dict1.put("key1", "value1");
+		dict1.put("key2", "value2");
+		Dictionary<String, String> dict2 = new TestDictionary<>();
+		dict2.put("key1", "value1");
+
+		softly.assertThat(dict1)
+			.containsAllEntriesOf(dict2);
+		softly.assertThatCode(() -> DictionaryAssert.assertThat(dict2)
+			.containsAllEntriesOf(dict1))
+			.as("does not containsAllEntriesOf")
+			.isInstanceOf(AssertionError.class);
+	}
+
+	@Test
+	public void containsExactlyEntriesOf(DictionarySoftAssertions softly) throws Exception {
+		Dictionary<String, String> dict1 = new TestDictionary<>();
+		dict1.put("key1", "value1");
+		dict1.put("key2", "value2");
+		Dictionary<String, String> dict2 = new TestDictionary<>();
+		dict2.put("key1", "value1");
+		dict2.put("key2", "value2");
+		Dictionary<String, String> dict3 = new TestDictionary<>();
+		dict3.put("key1", "value1");
+		Dictionary<String, String> dict4 = new TestDictionary<>();
+		dict4.put("key2", "value2");
+		dict4.put("key1", "value1");
+		Dictionary<String, String> dict5 = new TestDictionary<>();
+		dict5.put("key1", "value1");
+		dict5.put("key2", "value2");
+		dict5.put("key3", "value3");
+
+		softly.assertThat(dict1)
+			.containsExactlyEntriesOf(dict2);
+		softly.assertThatCode(() -> DictionaryAssert.assertThat(dict1)
+			.containsExactlyEntriesOf(dict3))
+			.as("does not containsExactlyEntriesOf")
+			.isInstanceOf(AssertionError.class);
+		softly.assertThatCode(() -> DictionaryAssert.assertThat(dict1)
+			.containsExactlyEntriesOf(dict4))
+			.as("does not containsExactlyEntriesOf")
+			.isInstanceOf(AssertionError.class);
+		softly.assertThatCode(() -> DictionaryAssert.assertThat(dict1)
+			.containsExactlyEntriesOf(dict5))
+			.as("does not containsExactlyEntriesOf")
+			.isInstanceOf(AssertionError.class);
+	}
+
+	@Test
+	public void containsExactlyInAnyOrderEntriesOf(DictionarySoftAssertions softly) throws Exception {
+		Dictionary<String, String> dict1 = new TestDictionary<>();
+		dict1.put("key1", "value1");
+		dict1.put("key2", "value2");
+		Dictionary<String, String> dict2 = new TestDictionary<>();
+		dict2.put("key1", "value1");
+		dict2.put("key2", "value2");
+		Dictionary<String, String> dict3 = new TestDictionary<>();
+		dict3.put("key1", "value1");
+		Dictionary<String, String> dict4 = new TestDictionary<>();
+		dict4.put("key2", "value2");
+		dict4.put("key1", "value1");
+		Dictionary<String, String> dict5 = new TestDictionary<>();
+		dict5.put("key1", "value1");
+		dict5.put("key2", "value2");
+		dict5.put("key3", "value3");
+
+		softly.assertThat(dict1)
+			.containsExactlyInAnyOrderEntriesOf(dict2);
+		softly.assertThat(dict1)
+			.containsExactlyInAnyOrderEntriesOf(dict4);
+		softly.assertThatCode(() -> DictionaryAssert.assertThat(dict1)
+			.containsExactlyInAnyOrderEntriesOf(dict3))
+			.as("does not containsExactlyInAnyOrderEntriesOf")
+			.isInstanceOf(AssertionError.class);
+		softly.assertThatCode(() -> DictionaryAssert.assertThat(dict1)
+			.containsExactlyInAnyOrderEntriesOf(dict5))
+			.as("does not containsExactlyInAnyOrderEntriesOf")
+			.isInstanceOf(AssertionError.class);
+	}
+
+	@Test
+	public void hasSameSizeAs(DictionarySoftAssertions softly) throws Exception {
+		Dictionary<String, String> dict1 = new TestDictionary<>();
+		dict1.put("key1", "value1");
+		dict1.put("key2", "value2");
+		Dictionary<String, String> dict2 = new TestDictionary<>();
+		dict2.put("key1", "value1");
+		dict2.put("key2", "value2");
+		Dictionary<String, String> dict3 = new TestDictionary<>();
+		dict3.put("key1", "value1");
+
+		softly.assertThat(dict1)
+			.hasSameSizeAs(dict2);
+		softly.assertThatCode(() -> DictionaryAssert.assertThat(dict1)
+			.hasSameSizeAs(dict3))
+			.as("does not hasSameSizeAs")
+			.isInstanceOf(AssertionError.class);
+	}
+
+	public static class TestDictionary<K, V> extends Dictionary<K, V> {
+		private final Map<K, V> map;
+
+		public TestDictionary() {
+			this.map = new LinkedHashMap<>();
+		}
+
+		@Override
+		public int size() {
+			return map.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return map.isEmpty();
+		}
+
+		@Override
+		public Enumeration<K> keys() {
+			return Collections.enumeration(map.keySet());
+		}
+
+		@Override
+		public Enumeration<V> elements() {
+			return Collections.enumeration(map.values());
+		}
+
+		@Override
+		public V get(Object key) {
+			if (key == null) {
+				return null;
+			}
+			return map.get(key);
+		}
+
+		@Override
+		public V put(K key, V value) {
+			if ((key == null) || (value == null)) {
+				throw new NullPointerException();
+			}
+			return map.put(key, value);
+		}
+
+		@Override
+		public V remove(Object key) {
+			if (key == null) {
+				return null;
+			}
+			return map.remove(key);
+		}
+
+		@Override
+		public String toString() {
+			return map.toString();
+		}
+	}
+
 }


### PR DESCRIPTION
This adds methods equivalent to the MapAssert methods which take Map
arguments. We also override the MapAssert methods which return MapAssert
so that they now return DictionaryAssert.
