### PR TITLE
proxy: Use our class loader to create the proxy objects

### DIFF
--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/context/CloseableBundleContextTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/context/CloseableBundleContextTest.java
@@ -27,7 +27,7 @@ public class CloseableBundleContextTest extends SoftAssertions {
 	@BeforeEach
 	void beforeEach() {
 		upstream = mock(BundleContext.class);
-		sut = CloseableBundleContext.proxy(CloseableBundleContextTest.class, upstream);
+		sut = CloseableBundleContext.proxy(upstream);
 	}
 
 	@ParameterizedTest

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/context/BundleContextRule.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/context/BundleContextRule.java
@@ -69,10 +69,8 @@ public class BundleContextRule implements AutoCloseable, MethodRule {
 			return this;
 		}
 
-		BundleContext bundleContext = CloseableBundleContext.proxy(testInstance
-			.getClass(),
-			FrameworkUtil.getBundle(testInstance.getClass())
-				.getBundleContext());
+		BundleContext bundleContext = CloseableBundleContext.proxy(FrameworkUtil.getBundle(testInstance.getClass())
+			.getBundleContext());
 
 		installBundle = new InstallBundle(bundleContext);
 

--- a/org.osgi.test.junit4/src/test/java/org/osgi/test/junit4/context/BundleContextRuleTest.java
+++ b/org.osgi.test.junit4/src/test/java/org/osgi/test/junit4/context/BundleContextRuleTest.java
@@ -230,7 +230,7 @@ public class BundleContextRuleTest {
 	public void closeableBundleContext_handlesSelectedMethodsOfObject() throws Exception {
 		BundleContext upstream = FrameworkUtil.getBundle(getClass())
 			.getBundleContext();
-		BundleContext closeableBC = CloseableBundleContext.proxy(getClass(), upstream);
+		BundleContext closeableBC = CloseableBundleContext.proxy(upstream);
 
 		closeableBC.toString();
 		assertThat(closeableBC).as("toString")

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
@@ -162,8 +162,7 @@ public class BundleContextExtension implements BeforeAllCallback, BeforeEachCall
 	public static BundleContext getBundleContext(ExtensionContext extensionContext) {
 		BundleContext bundleContext = getStore(extensionContext)
 			.getOrComputeIfAbsent(BUNDLE_CONTEXT_KEY,
-				key -> new CloseableResourceBundleContext(extensionContext.getRequiredTestClass(),
-					getParentBundleContext(extensionContext)),
+				key -> new CloseableResourceBundleContext(getParentBundleContext(extensionContext)),
 				CloseableResourceBundleContext.class)
 			.get();
 		return bundleContext;
@@ -188,8 +187,8 @@ public class BundleContextExtension implements BeforeAllCallback, BeforeEachCall
 
 		private final BundleContext bundleContext;
 
-		CloseableResourceBundleContext(Class<?> testClass, BundleContext bundleContext) {
-			this.bundleContext = CloseableBundleContext.proxy(testClass, bundleContext);
+		CloseableResourceBundleContext(BundleContext bundleContext) {
+			this.bundleContext = CloseableBundleContext.proxy(bundleContext);
 		}
 
 		@Override

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AbstractServiceExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AbstractServiceExtensionTest.java
@@ -83,7 +83,8 @@ abstract class AbstractServiceExtensionTest {
 			.get()
 			.getName();
 
-		bundleContext = CloseableBundleContext.proxy(ServiceExtensionTest.class);
+		bundleContext = CloseableBundleContext.proxy(FrameworkUtil.getBundle(ServiceExtensionTest.class)
+			.getBundleContext());
 	}
 
 	@AfterEach


### PR DESCRIPTION
We already have class loader access to all the necessary framework types
while the test bundle may not itself have access because it does not
need access.

This simplifies the API a bit, so we refactor to avoid the need to pass
a Class object into the proxy methods.

Fixes https://github.com/osgi/osgi-test/issues/229