### PR TITLE
[assertj] Change to use failure() rather than failWithMessage()

### DIFF
--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/AbstractBundleAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/AbstractBundleAssert.java
@@ -48,7 +48,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		isNotNull();
 		if ((actual.adapt(BundleRevision.class)
 			.getTypes() & BundleRevision.TYPE_FRAGMENT) == 0) {
-			failWithMessage("%nExpecting%n  <%s>%nto be a fragment, but it was not", actual);
+			throw failure("%nExpecting%n  <%s>%nto be a fragment, but it was not", actual);
 		}
 		return myself;
 	}
@@ -59,7 +59,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 			.getTypes() & BundleRevision.TYPE_FRAGMENT) != 0) {
 			String host = actual.getHeaders()
 				.get("Fragment-Host");
-			failWithMessage("%nExpecting%n  <%s>%nto not be a fragment, but it was, with host:%n  <%s>", actual, host);
+			throw failure("%nExpecting%n  <%s>%nto not be a fragment, but it was, with host:%n  <%s>", actual, host);
 		}
 		return myself;
 	}
@@ -67,7 +67,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasPermission(Object permission) {
 		isNotNull();
 		if (!actual.hasPermission(permission)) {
-			failWithMessage("%nExpecting%n  <%s>%nto have permission%n  <%s>%nbut it did not", actual, permission);
+			throw failure("%nExpecting%n  <%s>%nto have permission%n  <%s>%nbut it did not", actual, permission);
 		}
 		return myself;
 	}
@@ -75,7 +75,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF doesNotHavePermission(Object permission) {
 		isNotNull();
 		if (actual.hasPermission(permission)) {
-			failWithMessage("%nExpecting%n  <%s>%nnot to have permission%n  <%s>%nbut it did", actual, permission);
+			throw failure("%nExpecting%n  <%s>%nnot to have permission%n  <%s>%nbut it did", actual, permission);
 		}
 		return myself;
 	}
