### PR TITLE
[junit5] Servicefilter respect WildcardType

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/InjectService.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/InjectService.java
@@ -88,4 +88,17 @@ public @interface InjectService {
 	 */
 	long timeout() default DEFAULT_TIMEOUT;
 
+	/**
+	 * Indicate to take the serviceClass from not from the parameter. Use
+	 * `org.osgi.test.common.annotation.InjectService.AnyService` and the
+	 * ParameterType or FieldType`java.lang.Object` for any Service.
+	 *
+	 * @return The service class.
+	 */
+	Class<?> service() default Object.class;
+
+	public static final class AnyService {
+		private AnyService() {}
+	}
+
 }

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/service/ServiceConfiguration.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/service/ServiceConfiguration.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
+import org.osgi.test.common.annotation.InjectService.AnyService;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
@@ -51,10 +52,17 @@ public class ServiceConfiguration<S> implements AutoCloseable, ServiceAware<S> {
 	public ServiceConfiguration(Class<S> serviceType, String format, String[] args, int cardinality, long timeout) {
 		this.serviceType = requireNonNull(serviceType);
 
-		Filter filter = format("(objectClass=%s)", serviceType.getName());
+		Filter filter = null;
 		format = String.format(requireNonNull(format), (Object[]) requireNonNull(args));
 		if (!format.isEmpty()) {
-			filter = format("(&%s%s)", filter.toString(), format);
+
+			if (AnyService.class.equals(serviceType)) {
+				filter = format(format);
+			} else {
+				filter = format("(&(objectClass=%s)%s)", serviceType.getName(), format);
+			}
+		} else {
+			filter = format("(objectClass=%s)", serviceType.getName());
 		}
 		this.filter = filter;
 

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceExtension.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.List;
 import java.util.Optional;
 
@@ -131,7 +132,7 @@ public class ServiceExtension implements BeforeAllCallback, BeforeEachCallback, 
 			serviceType = ((ParameterizedType) genericMemberType).getActualTypeArguments()[0];
 		}
 		// The service type must be a raw type
-		if (serviceType instanceof Class) {
+		if (serviceType instanceof Class || serviceType instanceof WildcardType) {
 			return true;
 		}
 		throw new ParameterResolutionException("Can only resolve @" + InjectService.class.getSimpleName()
@@ -171,7 +172,16 @@ public class ServiceExtension implements BeforeAllCallback, BeforeEachCallback, 
 
 		// supportsParameter() If Jupiter does the right thing then this method
 		// should not be called without serviceType being a class
-		assert serviceType instanceof Class;
+		assert serviceType instanceof Class || serviceType instanceof WildcardType;
+
+		if (serviceType instanceof WildcardType) {
+			serviceType = Object.class;
+
+		}
+		if (!injectService.service()
+			.equals(Object.class)) {
+			serviceType = injectService.service();
+		}
 
 		ServiceConfiguration<?> configuration = getServiceConfiguration((Class<?>) serviceType, injectService.filter(),
 			injectService.filterArguments(), injectService.cardinality(), injectService.timeout(), extensionContext);

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AnyServiceTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AnyServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.junit5.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.BundleContext;
+import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.annotation.InjectService.AnyService;
+import org.osgi.test.common.dictionary.Dictionaries;
+import org.osgi.test.common.service.ServiceAware;
+import org.osgi.test.junit5.context.BundleContextExtension;
+import org.osgi.test.junit5.types.Foo;
+
+@ExtendWith(BundleContextExtension.class)
+@ExtendWith(ServiceExtension.class)
+public class AnyServiceTest {
+
+	@BeforeAll
+	public static void beforeAll(@InjectBundleContext BundleContext bundleContext) throws Exception {
+		bundleContext.registerService(B.class, new B() {}, Dictionaries.dictionaryOf("a", "b"));
+		bundleContext.registerService(Object.class, new Foo() {}, Dictionaries.dictionaryOf("a", "b"));
+
+	}
+
+	@InjectService(filter = "(a=b)")
+	ServiceAware<?>			field_ServiceAwareWildcard_Default;
+
+	@InjectService(filter = "(a=b)", service = AnyService.class)
+	ServiceAware<?>			field_ServiceAwareWildcard_AnyService;
+
+	@InjectService(filter = "(a=b)")
+	ServiceAware<Object>	field_ServiceAwareObject_Default;
+
+	@InjectService(filter = "(a=b)", service = AnyService.class)
+	ServiceAware<Object>	field_ServiceAwareObject_AnyService;
+
+	@Test
+	public void test_field_ServiceAwareWildcard_Default() throws Exception {
+		assertThat(field_ServiceAwareWildcard_Default.getServices()).hasSize(1)
+			.hasOnlyElementsOfTypes(Foo.class);
+	}
+
+	@Test
+	public void test_field_ServiceAwareWildcard_AnyService() throws Exception {
+		assertThat(field_ServiceAwareWildcard_AnyService.getServices()).hasSize(2)
+			.hasOnlyElementsOfTypes(B.class, Foo.class);
+	}
+
+	@Test
+	public void test_field_ServiceAwareObject_Default() throws Exception {
+		assertThat(field_ServiceAwareObject_Default.getServices()).hasSize(1)
+			.hasOnlyElementsOfTypes(Foo.class);
+	}
+
+	@Test
+	public void test_field_ServiceAwareObject_AnyService() throws Exception {
+		assertThat(field_ServiceAwareObject_AnyService.getServices()).hasSize(2)
+			.hasOnlyElementsOfTypes(B.class, Foo.class);
+	}
+
+	@Test
+	public void test_param_ServiceAwareWildcard_Default(
+		@InjectService(filter = "(a=b)") ServiceAware<?> param_ServiceAwareWildcard_Default) throws Exception {
+		assertThat(param_ServiceAwareWildcard_Default.getServices()).hasSize(1)
+			.hasOnlyElementsOfTypes(Foo.class);
+	}
+
+	public void test_param_ServiceAwareWildcard_AnyService(
+		@InjectService(filter = "(a=b)", service = AnyService.class) ServiceAware<?> param_ServiceAwareWildcard_AnyService)
+		throws Exception {
+		assertThat(param_ServiceAwareWildcard_AnyService.getServices()).hasSize(2)
+			.hasOnlyElementsOfTypes(B.class, Foo.class);
+	}
+
+	@Test
+	public void testWithServiceAwareCorrectSuperClass(
+		@InjectService(filter = "(a=b)", service = B.class) ServiceAware<A> anyServiceParameter) throws Exception {
+		assertThat(anyServiceParameter.getService()).isNotNull();
+	}
+
+	@Test
+	public void testParameterObjectWithAnyService(
+		@InjectService(filter = "(a=b)", service = AnyService.class) ServiceAware<Object> anyServiceParameter)
+		throws Exception {
+		assertThat(anyServiceParameter.getServices()).hasSize(2)
+			.hasOnlyElementsOfTypes(B.class, Foo.class);
+	}
+
+	@Test
+	public void testParameterAWithWithServiceB(
+		@InjectService(filter = "(a=b)", service = B.class) A anyServiceParameter) throws Exception {
+		assertThat(anyServiceParameter).isNotNull();
+	}
+
+	@Test
+	public void testParameterWithSameServiceClasse(
+		@InjectService(filter = "(a=b)", service = B.class) B anyServiceParameter) throws Exception {
+		assertThat(anyServiceParameter).isNotNull();
+	}
+
+	@Test
+	public void testParameterServiceBandparemObject(
+		@InjectService(filter = "(a=b)", service = B.class) Object anyServiceParameter) throws Exception {
+		assertThat(anyServiceParameter).isNotNull();
+	}
+
+	interface A {
+
+	}
+
+	interface B extends A {
+
+	}
+}


### PR DESCRIPTION
We should provide a Way to generate an objectClass servicefilter with a wildcard `(objectClass=java.lang.Object)` when using `@InjectService`

Examples that should work:

`@InjectService(filter = "(a=b)") ServiceAware<?> anyServiceParameter`

`@InjectService(filter = "(a=b)", anyObjectClass = true) Object anyServiceParameter`