### PR TITLE
build: Use JUnit 5.6.0 as compile version for junit5 projects

### DIFF
--- a/org.osgi.test.assertj.framework/pom.xml
+++ b/org.osgi.test.assertj.framework/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.test.common</artifactId>
-			<version>${project.version}</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/org.osgi.test.assertj.framework/test.bndrun
+++ b/org.osgi.test.assertj.framework/test.bndrun
@@ -44,12 +44,12 @@
     begin=-1
 -runbundles: \
 	assertj-core;version='[3.17.2,3.17.3)',\
-	junit-jupiter-api;version='[5.6.2,5.6.3)',\
-	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
-	junit-jupiter-params;version='[5.6.2,5.6.3)',\
-	junit-platform-commons;version='[1.6.2,1.6.3)',\
-	junit-platform-engine;version='[1.6.2,1.6.3)',\
-	junit-platform-launcher;version='[1.6.2,1.6.3)',\
+	junit-jupiter-api;version='[5.7.0,5.7.1)',\
+	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
+	junit-jupiter-params;version='[5.7.0,5.7.1)',\
+	junit-platform-commons;version='[1.7.0,1.7.1)',\
+	junit-platform-engine;version='[1.7.0,1.7.1)',\
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	net.bytebuddy.byte-buddy;version='[1.10.13,1.10.14)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.mockito.mockito-core;version='[3.5.10,3.5.11)',\

--- a/org.osgi.test.assertj.promise/pom.xml
+++ b/org.osgi.test.assertj.promise/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.test.common</artifactId>
-			<version>${project.version}</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/org.osgi.test.assertj.promise/test.bndrun
+++ b/org.osgi.test.assertj.promise/test.bndrun
@@ -44,11 +44,11 @@
     begin=-1
 -runbundles: \
 	assertj-core;version='[3.17.2,3.17.3)',\
-	junit-jupiter-api;version='[5.6.2,5.6.3)',\
-	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
-	junit-platform-commons;version='[1.6.2,1.6.3)',\
-	junit-platform-engine;version='[1.6.2,1.6.3)',\
-	junit-platform-launcher;version='[1.6.2,1.6.3)',\
+	junit-jupiter-api;version='[5.7.0,5.7.1)',\
+	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
+	junit-platform-commons;version='[1.7.0,1.7.1)',\
+	junit-platform-engine;version='[1.7.0,1.7.1)',\
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.test.assertj.promise;version='[0.10.0,0.10.1)',\
 	org.osgi.test.assertj.promise-tests;version='[0.10.0,0.10.1)',\

--- a/org.osgi.test.common/test.bndrun
+++ b/org.osgi.test.common/test.bndrun
@@ -44,12 +44,12 @@
     begin=-1
 -runbundles: \
 	assertj-core;version='[3.17.2,3.17.3)',\
-	junit-jupiter-api;version='[5.6.2,5.6.3)',\
-	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
-	junit-jupiter-params;version='[5.6.2,5.6.3)',\
-	junit-platform-commons;version='[1.6.2,1.6.3)',\
-	junit-platform-engine;version='[1.6.2,1.6.3)',\
-	junit-platform-launcher;version='[1.6.2,1.6.3)',\
+	junit-jupiter-api;version='[5.7.0,5.7.1)',\
+	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
+	junit-jupiter-params;version='[5.7.0,5.7.1)',\
+	junit-platform-commons;version='[1.7.0,1.7.1)',\
+	junit-platform-engine;version='[1.7.0,1.7.1)',\
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	net.bytebuddy.byte-buddy;version='[1.10.13,1.10.14)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.mockito.mockito-core;version='[3.5.10,3.5.11)',\

--- a/org.osgi.test.junit4/pom.xml
+++ b/org.osgi.test.junit4/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.test.common</artifactId>
-			<version>${project.version}</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.servicemix.bundles</groupId>