@@ -83,7 +83,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasSymbolicName(String expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getSymbolicName(), expected)) {
-			failWithActualExpectedAndMessage(actual.getSymbolicName(), expected,
+			throw failureWithActualExpected(actual.getSymbolicName(), expected,
 				"%nExpecting%n  <%s>%nto have symbolic name:%n  <%s>%n but was:%n  <%s>", actual, expected,
 				actual.getSymbolicName());
 		}
@@ -98,7 +98,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasLocation(String expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getLocation(), expected)) {
-			failWithActualExpectedAndMessage(actual.getLocation(), expected,
+			throw failureWithActualExpected(actual.getLocation(), expected,
 				"%nExpecting%n  <%s>%nto have location:%n  <%s>%n but was:%n  <%s>", actual, expected,
 				actual.getLocation());
 		}
@@ -113,7 +113,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasEntry(String entry) {
 		isNotNull();
 		if (actual.getEntry(entry) == null) {
-			failWithMessage("%nExpecting%n <%s>%nto have entry:%n <%s>%n but it did not", actual, entry);
+			throw failure("%nExpecting%n <%s>%nto have entry:%n <%s>%n but it did not", actual, entry);
 		}
 		return myself;
 	}
@@ -122,7 +122,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		isNotNull();
 		URL url = actual.getEntry(resource);
 		if (url != null) {
-			failWithMessage("%nExpecting%n  <%s>%nto not have entry:%n  <%s>%n but it did:%n  <%s>", actual, resource,
+			throw failure("%nExpecting%n  <%s>%nto not have entry:%n  <%s>%n but it did:%n  <%s>", actual, resource,
 				url);
 		}
 		return myself;
@@ -131,7 +131,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasResource(String resource) {
 		isNotNull();
 		if (actual.getResource(resource) == null) {
-			failWithMessage("%nExpecting%n  <%s>%nto have resource:%n  <%s>%n but it did not", actual, resource);
+			throw failure("%nExpecting%n  <%s>%nto have resource:%n  <%s>%n but it did not", actual, resource);
 		}
 		return myself;
 	}
@@ -140,7 +140,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		isNotNull();
 		URL url = actual.getResource(resource);
 		if (url != null) {
-			failWithMessage("%nExpecting%n  <%s>%nto not have resource:%n  <%s>%n but it did:%n  <%s>", actual,
+			throw failure("%nExpecting%n  <%s>%nto not have resource:%n  <%s>%n but it did:%n  <%s>", actual,
 				resource, url);
 		}
 		return myself;
@@ -149,7 +149,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 	public SELF hasBundleId(long expected) {
 		isNotNull();
 		if (actual.getBundleId() != expected) {
-			failWithActualExpectedAndMessage(actual.getBundleId(), expected,
+			throw failureWithActualExpected(actual.getBundleId(), expected,
 				"%nExpecting%n  <%s>%nto have bundle ID:%n  <%d>%n but was:%n  <%d>", actual, expected,
 				actual.getBundleId());
 		}
@@ -179,7 +179,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		isNotNull();
 		Version expectedVersion = getVersion(expected);
 		if (!Objects.equals(actual.getVersion(), expectedVersion)) {
-			failWithActualExpectedAndMessage(actual.getVersion(), expected,
+			throw failureWithActualExpected(actual.getVersion(), expected,
 				"%nExpecting%n  <%s>%nto have version:%n  <%s>%n but was:%n  <%s>", actual, expected,
 				actual.getVersion());
 		}
@@ -190,7 +190,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		isNotNull();
 		long expectedTime = getTime(expected);
 		if (actual.getLastModified() != expectedTime) {
-			failWithMessage("%nExpecting%n <%s>%nto have last modified time:%n  <%d>%n but it was:%n  <%d>", actual,
+			throw failure("%nExpecting%n <%s>%nto have last modified time:%n  <%d>%n but it was:%n  <%d>", actual,
 				expectedTime, actual.getLastModified());
 		}
 		return myself;
@@ -231,7 +231,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		}
 		final String expectedString = BITMAP.toString(expected);
 		if ((actual.getState() & expected) == 0) {
-			failWithMessage("%nExpecting%n  <%s>%nto be in state:%n  <%d:%s>%n but was in state:%n  <%s>", actual,
+			throw failure("%nExpecting%n  <%s>%nto be in state:%n  <%d:%s>%n but was in state:%n  <%s>", actual,
 				expected, expectedString, BITMAP.maskToString(actual.getState()));
 		}
 		return myself;
@@ -241,7 +241,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		isNotNull();
 		final String expectedState = BITMAP.toString(expected);
 		if ((actual.getState() & expected) != 0) {
-			failWithMessage("%nExpecting%n  <%s>%nnot to be in state:%n  <%d:%s>%n but it was", actual, expected,
+			throw failure("%nExpecting%n  <%s>%nnot to be in state:%n  <%d:%s>%n but it was", actual, expected,
 				expectedState);
 		}
 		return myself;
@@ -254,7 +254,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		}
 		if ((actual.getState() & mask) == 0) {
 			final String states = BITMAP.maskToString(mask);
-			failWithMessage("%nExpecting%n  <%s>%nto be in one of states:%n  [%s]%n but was in state:%n  <%s>", actual,
+			throw failure("%nExpecting%n  <%s>%nto be in one of states:%n  [%s]%n but was in state:%n  <%s>", actual,
 				states, BITMAP.maskToString(actual.getState()));
 		}
 		return myself;
@@ -267,7 +267,7 @@ public abstract class AbstractBundleAssert<SELF extends AbstractBundleAssert<SEL
 		}
 		if ((actual.getState() & mask) != 0) {
 			final String states = BITMAP.maskToString(mask);
-			failWithMessage("%nExpecting%n  <%s>%nto not be in one of states:%n  [%s]%n but was in state:%n  <%s>",
+			throw failure("%nExpecting%n  <%s>%nto not be in one of states:%n  [%s]%n but was in state:%n  <%s>",
 				actual, states, BITMAP.maskToString(actual.getState()));
 		}
 		return myself;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundlecontext/AbstractBundleContextAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundlecontext/AbstractBundleContextAssert.java
@@ -41,7 +41,7 @@ public abstract class AbstractBundleContextAssert<SELF extends AbstractBundleCon
 	public SELF hasProperty(String key) {
 		isNotNull();
 		if (actual.getProperty(key) == null) {
-			failWithMessage("%nExpecting%n <%s>%nto have property:%n <%s>%n but it did not", actual, key);
+			throw failure("%nExpecting%n <%s>%nto have property:%n <%s>%n but it did not", actual, key);
 		}
 		return myself;
 	}
@@ -56,7 +56,7 @@ public abstract class AbstractBundleContextAssert<SELF extends AbstractBundleCon
 		isNotNull();
 		String value = actual.getProperty(key);
 		if (value != null) {
-			failWithMessage("%nExpecting%n  <%s>%nto not have property:%n  <%s>%n but it did:%n  <%s>", actual, key,
+			throw failure("%nExpecting%n  <%s>%nto not have property:%n  <%s>%n but it did:%n  <%s>", actual, key,
 				value);
 		}
 		return myself;
@@ -65,7 +65,7 @@ public abstract class AbstractBundleContextAssert<SELF extends AbstractBundleCon
 	public SELF hasBundleWithId(long id) {
 		isNotNull();
 		if (actual.getBundle(id) == null) {
-			failWithMessage("%nExpecting%n <%s>%nto have bundle with id:%n <%d>%n but it did not", actual, id);
+			throw failure("%nExpecting%n <%s>%nto have bundle with id:%n <%d>%n but it did not", actual, id);
 		}
 		return myself;
 	}
@@ -79,7 +79,7 @@ public abstract class AbstractBundleContextAssert<SELF extends AbstractBundleCon
 		isNotNull();
 		Bundle value = actual.getBundle(id);
 		if (value != null) {
-			failWithMessage("%nExpecting%n  <%s>%nto not have bundle with id:%n  <%d>%n but it did:%n  <%s>", actual,
+			throw failure("%nExpecting%n  <%s>%nto not have bundle with id:%n  <%d>%n but it did:%n  <%s>", actual,
 				id, value);
 		}
 		return myself;
@@ -88,7 +88,7 @@ public abstract class AbstractBundleContextAssert<SELF extends AbstractBundleCon
 	public SELF hasBundleWithLocation(String location) {
 		isNotNull();
 		if (actual.getBundle(location) == null) {
-			failWithMessage("%nExpecting%n <%s>%nto have bundle with location:%n <%s>%n but it did not", actual,
+			throw failure("%nExpecting%n <%s>%nto have bundle with location:%n <%s>%n but it did not", actual,
 				location);
 		}
 		return myself;
@@ -103,7 +103,7 @@ public abstract class AbstractBundleContextAssert<SELF extends AbstractBundleCon
 		isNotNull();
 		Bundle value = actual.getBundle(location);
 		if (value != null) {
-			failWithMessage("%nExpecting%n  <%s>%nto not have bundle with location:%n  <%s>%n but it did:%n  <%s>",
+			throw failure("%nExpecting%n  <%s>%nto not have bundle with location:%n  <%s>%n but it did:%n  <%s>",
 				actual, location, value);
 		}
 		return myself;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/AbstractBundleEventAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/AbstractBundleEventAssert.java
@@ -37,7 +37,7 @@ public abstract class AbstractBundleEventAssert<SELF extends AbstractBundleEvent
 	public SELF hasBundle(Bundle expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getBundle(), expected)) {
-			failWithActualExpectedAndMessage(actual.getBundle(), expected,
+			throw this.failureWithActualExpected(actual.getBundle(), expected,
 				"%nExpecting%n <%s>%nto have bundle source:%n <%s>%n but was:%n<%s>", actual, expected,
 				actual.getBundle());
 		}
@@ -52,7 +52,7 @@ public abstract class AbstractBundleEventAssert<SELF extends AbstractBundleEvent
 	public SELF hasOrigin(Bundle expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getOrigin(), expected)) {
-			failWithActualExpectedAndMessage(actual.getOrigin(), expected,
+			throw failureWithActualExpected(actual.getOrigin(), expected,
 				"%nExpecting%n <%s>%nto have originating bundle:%n <%s>%n but was:%n<%s>", actual, expected,
 				actual.getOrigin());
 		}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundlereference/AbstractBundleReferenceAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundlereference/AbstractBundleReferenceAssert.java
@@ -35,7 +35,7 @@ public abstract class AbstractBundleReferenceAssert<SELF extends AbstractBundleR
 	public SELF refersToBundle(Bundle expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getBundle(), expected)) {
-			failWithActualExpectedAndMessage(actual.getBundle(), expected,
+			throw failureWithActualExpected(actual.getBundle(), expected,
 				"%nExpecting%n <%s>%nto have bundle source:%n <%s>%n but was:%n<%s>", actual, expected,
 				actual.getBundle());
 		}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/event/AbstractBitmappedTypeEventAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/event/AbstractBitmappedTypeEventAssert.java
@@ -45,7 +45,7 @@ public abstract class AbstractBitmappedTypeEventAssert<SELF extends AbstractBitm
 				"Multiple bits set in expected (" + expected + ") - do you mean to use isOfTypeMaskedBy()?");
 		}
 		if ((actualType() & expected) == 0) {
-			failWithMessage("%nExpecting%n <%s>%nto be of type:%n <%d:%s>%n but was of type:%n <%s>", actual, expected,
+			throw failure("%nExpecting%n <%s>%nto be of type:%n <%d:%s>%n but was of type:%n <%s>", actual, expected,
 				bitmap.toString(expected), bitmap.maskToString(actualType()));
 		}
 		return myself;
@@ -54,7 +54,7 @@ public abstract class AbstractBitmappedTypeEventAssert<SELF extends AbstractBitm
 	public SELF isNotOfType(int expected) {
 		isNotNull();
 		if ((actualType() & expected) != 0) {
-			failWithMessage("%nExpecting%n <%s>%nnot to be of type:%n <%d:%s>%nbut it was", actual,
+			throw failure("%nExpecting%n <%s>%nnot to be of type:%n <%d:%s>%nbut it was", actual,
 				expected,
 				bitmap.toString(expected));
 		}
@@ -67,7 +67,7 @@ public abstract class AbstractBitmappedTypeEventAssert<SELF extends AbstractBitm
 			throw new IllegalArgumentException("Mask testing for an illegal type: " + mask);
 		}
 		if ((actualType() & mask) == 0) {
-			failWithMessage("%nExpecting%n <%s>%nto be of one of types:%n [%s]%n but was of type:%n <%s>",
+			throw failure("%nExpecting%n <%s>%nto be of one of types:%n [%s]%n but was of type:%n <%s>",
 				actual,
 				bitmap.maskToString(mask), bitmap.maskToString(actualType()));
 		}
@@ -80,7 +80,7 @@ public abstract class AbstractBitmappedTypeEventAssert<SELF extends AbstractBitm
 			throw new IllegalArgumentException("Mask testing for an illegal type: " + mask);
 		}
 		if ((actualType() & mask) != 0) {
-			failWithMessage("%nExpecting%n <%s>%nto not be of one of types:%n [%s]%n but was of type:%n <%s>",
+			throw failure("%nExpecting%n <%s>%nto not be of one of types:%n [%s]%n but was of type:%n <%s>",
 				actual,
 				bitmap.maskToString(mask), bitmap.maskToString(actualType()));
 		}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/AbstractFrameworkEventAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/AbstractFrameworkEventAssert.java
@@ -34,7 +34,7 @@ public abstract class AbstractFrameworkEventAssert<SELF extends AbstractFramewor
 	public SELF hasBundle(Bundle expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getBundle(), expected)) {
-			failWithActualExpectedAndMessage(actual
+			throw failureWithActualExpected(actual
 				.getBundle(),
 				expected,
 				"%nExpecting%n <%s>%nto have bundle source:%n <%s>%n but was:%n<%s>", actual, expected,
@@ -46,7 +46,7 @@ public abstract class AbstractFrameworkEventAssert<SELF extends AbstractFramewor
 	public SELF hasThrowable(Throwable expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getThrowable(), expected)) {
-			failWithActualExpectedAndMessage(actual.getThrowable(), expected,
+			throw failureWithActualExpected(actual.getThrowable(), expected,
 				"%nExpecting%n <%s>%nto have throwable:%n <%s>%n but was:%n<%s>", actual, expected,
 				actual.getThrowable());
 		}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/AbstractServiceEventAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/AbstractServiceEventAssert.java
@@ -33,7 +33,7 @@ public abstract class AbstractServiceEventAssert<SELF extends AbstractServiceEve
 	public SELF hasServiceReference(ServiceReference<?> expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getServiceReference(), expected)) {
-			failWithActualExpectedAndMessage(actual.getServiceReference(),
+			throw failureWithActualExpected(actual.getServiceReference(),
 				expected,
 				"%nExpecting%n <%s>%nto have service reference:%n <%s>%n but was:%n<%s>", actual, expected,
 				actual.getServiceReference());

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/version/AbstractVersionAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/version/AbstractVersionAssert.java
@@ -43,7 +43,7 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		isNotNull();
 		int a = actual.getMajor();
 		if (expected != a) {
-			failWithActualExpectedAndMessage(a, expected,
+			throw failureWithActualExpected(a, expected,
 				"%nExpecting%n <%s>%nto have major version:%n  <%d>%n but it was:%n  <%d>", actual, expected, a);
 		}
 		return myself;
@@ -57,7 +57,7 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		isNotNull();
 		int a = actual.getMinor();
 		if (expected != a) {
-			failWithActualExpectedAndMessage(a, expected,
+			throw failureWithActualExpected(a, expected,
 				"%nExpecting%n <%s>%nto have minor version:%n  <%d>%n but it was:%n  <%d>", actual, expected, a);
 		}
 		return myself;
@@ -71,7 +71,7 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		isNotNull();
 		int a = actual.getMicro();
 		if (expected != a) {
-			failWithActualExpectedAndMessage(a, expected,
+			throw failureWithActualExpected(a, expected,
 				"%nExpecting%n <%s>%nto have micro version:%n <%d>%n but it was:%n <%d>", actual, expected, a);
 		}
 		return myself;
@@ -85,7 +85,7 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 		isNotNull();
 		String a = actual.getQualifier();
 		if (!Objects.equals(a, expected)) {
-			failWithActualExpectedAndMessage(a, expected,
+			throw failureWithActualExpected(a, expected,
 				"%nExpecting%n <%s>%nto have qualifier:%n <%s>%n but it was:%n <%s>", actual, expected, a);
 		}
 		return myself;
@@ -102,7 +102,7 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 	public SELF isInRange(VersionRange range) {
 		isNotNull();
 		if (!range.includes(actual)) {
-			failWithMessage("%nExpecting%n <%s>%nto be in range:%n <%s>%n but it was not", actual, range);
+			throw failure("%nExpecting%n <%s>%nto be in range:%n <%s>%n but it was not", actual, range);
 		}
 		return myself;
 	}
@@ -114,7 +114,7 @@ public class AbstractVersionAssert<SELF extends AbstractVersionAssert<SELF, ACTU
 	public SELF isNotInRange(VersionRange range) {
 		isNotNull();
 		if (range.includes(actual)) {
-			failWithMessage("%nExpecting%n <%s>%nto not be in range:%n <%s>%n but it was", actual, range);
+			throw failure("%nExpecting%n <%s>%nto not be in range:%n <%s>%n but it was", actual, range);
 		}
 		return myself;
 	}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/versionrange/AbstractVersionBoundAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/versionrange/AbstractVersionBoundAssert.java
@@ -32,7 +32,7 @@ public class AbstractVersionBoundAssert<SELF extends AbstractVersionBoundAssert<
 	public SELF isClosed() {
 		isNotNull();
 		if (isOpen) {
-			failWithMessage("%nExpecting version bound%n <%s>%nto be closed, but it was open", actual);
+			throw failure("%nExpecting version bound%n <%s>%nto be closed, but it was open", actual);
 		}
 		return myself;
 	}
@@ -40,7 +40,7 @@ public class AbstractVersionBoundAssert<SELF extends AbstractVersionBoundAssert<
 	public SELF isOpen() {
 		isNotNull();
 		if (!isOpen) {
-			failWithMessage("%nExpecting version bound%n <%s>%nto be open, but it was closed", actual);
+			throw failure("%nExpecting version bound%n <%s>%nto be open, but it was closed", actual);
 		}
 		return myself;
 	}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/versionrange/AbstractVersionRangeAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/versionrange/AbstractVersionRangeAssert.java
@@ -50,7 +50,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 		isNotNull();
 		Version a = actual.getLeft();
 		if (!Objects.equals(expected, a)) {
-			failWithActualExpectedAndMessage(a, expected,
+			throw failureWithActualExpected(a, expected,
 				"%nExpecting version range%n <%s>%nto have lower bound:%n <%s>%n but it was:%n <%s>", actual, expected,
 				a);
 		}
@@ -60,7 +60,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF isLeftOpen() {
 		isNotNull();
 		if (actual.getLeftType() != LEFT_OPEN) {
-			failWithMessage("%nExpecting version range%n <%s>%nto have open lower bound%n but it was closed", actual);
+			throw failure("%nExpecting version range%n <%s>%nto have open lower bound%n but it was closed", actual);
 		}
 		return myself;
 	}
@@ -68,7 +68,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF isLeftClosed() {
 		isNotNull();
 		if (actual.getLeftType() != LEFT_CLOSED) {
-			failWithMessage("%nExpecting version range%n <%s>%nto have closed lower bound%n but it was open", actual);
+			throw failure("%nExpecting version range%n <%s>%nto have closed lower bound%n but it was open", actual);
 		}
 		return myself;
 	}
@@ -86,7 +86,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 		isNotNull();
 		Version a = actual.getRight();
 		if (!Objects.equals(expected, a)) {
-			failWithActualExpectedAndMessage(a, expected,
+			throw failureWithActualExpected(a, expected,
 				"%nExpecting version range%n <%s>%nto have upper bound:%n <%s>%n but it was:%n <%s>", actual, expected,
 				a);
 		}
@@ -96,7 +96,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF isRightOpen() {
 		isNotNull();
 		if (actual.getRightType() != RIGHT_OPEN) {
-			failWithMessage("%nExpecting version range%n <%s>%nto have open upper bound%nbut it was closed", actual);
+			throw failure("%nExpecting version range%n <%s>%nto have open upper bound%nbut it was closed", actual);
 		}
 		return myself;
 	}
@@ -104,7 +104,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF isRightClosed() {
 		isNotNull();
 		if (actual.getRightType() != RIGHT_CLOSED) {
-			failWithMessage("%nExpecting version range%n <%s>%nto have closed upper bound%nbut it was open", actual);
+			throw failure("%nExpecting version range%n <%s>%nto have closed upper bound%nbut it was open", actual);
 		}
 		return myself;
 	}
@@ -116,7 +116,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF includes(Version version) {
 		isNotNull();
 		if (!actual.includes(version)) {
-			failWithMessage("%nExpecting version range%n <%s>%nto include version%n <%s>%nbut it does not", actual,
+			throw failure("%nExpecting version range%n <%s>%nto include version%n <%s>%nbut it does not", actual,
 				version);
 		}
 		return myself;
@@ -129,7 +129,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF doesNotInclude(Version version) {
 		isNotNull();
 		if (actual.includes(version)) {
-			failWithMessage("%nExpecting version range%n <%s>%nto not include version%n <%s>%nbut it does", actual,
+			throw failure("%nExpecting version range%n <%s>%nto not include version%n <%s>%nbut it does", actual,
 				version);
 		}
 		return myself;
@@ -138,7 +138,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF isEmpty() {
 		isNotNull();
 		if (!actual.isEmpty()) {
-			failWithMessage("%nExpecting version range%n <%s>%nto be empty%nbut it was not", actual);
+			throw failure("%nExpecting version range%n <%s>%nto be empty%nbut it was not", actual);
 		}
 		return myself;
 	}
@@ -146,7 +146,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF isNotEmpty() {
 		isNotNull();
 		if (actual.isEmpty()) {
-			failWithMessage("%nExpecting version range%n <%s>%nto be empty%nbut it was not", actual);
+			throw failure("%nExpecting version range%n <%s>%nto be empty%nbut it was not", actual);
 		}
 		return myself;
 	}
@@ -154,7 +154,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF isExact() {
 		isNotNull();
 		if (!actual.isExact()) {
-			failWithMessage("%nExpecting version range%n <%s>%nto be exact%nbut it was not", actual);
+			throw failure("%nExpecting version range%n <%s>%nto be exact%nbut it was not", actual);
 		}
 		return myself;
 	}
@@ -162,7 +162,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 	public SELF isNotExact() {
 		isNotNull();
 		if (actual.isExact()) {
-			failWithMessage("%nExpecting version range%n <%s>%nto be exact%nbut it was not", actual);
+			throw failure("%nExpecting version range%n <%s>%nto be exact%nbut it was not", actual);
 		}
 		return myself;
 	}
@@ -177,7 +177,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 		isNotNull();
 		if (actual.intersection(versions)
 			.isEmpty()) {
-			failWithMessage("%nExpecting version range%n <%s>%nto intersect all of%n <%s>%nbut it does not", actual,
+			throw failure("%nExpecting version range%n <%s>%nto intersect all of%n <%s>%nbut it does not", actual,
 				Arrays.toString(versions));
 		}
 		return myself;
@@ -194,7 +194,7 @@ public class AbstractVersionRangeAssert<SELF extends AbstractVersionRangeAssert<
 		VersionRange intersection = actual.intersection(versions);
 		if (!intersection
 			.isEmpty()) {
-			failWithMessage(
+			throw failure(
 				"%nExpecting version range%n <%s>%nto not intersect any of%n <%s>%nbut it has intersection%n <%s>",
 				actual, Arrays.toString(versions), intersection);
 		}

--- a/org.osgi.test.assertj.promise/src/main/java/org/osgi/test/assertj/promise/AbstractPromiseAssert.java
+++ b/org.osgi.test.assertj.promise/src/main/java/org/osgi/test/assertj/promise/AbstractPromiseAssert.java
@@ -47,7 +47,7 @@ public abstract class AbstractPromiseAssert<SELF extends AbstractPromiseAssert<S
 
 	void assertDone() {
 		if (!actual.isDone()) {
-			failWithMessage("%nExpecting%n  <%s>%nto be done.", actual);
+			throw failure("%nExpecting%n  <%s>%nto be done.", actual);
 		}
 	}
 
@@ -65,7 +65,7 @@ public abstract class AbstractPromiseAssert<SELF extends AbstractPromiseAssert<S
 
 	void assertNotDone() {
 		if (actual.isDone()) {
-			failWithMessage("%nExpecting%n  <%s>%nto not be done.", actual);
+			throw failure("%nExpecting%n  <%s>%nto not be done.", actual);
 		}
 	}
 
@@ -98,7 +98,7 @@ public abstract class AbstractPromiseAssert<SELF extends AbstractPromiseAssert<S
 			actual.onResolve(latch::countDown);
 			try {
 				if (!latch.await(timeout, unit)) {
-					failWithMessage("%nExpecting%n  <%s>%nto have resolved.", actual);
+					throw failure("%nExpecting%n  <%s>%nto have resolved.", actual);
 				}
 			} catch (InterruptedException e) {
 				Thread.currentThread()
@@ -139,7 +139,7 @@ public abstract class AbstractPromiseAssert<SELF extends AbstractPromiseAssert<S
 		actual.onResolve(latch::countDown);
 		try {
 			if (latch.await(timeout, unit)) {
-				failWithMessage("%nExpecting%n  <%s>%nto not have resolved.", actual);
+				throw failure("%nExpecting%n  <%s>%nto not have resolved.", actual);
 			}
 		} catch (InterruptedException e) {
 			Thread.currentThread()
@@ -177,7 +177,7 @@ public abstract class AbstractPromiseAssert<SELF extends AbstractPromiseAssert<S
 	void assertFailed() {
 		Throwable fail = getFailure(actual);
 		if (fail == null) {
-			failWithMessage("%nExpecting%n  <%s>%nto have failed.", actual);
+			throw failure("%nExpecting%n  <%s>%nto have failed.", actual);
 		}
 	}
 
@@ -210,7 +210,7 @@ public abstract class AbstractPromiseAssert<SELF extends AbstractPromiseAssert<S
 		if (actual.isDone()) {
 			Throwable fail = getFailure(actual);
 			if (fail != null) {
-				failWithMessage("%nExpecting%n  <%s>%nto have not failed but failed with:%n%s", actual,
+				throw failure("%nExpecting%n  <%s>%nto have not failed but failed with:%n%s", actual,
 					Exceptions.toString(fail));
 			}
 		}
@@ -244,14 +244,12 @@ public abstract class AbstractPromiseAssert<SELF extends AbstractPromiseAssert<S
 		try {
 			return promise.getValue();
 		} catch (InvocationTargetException e) {
-			failWithMessage("%nExpecting%n  <%s>%nto have not failed but failed with %s", promise,
+			throw failure("%nExpecting%n  <%s>%nto have not failed but failed with %s", promise,
 				Exceptions.toString(e.getCause()));
-			return null;
 		} catch (InterruptedException e) {
 			Thread.currentThread()
 				.interrupt();
-			fail("unexpected exception", e);
-			return null;
+			throw new AssertionError("unexpected exception", e);
 		}
 	}
 


### PR DESCRIPTION
Helps improve reported code coverage metrics and also helps the compiler to know certain code blocks are unreachable.