### PR TITLE
ServiceExtension improvements

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/service/ServiceConfiguration.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/service/ServiceConfiguration.java
@@ -44,6 +44,10 @@ public class ServiceConfiguration<S> implements AutoCloseable, ServiceAware<S> {
 	private final long						timeout;
 	private volatile ServiceTracker<S, S>	tracker;
 
+	public ServiceConfiguration(ServiceConfigurationKey<S> key) {
+		this(key.serviceType, key.filter, key.filterArguments, key.cardinality, key.timeout);
+	}
+
 	public ServiceConfiguration(Class<S> serviceType, String format, String[] args, int cardinality, long timeout) {
 		this.serviceType = requireNonNull(serviceType);
 

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/service/ServiceConfigurationKey.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/service/ServiceConfigurationKey.java
@@ -1,24 +1,25 @@
 package org.osgi.test.common.service;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Arrays;
 import java.util.Objects;
 
-import org.osgi.test.common.annotation.InjectService;
+public class ServiceConfigurationKey<S> {
 
-public class ServiceConfigurationKey {
+	final Class<S>	serviceType;
+	final String	filter;
+	final String[]	filterArguments;
+	final int		cardinality;
+	final long		timeout;
 
-	private final int		cardinality;
-	private final String	filter;
-	private final String[]	filterArguments;
-	private final String	serviceName;
-	private final long		timeout;
-
-	public ServiceConfigurationKey(Class<?> serviceType, InjectService injectService) {
-		this.serviceName = serviceType.getName();
-		this.cardinality = injectService.cardinality();
-		this.filter = injectService.filter();
-		this.filterArguments = injectService.filterArguments();
-		this.timeout = injectService.timeout();
+	public ServiceConfigurationKey(Class<S> serviceType, String filter, String[] filterArguments, int cardinality,
+		long timeout) {
+		this.serviceType = requireNonNull(serviceType);
+		this.filter = filter;
+		this.filterArguments = filterArguments;
+		this.cardinality = cardinality;
+		this.timeout = timeout;
 	}
 
 	@Override
@@ -26,7 +27,7 @@ public class ServiceConfigurationKey {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + Arrays.hashCode(filterArguments);
-		result = prime * result + Objects.hash(cardinality, filter, serviceName, timeout);
+		result = prime * result + Objects.hash(cardinality, filter, serviceType.getName(), timeout);
 		return result;
 	}
 
@@ -38,10 +39,10 @@ public class ServiceConfigurationKey {
 		if (!(obj instanceof ServiceConfigurationKey)) {
 			return false;
 		}
-		ServiceConfigurationKey other = (ServiceConfigurationKey) obj;
+		ServiceConfigurationKey<?> other = (ServiceConfigurationKey<?>) obj;
 		return cardinality == other.cardinality && Objects.equals(filter, other.filter)
-			&& Arrays.equals(filterArguments, other.filterArguments) && Objects.equals(serviceName, other.serviceName)
+			&& Arrays.equals(filterArguments, other.filterArguments)
+			&& Objects.equals(serviceType.getName(), other.serviceType.getName())
 			&& timeout == other.timeout;
 	}
-
 }

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/service/ServiceRule.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/service/ServiceRule.java
@@ -59,7 +59,7 @@ import org.osgi.test.common.service.ServiceConfigurationKey;
  */
 public class ServiceRule implements AutoCloseable, MethodRule {
 
-	private final Map<ServiceConfigurationKey, ServiceConfiguration<?>> configurations = new ConcurrentHashMap<>();
+	private final Map<ServiceConfigurationKey<?>, ServiceConfiguration<?>> configurations = new ConcurrentHashMap<>();
 
 	public ServiceRule init(Object testInstance) {
 		BundleContext bundleContext = FrameworkUtil.getBundle(testInstance
@@ -83,10 +83,10 @@ public class ServiceRule implements AutoCloseable, MethodRule {
 
 	@Override
 	public void close() throws Exception {
-		for (Iterator<Entry<ServiceConfigurationKey, ServiceConfiguration<?>>> itr = configurations
+		for (Iterator<Entry<ServiceConfigurationKey<?>, ServiceConfiguration<?>>> itr = configurations
 			.entrySet()
 			.iterator(); itr.hasNext();) {
-			Entry<ServiceConfigurationKey, ServiceConfiguration<?>> entry = itr.next();
+			Entry<ServiceConfigurationKey<?>, ServiceConfiguration<?>> entry = itr.next();
 			entry.getValue()
 				.close();
 			itr.remove();
@@ -120,17 +120,17 @@ public class ServiceRule implements AutoCloseable, MethodRule {
 		InjectService injectService,
 		Class<X> serviceType,
 		BundleContext bundleContext,
-		Map<ServiceConfigurationKey, ServiceConfiguration<?>> configurations) {
+		Map<ServiceConfigurationKey<?>, ServiceConfiguration<?>> configurations) {
 		@SuppressWarnings("unchecked")
 		ServiceConfiguration<X> closeableTrackServices = (ServiceConfiguration<X>) configurations.computeIfAbsent(
-			new ServiceConfigurationKey(serviceType, injectService),
-			k -> new ServiceConfiguration<>(serviceType, injectService.filter(), injectService.filterArguments(),
-				injectService.cardinality(), injectService.timeout()).init(bundleContext));
+			new ServiceConfigurationKey<>(serviceType, injectService.filter(), injectService.filterArguments(),
+				injectService.cardinality(), injectService.timeout()),
+			key -> new ServiceConfiguration<>(key).init(bundleContext));
 		return closeableTrackServices;
 	}
 
 	static Object resolveReturnValue(Class<?> memberType, Type genericMemberType, InjectService serviceUseParameter,
-		BundleContext bundleContext, Map<ServiceConfigurationKey, ServiceConfiguration<?>> configurations) {
+		BundleContext bundleContext, Map<ServiceConfigurationKey<?>, ServiceConfiguration<?>> configurations) {
 
 		Type serviceType = genericMemberType;
 

--- a/org.osgi.test.junit4/src/test/java/org/osgi/test/junit4/service/ServiceRuleTest.java
+++ b/org.osgi.test.junit4/src/test/java/org/osgi/test/junit4/service/ServiceRuleTest.java
@@ -96,7 +96,7 @@ public class ServiceRuleTest {
 		assertThatExceptionOfType(AssertionError.class) //
 			.isThrownBy(() -> {
 				try (BundleContextRule bcRule = new BundleContextRule();
-					ServiceConfiguration<Foo> foos = new ServiceConfiguration<>(Foo.class, "", new String[0], 1, 50)) {
+					ServiceConfiguration<Foo> foos = new ServiceConfiguration<>(Foo.class, "", new String[0], 1, 50L)) {
 
 					bcRule.init(this);
 
@@ -155,7 +155,7 @@ public class ServiceRuleTest {
 	@Test
 	public void successWhenServiceWithTimeout() throws Exception {
 		try (BundleContextRule bcRule = new BundleContextRule();
-			ServiceConfiguration<Foo> foos = new ServiceConfiguration<>(Foo.class, "", new String[0], 1, 1000)) {
+			ServiceConfiguration<Foo> foos = new ServiceConfiguration<>(Foo.class, "", new String[0], 1, 1000L)) {
 
 			bcRule.init(this);
 
@@ -405,7 +405,7 @@ public class ServiceRuleTest {
 			.isThrownBy(() -> {
 				try (BundleContextRule bcRule = new BundleContextRule();
 						ServiceConfiguration<Foo> fooRule = new ServiceConfiguration<>(Foo.class, "", new String[0], 1,
-							-1)) {
+						-1L)) {
 				}
 			});
 	}

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AbstractServiceExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AbstractServiceExtensionTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +26,6 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.test.common.context.CloseableBundleContext;
 import org.osgi.test.common.dictionary.Dictionaries;
 import org.osgi.test.common.exceptions.Exceptions;
-import org.osgi.test.common.service.ServiceAware;
 import org.osgi.test.junit5.ExecutorExtension;
 import org.osgi.test.junit5.ExecutorParameter;
 import org.osgi.test.junit5.types.Foo;
@@ -34,14 +34,11 @@ import org.osgi.test.junit5.types.Foo;
 abstract class AbstractServiceExtensionTest {
 
 	@ExtendWith(ServiceExtension.class)
-	static class TestBase {
+	abstract static class TestBase {
+		static AtomicReference<SoftAssertions>		lastSoftAssertions	= new AtomicReference<>();
 		static AtomicReference<Foo>					lastService			= new AtomicReference<>();
-		static AtomicReference<ServiceAware<Foo>>	lastServiceAware	= new AtomicReference<>();
 		static AtomicReference<List<Foo>>			lastServices		= new AtomicReference<>();
-
-		ServiceAware<Foo> getServiceAware() {
-			return null;
-		}
+		SoftAssertions								softly;
 
 		Foo getService() {
 			return null;
@@ -53,15 +50,24 @@ abstract class AbstractServiceExtensionTest {
 
 		@BeforeAll
 		static void beforeAll() {
+			lastSoftAssertions.set(null);
 			lastService.set(null);
-			lastServiceAware.set(null);
+			lastServices.set(null);
+		}
+
+		@BeforeEach
+		void beforeEach() {
+			lastSoftAssertions.set(softly = new SoftAssertions());
+			lastService.set(null);
 			lastServices.set(null);
 		}
 
 		@Test
-		final void test() {
+		abstract void test() throws Exception;
+
+		@AfterEach
+		void afterEach() {
 			lastService.set(getService());
-			lastServiceAware.set(getServiceAware());
 			lastServices.set(getServices());
 		}
 	}

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtensionTest.java
@@ -42,6 +42,10 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		Foo getService() {
 			return foo;
 		}
+
+		@Override
+		@Test
+		void test() throws Exception {}
 	}
 
 	@Test
@@ -61,6 +65,10 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		Foo getService() {
 			return foo;
 		}
+
+		@Override
+		@Test
+		void test() throws Exception {}
 	}
 
 	@Test
@@ -91,6 +99,10 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		Foo getService() {
 			return foo;
 		}
+
+		@Override
+		@Test
+		void test() throws Exception {}
 	}
 
 	@Test
@@ -113,6 +125,10 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		Foo getService() {
 			return foo;
 		}
+
+		@Override
+		@Test
+		void test() throws Exception {}
 	}
 
 	@Test
@@ -133,6 +149,10 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		List<Foo> getServices() {
 			return foos;
 		}
+
+		@Override
+		@Test
+		void test() throws Exception {}
 	}
 
 	@Test
@@ -191,6 +211,10 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		Foo getService() {
 			return foo;
 		}
+
+		@Override
+		@Test
+		void test() throws Exception {}
 	}
 
 	@Test
@@ -209,6 +233,10 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		Foo getService() {
 			return foo;
 		}
+
+		@Override
+		@Test
+		void test() throws Exception {}
 	}
 
 	@Test
@@ -226,6 +254,10 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		Foo getService() {
 			return foo;
 		}
+
+		@Override
+		@Test
+		void test() throws Exception {}
 	}
 
 	@Test

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtension_SanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtension_SanityCheckingTest.java
@@ -72,21 +72,6 @@ public class ServiceExtension_SanityCheckingTest {
 			.hasMessageMatching("@InjectService field \\[bc\\] must not be.*final.*");
 	}
 
-	static class StaticField extends TestBase {
-		@InjectService
-		static Date bc = null;
-
-		@Override
-		@Test
-		void myTest() {}
-	}
-
-	@Test
-	void annotatedField_thatIsStatic_throwsException() {
-		assertThatTest(StaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectService field \\[bc\\] must not be.*static.*");
-	}
-
 	static class PrivateField extends TestBase {
 		@InjectService
 		private Date bc = null;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/SingleServiceTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/SingleServiceTest.java
@@ -18,6 +18,8 @@ package org.osgi.test.junit5.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.service.log.LogService;
@@ -28,9 +30,21 @@ import org.osgi.test.common.service.ServiceAware;
 public class SingleServiceTest {
 
 	@InjectService
+	static LogService			staticLogService;
+	@InjectService
 	LogService					logService;
 	@InjectService
 	ServiceAware<LogService>	lsServiceAware;
+
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		assertThat(staticLogService).isNotNull();
+	}
+
+	@BeforeEach
+	public void beforeEach() throws Exception {
+		assertThat(staticLogService).isNotNull();
+	}
 
 	@Test
 	public void testWithLogServiceUse() throws Exception {


### PR DESCRIPTION
We add a public static method to create a managed ServiceConfiguration.
We use a CloseableResource to store the ServiceConfiguration in the
execution context store so that is will be properly closed when the
execution contexts completes. We also use a store keyed to the execution
context as we do in BundleContextExtension. We use the
BundleContextExtension to supply the BundleContext for the
ServiceExtension. Finally, we add support for injecting a service into
a static field.

Also some improvements to BundleContextExtension.