--- a/org.osgi.test.junit5.cm/pom.xml
+++ b/org.osgi.test.junit5.cm/pom.xml
@@ -40,22 +40,25 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.test.common</artifactId>
-			<version>${project.version}</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<scope>compile</scope>
+			<version>${junit-jupiter.compile.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-commons</artifactId>
-			<scope>compile</scope>
+			<version>${junit-platform.compile.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<scope>compile</scope>
+			<version>${junit-jupiter.compile.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/org.osgi.test.junit5.cm/test.bndrun
+++ b/org.osgi.test.junit5.cm/test.bndrun
@@ -43,11 +43,11 @@
     begin=-1
 -runbundles: \
 	assertj-core;version='[3.17.2,3.17.3)',\
-	junit-jupiter-api;version='[5.6.2,5.6.3)',\
-	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
-	junit-platform-commons;version='[1.6.2,1.6.3)',\
-	junit-platform-engine;version='[1.6.2,1.6.3)',\
-	junit-platform-launcher;version='[1.6.2,1.6.3)',\
+	junit-jupiter-api;version='[5.7.0,5.7.1)',\
+	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
+	junit-platform-commons;version='[1.7.0,1.7.1)',\
+	junit-platform-engine;version='[1.7.0,1.7.1)',\
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.apache.felix.configadmin;version='[1.9.18,1.9.19)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.test.assertj.framework;version='[0.10.0,0.10.1)',\

--- a/org.osgi.test.junit5/pom.xml
+++ b/org.osgi.test.junit5/pom.xml
@@ -40,22 +40,25 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.test.common</artifactId>
-			<version>${project.version}</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<scope>compile</scope>
+			<version>${junit-jupiter.compile.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-commons</artifactId>
-			<scope>compile</scope>
+			<version>${junit-platform.compile.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<scope>compile</scope>
+			<version>${junit-jupiter.compile.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/org.osgi.test.junit5/test.bndrun
+++ b/org.osgi.test.junit5/test.bndrun
@@ -44,13 +44,13 @@
     begin=-1
 -runbundles: \
 	assertj-core;version='[3.17.2,3.17.3)',\
-	junit-jupiter-api;version='[5.6.2,5.6.3)',\
-	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
-	junit-jupiter-params;version='[5.6.2,5.6.3)',\
-	junit-platform-commons;version='[1.6.2,1.6.3)',\
-	junit-platform-engine;version='[1.6.2,1.6.3)',\
-	junit-platform-launcher;version='[1.6.2,1.6.3)',\
-	junit-platform-testkit;version='[1.6.2,1.6.3)',\
+	junit-jupiter-api;version='[5.7.0,5.7.1)',\
+	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
+	junit-jupiter-params;version='[5.7.0,5.7.1)',\
+	junit-platform-commons;version='[1.7.0,1.7.1)',\
+	junit-platform-engine;version='[1.7.0,1.7.1)',\
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	junit-platform-testkit;version='[1.7.0,1.7.1)',\
 	net.bytebuddy.byte-buddy;version='[1.10.13,1.10.14)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.mockito.mockito-core;version='[3.5.10,3.5.11)',\

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,10 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<bnd.version>5.1.2</bnd.version>
-		<junit-jupiter.version>5.6.2</junit-jupiter.version>
-		<junit-platform.version>1.6.2</junit-platform.version>
+		<junit-jupiter.compile.version>5.6.0</junit-jupiter.compile.version>
+		<junit-platform.compile.version>1.6.0</junit-platform.compile.version>
+		<junit-jupiter.version>5.7.0</junit-jupiter.version>
+		<junit-platform.version>1.7.0</junit-platform.version>
 		<assertj.version>3.17.2</assertj.version>
 	</properties>
 
@@ -114,6 +116,7 @@
 					<executions>
 						<execution>
 							<id>bnd-process</id>
+							<phase>process-classes</phase>
 							<goals>
 								<goal>bnd-process</goal>
 							</goals>
@@ -664,6 +667,9 @@
 	<profiles>
 		<profile>
 			<id>bnd-next</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
 			<properties>
 				<bnd.version>5.2.0-SNAPSHOT</bnd.version>
 			</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 
 	<properties>
 		<revision>0.10.0-SNAPSHOT</revision>
+		<project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
We also test build against the latest JUnit using a profile.

