### PR TITLE
Observe Service-, Framework- and BundleEvents

### DIFF
--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/event/AbstractBitmappedTypeEventAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/event/AbstractBitmappedTypeEventAssert.java
@@ -54,8 +54,7 @@ public abstract class AbstractBitmappedTypeEventAssert<SELF extends AbstractBitm
 	public SELF isNotOfType(int expected) {
 		isNotNull();
 		if ((actualType() & expected) != 0) {
-			throw failure("%nExpecting%n <%s>%nnot to be of type:%n <%d:%s>%nbut it was", actual,
-				expected,
+			throw failure("%nExpecting%n <%s>%nnot to be of type:%n <%d:%s>%nbut it was", actual, expected,
 				bitmap.toString(expected));
 		}
 		return myself;
@@ -67,8 +66,7 @@ public abstract class AbstractBitmappedTypeEventAssert<SELF extends AbstractBitm
 			throw new IllegalArgumentException("Mask testing for an illegal type: " + mask);
 		}
 		if ((actualType() & mask) == 0) {
-			throw failure("%nExpecting%n <%s>%nto be of one of types:%n [%s]%n but was of type:%n <%s>",
-				actual,
+			throw failure("%nExpecting%n <%s>%nto be of one of types:%n [%s]%n but was of type:%n <%s>", actual,
 				bitmap.maskToString(mask), bitmap.maskToString(actualType()));
 		}
 		return myself;
@@ -80,8 +78,7 @@ public abstract class AbstractBitmappedTypeEventAssert<SELF extends AbstractBitm
 			throw new IllegalArgumentException("Mask testing for an illegal type: " + mask);
 		}
 		if ((actualType() & mask) != 0) {
-			throw failure("%nExpecting%n <%s>%nto not be of one of types:%n [%s]%n but was of type:%n <%s>",
-				actual,
+			throw failure("%nExpecting%n <%s>%nto not be of one of types:%n [%s]%n but was of type:%n <%s>", actual,
 				bitmap.maskToString(mask), bitmap.maskToString(actualType()));
 		}
 		return myself;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/event/AbstractEventRecordingAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/event/AbstractEventRecordingAssert.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.assertj.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.ClassBasedNavigableListAssert;
+import org.assertj.core.api.ListAssert;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.test.assertj.bundleevent.BundleEventAssert;
+import org.osgi.test.assertj.frameworkevent.FrameworkEventAssert;
+import org.osgi.test.assertj.serviceevent.ServiceEventAssert;
+import org.osgi.test.common.event.EventRecording;
+import org.osgi.test.common.event.EventRecording.TimedEvent;
+
+public abstract class AbstractEventRecordingAssert<SELF extends AbstractEventRecordingAssert<SELF, ACTUAL>, ACTUAL extends EventRecording>
+	extends AbstractAssert<SELF, ACTUAL> {
+
+	protected AbstractEventRecordingAssert(ACTUAL actual, Class<SELF> selfType) {
+		super(actual, selfType);
+	}
+
+	public SELF isTimedOut() {
+		isNotNull();
+		if (!actual.isTimedOut()) {
+			throw failure("%nExpecting%n  <%s>%nto be a timedOut, but it was not", actual);
+		}
+		return myself;
+	}
+
+	public SELF isNotTimedOut() {
+		isNotNull();
+		if (actual.isTimedOut()) {
+			throw failure("%nExpecting%n  <%s>%nto not be a timedOut, but it was", actual);
+		}
+		return myself;
+	}
+
+	public <T> ListAssert<T> hasEventsThat(Class<T> clazz) {
+		isNotNull();
+		List<T> list = actual.events(clazz);
+		return new ListAssert<T>(list);
+	}
+
+	public <T> ListAssert<TimedEvent<T>> hasTimedEventsThat(Class<T> clazz) {
+		isNotNull();
+		List<TimedEvent<T>> list = actual.timedEvents(clazz);
+		return new ListAssert<TimedEvent<T>>(list);
+	}
+
+	public ListAssert<?> hasEventsThat() {
+		return hasEventsThat(Object.class);
+	}
+
+	public ListAssert<TimedEvent<Object>> hasTimedEventsThat() {
+		return hasTimedEventsThat(Object.class);
+	}
+
+	public ClassBasedNavigableListAssert<?, List<? extends ServiceEvent>, ServiceEvent, ServiceEventAssert> hasServiceEventsThat() {
+		isNotNull();
+		List<ServiceEvent> list = actual.events(ServiceEvent.class);
+		return assertThat(list, ServiceEventAssert.class);
+	}
+
+	public ListAssert<TimedEvent<ServiceEvent>> hasTimedServiceEventsThat() {
+		return hasTimedEventsThat(ServiceEvent.class);
+	}
+
+	public ClassBasedNavigableListAssert<?, List<? extends FrameworkEvent>, FrameworkEvent, FrameworkEventAssert> hasFrameworkEventsThat() {
+		isNotNull();
+		List<FrameworkEvent> list = actual.events(FrameworkEvent.class);
+		return assertThat(list, FrameworkEventAssert.class);
+	}
+
+	public ListAssert<TimedEvent<FrameworkEvent>> hasTimedFrameworkEventsThat() {
+		return hasTimedEventsThat(FrameworkEvent.class);
+	}
+
+	public ClassBasedNavigableListAssert<?, List<? extends BundleEvent>, BundleEvent, BundleEventAssert> hasBundleEventsThat() {
+		isNotNull();
+		List<BundleEvent> list = actual.events(BundleEvent.class);
+		return assertThat(list, BundleEventAssert.class);
+	}
+
+	public ListAssert<TimedEvent<BundleEvent>> hasTimedBundleEventsThat() {
+		isNotNull();
+		return hasTimedEventsThat(BundleEvent.class);
+	}
+
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/event/EventRecordingAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/event/EventRecordingAssert.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.assertj.event;
+
+import java.util.function.Predicate;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.test.common.event.BundleEvents;
+import org.osgi.test.common.event.EventRecording;
+import org.osgi.test.common.event.FrameworkEvents;
+import org.osgi.test.common.event.ServiceEvents;
+
+public class EventRecordingAssert extends AbstractEventRecordingAssert<EventRecordingAssert, EventRecording> {
+
+	public EventRecordingAssert(EventRecording actual, Class<EventRecordingAssert> selfType) {
+		super(actual, selfType);
+	}
+
+	public static EventRecordingAssert assertThat(EventRecording actual) {
+		return new EventRecordingAssert(actual, EventRecordingAssert.class);
+	}
+
+	/**
+	 * @param execute - the action that will be invoked.
+	 * @param predicate - Predicate that would be tested against the
+	 *            ServiceEvents
+	 * @param timeout - the time in that the matches must happened
+	 */
+	public static EventRecordingAssert assertThatServiceEvent(Runnable execute,
+		Predicate<ServiceEvent> predicate, int timeout) throws Exception {
+		return assertThat(execute, ServiceEvents.isServiceEventAnd(predicate), timeout);
+	}
+
+	/**
+	 * @param execute - the action that will be invoked.
+	 * @param predicate - Predicate that would be tested against the
+	 *            BundleEvents
+	 * @param timeout - the time in that the matches must happened
+	 */
+	public static EventRecordingAssert assertThatBundleEvent(Runnable execute, Predicate<BundleEvent> predicate,
+		int timeout) throws Exception {
+		return assertThat(execute, BundleEvents.isBundleEventAnd(predicate), timeout);
+	}
+
+	/**
+	 * @param execute - the action that will be invoked.
+	 * @param predicate - Predicate that would be tested against the
+	 *            FrameworkEvents
+	 * @param timeout - the time in that the matches must happened
+	 */
+	public static EventRecordingAssert assertThatFrameworkEvent(Runnable execute,
+		Predicate<FrameworkEvent> predicate, int timeout) throws Exception {
+		return assertThat(execute, FrameworkEvents.isFrameworkEventAnd(predicate), timeout);
+	}
+
+	/**
+	 * @param execute - the action that will be invoked.
+	 * @param predicate - Predicate that would be tested against the Events
+	 * @param timeout - the time in that the matches must happened
+	 */
+	public static EventRecordingAssert assertThat(Runnable execute, Predicate<Object> predicate, int timeout)
+		throws Exception {
+		BundleContext bc = FrameworkUtil.getBundle(EventRecordingAssert.class)
+			.getBundleContext();
+
+		EventRecording awaitResult = EventRecording.recordEvents(bc, execute, predicate, timeout);
+		return new EventRecordingAssert(awaitResult, EventRecordingAssert.class);
+	}
+
+	/**
+	 * @param execute - the action that will be invoked.
+	 * @param timeout - the time in that the matches must happened
+	 */
+	public static EventRecordingAssert assertThat(Runnable execute, int timeout) throws Exception {
+		return assertThat(execute, (se) -> false, timeout);
+	}
+
+	/**
+	 * @param execute - the action that will be invoked.
+	 */
+	public static EventRecordingAssert assertThat(Runnable execute) throws Exception {
+		return assertThat(execute, 200);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/AbstractServiceEventAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/AbstractServiceEventAssert.java
@@ -33,11 +33,20 @@ public abstract class AbstractServiceEventAssert<SELF extends AbstractServiceEve
 	public SELF hasServiceReference(ServiceReference<?> expected) {
 		isNotNull();
 		if (!Objects.equals(actual.getServiceReference(), expected)) {
-			throw failureWithActualExpected(actual.getServiceReference(),
-				expected,
+			throw failureWithActualExpected(actual.getServiceReference(), expected,
 				"%nExpecting%n <%s>%nto have service reference:%n <%s>%n but was:%n<%s>", actual, expected,
 				actual.getServiceReference());
 		}
 		return myself;
 	}
+// TODO: Extra PR
+//	public ServiceReferenceAssert hasServiceReferenceThat() {
+//		isNotNull();
+//
+//		ServiceReference<?> serviceReference = actual.getServiceReference();
+//		if (serviceReference == null) {
+//			throw new AssertionError("serviceReference must not be null", null);
+//		}
+//		return new ServiceReferenceAssert(serviceReference);
+//	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventConditions.java
@@ -1,0 +1,96 @@
+package org.osgi.test.assertj.serviceevent;
+
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.test.common.bitmaps.ServiceEventType;
+import org.osgi.test.common.dictionary.Dictionaries;
+import org.osgi.test.common.event.ServiceEvents;
+
+public class ServiceEventConditions {
+
+	public static Condition<ServiceEvent> isType(final int eventTypeMask) {
+		return new Condition<ServiceEvent>(ServiceEvents.isType(eventTypeMask), "isType with mask '%s' (%s)",
+			eventTypeMask, ServiceEventType.BITMAP.maskToString(eventTypeMask));
+	}
+
+	public static Condition<ServiceEvent> isTypeRegistered() {
+		return isType(ServiceEvent.REGISTERED);
+	}
+
+	public static Condition<ServiceEvent> isTypeModified() {
+		return isType(ServiceEvent.MODIFIED);
+	}
+
+	public static Condition<ServiceEvent> isTypeModifiedEndmatch() {
+		return isType(ServiceEvent.MODIFIED_ENDMATCH);
+	}
+
+	public static Condition<ServiceEvent> isTypeUnregistering() {
+		return isType(ServiceEvent.UNREGISTERING);
+	}
+
+	public static Condition<ServiceEvent> containsServiceProperties(Map<String, Object> map) {
+		return
+
+		new Condition<ServiceEvent>(ServiceEvents.containsServiceProperties(map), "contains ServiceProperties %s", map);
+	}
+
+	public static Condition<ServiceEvent> containsServiceProperties(Dictionary<String, Object> dictionary) {
+		return containsServiceProperties(Dictionaries.asMap(dictionary));
+	}
+
+	public static Condition<ServiceEvent> hasObjectClass(final Class<?> objectClass) {
+
+		return new Condition<ServiceEvent>(ServiceEvents.hasObjectClass(objectClass), "has Objectclass %s",
+			objectClass.getName());
+	}
+
+	public static Condition<ServiceEvent> containServiceProperty(final String key, Object value) {
+		return containsServiceProperties(Dictionaries.dictionaryOf(key, value));
+	}
+
+	public static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
+		Map<String, Object> map) {
+
+		return Assertions.allOf(isType(eventTypeMask), hasObjectClass(objectClass), containsServiceProperties(map));
+	}
+
+	public static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
+		Dictionary<String, Object> dictionary) {
+		return matches(eventTypeMask, objectClass, Dictionaries.asMap(dictionary));
+	}
+
+	public static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass) {
+		return matches(eventTypeMask, objectClass, new HashMap<String, Object>());
+	}
+
+	public static Condition<ServiceEvent> isTypeRegistered(final Class<?> objectClass) {
+		return matches(ServiceEvent.REGISTERED, objectClass);
+	}
+
+	public static Condition<ServiceEvent> isTypeRegisteredWith(final Class<?> objectClass, Map<String, Object> map) {
+		return matches(ServiceEvent.REGISTERED, objectClass, map);
+	}
+
+	public static Condition<ServiceEvent> isTypeRegisteredWith(final Class<?> objectClass,
+		Dictionary<String, Object> dictionary) {
+		return matches(ServiceEvent.REGISTERED, objectClass, dictionary);
+	}
+
+	public static Condition<ServiceEvent> isTypeUnregistering(final Class<?> objectClass) {
+		return matches(ServiceEvent.UNREGISTERING, objectClass);
+	}
+
+	public static Condition<ServiceEvent> isTypeModified(final Class<?> objectClass) {
+		return matches(ServiceEvent.MODIFIED, objectClass);
+	}
+
+	public static Condition<ServiceEvent> isTypeModifiedEndmatch(final Class<?> objectClass) {
+		return matches(ServiceEvent.MODIFIED_ENDMATCH, objectClass);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/event/EventRecordingAssertIntegrationTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/event/EventRecordingAssertIntegrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.assertj.event;
+
+import static org.osgi.framework.ServiceEvent.REGISTERED;
+import static org.osgi.test.assertj.serviceevent.ServiceEventConditions.containServiceProperty;
+import static org.osgi.test.assertj.serviceevent.ServiceEventConditions.containsServiceProperties;
+import static org.osgi.test.assertj.serviceevent.ServiceEventConditions.hasObjectClass;
+import static org.osgi.test.assertj.serviceevent.ServiceEventConditions.isTypeModified;
+import static org.osgi.test.assertj.serviceevent.ServiceEventConditions.isTypeModifiedEndmatch;
+import static org.osgi.test.assertj.serviceevent.ServiceEventConditions.isTypeRegistered;
+import static org.osgi.test.assertj.serviceevent.ServiceEventConditions.isTypeUnregistering;
+import static org.osgi.test.assertj.serviceevent.ServiceEventConditions.matches;
+import static org.osgi.test.common.dictionary.Dictionaries.dictionaryOf;
+
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.test.common.event.ServiceEvents;
+
+public class EventRecordingAssertIntegrationTest {
+
+	BundleContext	bc	= FrameworkUtil.getBundle(EventRecordingAssertIntegrationTest.class)
+		.getBundleContext();
+	String			k1	= "key1";
+	String			v1	= "value1";
+
+	String			k2	= "key2";
+	String			v2	= "value2";
+
+	@Test
+	void exampleIntegrationTest() throws Exception {
+
+		// Setup assert
+		EventRecordingAssert eAssert = EventRecordingAssert.assertThatServiceEvent(() -> {
+			ServiceRegistration<A> reg = null;
+			reg = bc.registerService(A.class, new A() {}, dictionaryOf(k1, v1));
+			reg.setProperties(dictionaryOf(k1, v1, k2, v2));
+			reg.unregister();
+		}, ServiceEvents.isTypeUnregistering(A.class), 20);
+
+		// check whether the Predicate matches or the timeout
+		eAssert.isNotTimedOut();
+
+		// get ListAsserts and check them
+		eAssert.hasEventsThat()
+			.isNotEmpty();
+
+		eAssert.hasFrameworkEventsThat()
+			.isEmpty();
+
+		eAssert.hasBundleEventsThat()
+			.isEmpty();
+
+		// ListAsserts in combination with Conditions
+		eAssert.hasServiceEventsThat()
+			.areAtLeast(1, isTypeModified())
+			.are(hasObjectClass(A.class))
+			.areExactly(3, hasObjectClass(A.class))
+			.areNot(isTypeModifiedEndmatch())
+			.first()
+			.isOfType(REGISTERED);
+
+		eAssert.hasServiceEventsThat()
+			.isNotEmpty()
+			.hasSize(3);
+
+		eAssert.hasServiceEventsThat()
+			.element(0)
+			.is(isTypeRegistered())
+			.is(hasObjectClass(A.class))
+			.is(isTypeRegistered(A.class))
+			.is(containServiceProperty(k1, v1))
+			.is(matches(REGISTERED, A.class, dictionaryOf(k1, v1)));
+
+		eAssert.hasServiceEventsThat()
+			.element(1)// ServiceEventAssert
+			.is(isTypeModified(A.class))
+			.is(containsServiceProperties(dictionaryOf(k1, v1, k2, v2)));
+
+		// TODO: Extra PR
+		// .hasServiceReferenceThat()// ServiceReferenceAssert
+		// .hasServicePropertiesThat()// DictionaryAssert
+		// .containsEntry(k1, v1);
+
+		eAssert.hasServiceEventsThat()
+			.element(2)
+			.is(isTypeUnregistering(A.class));
+	}
+
+	@Test
+	void testClone() throws Exception {
+
+		// Setup assert
+		EventRecordingAssert.assertThat(() -> {
+			ServiceRegistration<A> reg = null;
+			reg = bc.registerService(A.class, new A() {}, dictionaryOf(k1, v1));
+			reg.setProperties(dictionaryOf(k1, v1, k2, v2));
+			reg.unregister();
+		})
+			.hasServiceEventsThat()
+			.first()
+			.isNot(containServiceProperty(k2, v2));
+	}
+
+	class A {
+
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/event/EventRecordingAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/event/EventRecordingAssertTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.assertj.event;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.assertj.testutil.AbstractAssertTest;
+import org.osgi.test.common.event.EventRecording;
+import org.osgi.test.common.event.EventRecording.TimedEvent;
+
+public class EventRecordingAssertTest extends AbstractAssertTest<EventRecordingAssert, EventRecording> {
+
+	public EventRecordingAssertTest() {
+		super(EventRecordingAssert::assertThat);
+	}
+
+	private EventRecording		recording;
+	private Bundle				b	= mock(Bundle.class);
+
+	private ServiceReference<?>	sr	= mock(ServiceReference.class);
+
+	TimedEvent<FrameworkEvent>	tfe	= new TimedEvent<FrameworkEvent>(new FrameworkEvent(FrameworkEvent.INFO, b, null));
+	TimedEvent<BundleEvent>		tbe	= new TimedEvent<BundleEvent>(new BundleEvent(BundleEvent.STARTED, b, b));
+	TimedEvent<ServiceEvent>	tse	= new TimedEvent<ServiceEvent>(new ServiceEvent(ServiceEvent.REGISTERED, sr));
+
+	@Test
+	public void isTimedOut() throws Exception {
+		recording = recordings(false, tfe);
+
+		setActual(recording);
+		assertPassing("isNot", x -> aut.isNotTimedOut(), null);
+		assertFailing("is", x -> aut.isTimedOut(), null)
+			.hasMessageMatching("(?si).*to be a timedOut.*but it was not.*");
+
+		recording = recordings(true, tfe);
+
+		setActual(recording);
+		assertPassing("is", x -> aut.isTimedOut(), null);
+		assertFailing("isNot", x -> aut.isNotTimedOut(), null)
+			.hasMessageMatching("(?si).*not.*be a timedOut.*but it was.*");
+	}
+
+	private static EventRecording recordings(boolean timedOut, TimedEvent<?>... events) {
+
+		return new EventRecording() {
+
+			@Override
+			public boolean isTimedOut() {
+				return timedOut;
+			}
+
+			@Override
+			public List<TimedEvent<?>> timedEvents() {
+				return Arrays.asList(events);
+			}
+		};
+	}
+
+	class A {
+
+	}
+}

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/event/BundleEvents.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/event/BundleEvents.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.common.event;
+
+import java.util.function.Predicate;
+
+import org.osgi.framework.BundleEvent;
+
+public class BundleEvents extends Events {
+
+	private BundleEvents() {}
+
+	// BundleEvents
+
+	public static Predicate<Object> isBundleEvent() {
+		return e -> e instanceof BundleEvent;
+	}
+
+	public static Predicate<Object> isBundleEventAnd(Predicate<BundleEvent> predicate) {
+		return e -> isBundleEvent().test(e) && predicate.test((BundleEvent) e);
+	}
+
+	static Predicate<BundleEvent> isType(final int eventTypeMask) {
+		return e -> (e.getType() & eventTypeMask) != 0;
+	}
+
+	// BundleEvents - by type
+	static Predicate<BundleEvent> isTypeInstalled() {
+		return e -> isType(BundleEvent.INSTALLED).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeLazyActivation() {
+		return e -> isType(BundleEvent.LAZY_ACTIVATION).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeResolved() {
+		return e -> isType(BundleEvent.RESOLVED).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeStarted() {
+		return e -> isType(BundleEvent.STARTED).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeStarting() {
+		return e -> isType(BundleEvent.STARTING).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeStopped() {
+		return e -> isType(BundleEvent.STOPPED).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeStopping() {
+		return e -> isType(BundleEvent.STOPPING).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeUninstalled() {
+		return e -> isType(BundleEvent.UNINSTALLED).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeUnresolved() {
+		return e -> isType(BundleEvent.UNRESOLVED).test(e);
+	}
+
+	static Predicate<BundleEvent> isTypeUpdated() {
+		return e -> isType(BundleEvent.UPDATED).test(e);
+	}
+}

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/event/CloneUtil.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/event/CloneUtil.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.common.event;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+
+public class CloneUtil {
+	public static ServiceEvent clone(ServiceEvent serviceEvent) {
+		return new ServiceEvent(serviceEvent.getType(), clone(serviceEvent.getServiceReference()));
+	}
+
+	public static BundleEvent clone(BundleEvent bundleEvent) {
+		return new BundleEvent(bundleEvent.getType(), clone(bundleEvent.getBundle()), clone(bundleEvent.getOrigin()));
+	}
+
+	public static FrameworkEvent clone(FrameworkEvent frameworkEvent) {
+		return new FrameworkEvent(frameworkEvent.getType(), clone(frameworkEvent.getBundle()),
+			frameworkEvent.getThrowable());
+	}
+
+	public static ServiceReference<?> clone(ServiceReference<?> serviceReference) {
+		Map<String, Object> props = new HashMap<>();
+		if (serviceReference.getPropertyKeys() != null) {
+			for (String key : serviceReference.getPropertyKeys()) {
+				props.put(key, serviceReference.getProperty(key));
+			}
+		}
+		Bundle bundle = clone(serviceReference.getBundle());
+		Bundle[] usingBundles = serviceReference.getUsingBundles() == null ? null
+			: Stream.of(serviceReference.getUsingBundles())
+				.map(b -> clone(b))
+				.toArray(Bundle[]::new);
+		ServiceReference<?> serviceReferenceProxyInstance = (ServiceReference<?>) Proxy
+			.newProxyInstance(ServiceReference.class.getClassLoader(), new Class[] {
+				ServiceReference.class
+			}, new InvocationHandler() {
+				@Override
+				public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+					if (method.getName()
+						.equals("getProperty")) {
+						return props.get(args[0]);
+					}
+					if (method.getName()
+						.equals("getPropertyKeys")) {
+						return props.keySet()
+							.stream()
+							.toArray(String[]::new);
+					}
+					if (method.getName()
+						.equals("getBundle")) {
+						return bundle;
+					}
+					if (method.getName()
+						.equals("getUsingBundles")) {
+						return usingBundles;
+					}
+					return method.invoke(proxy, args);
+				}
+			});
+		return serviceReferenceProxyInstance;
+	}
+
+	public static Bundle clone(Bundle bundle) {
+		if (bundle == null) {
+			return null;
+		}
+		int state = bundle.getState();
+		long lastModified = bundle.getLastModified();
+		Bundle bundleProxyInstance = (Bundle) Proxy.newProxyInstance(Bundle.class.getClassLoader(), new Class[] {
+			Bundle.class
+		}, new InvocationHandler() {
+			@Override
+			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+				if (method.getName()
+					.equals("getState")) {
+					return state;
+				}
+				if (method.getName()
+					.equals("getLastModified")) {
+					return lastModified;
+				}
+				return method.invoke(proxy, args);
+			}
+		});
+		return bundleProxyInstance;
+	}
+}

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/event/EventRecording.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/event/EventRecording.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.common.event;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceListener;
+
+public interface EventRecording {
+	boolean isTimedOut();
+
+	List<TimedEvent<?>> timedEvents();
+
+	@SuppressWarnings("unchecked")
+	default <T> List<TimedEvent<T>> timedEvents(Class<T> clazz) {
+		return timedEvents().stream()
+			.filter((te) -> clazz.isInstance(te.getEvent()))
+			.map((te) -> (TimedEvent<T>) te)
+			.collect(Collectors.toList());
+	}
+
+	default List<?> events() {
+		return timedEvents().stream()
+			.map(TimedEvent::getEvent)
+			.collect(Collectors.toList());
+	}
+
+	default <T> List<T> events(Class<T> clazz) {
+		return timedEvents(clazz).stream()
+			.map(TimedEvent::getEvent)
+			.collect(Collectors.toList());
+	}
+
+	default List<ServiceEvent> serviceEvents() {
+		return events(ServiceEvent.class);
+	}
+
+	default List<TimedEvent<ServiceEvent>> timedServiceEvents() {
+		return timedEvents(ServiceEvent.class);
+	}
+
+	default List<BundleEvent> bundleEvents() {
+
+		return events(BundleEvent.class);
+	}
+
+	default List<TimedEvent<BundleEvent>> timedBundleEvents() {
+		return timedEvents(BundleEvent.class);
+	}
+
+	default List<FrameworkEvent> frameworkEvents() {
+		return events(FrameworkEvent.class);
+	}
+
+	default List<TimedEvent<FrameworkEvent>> timedFrameworkEvents() {
+		return timedEvents(FrameworkEvent.class);
+	}
+
+	static class EventsRecordingImpl implements EventRecording {
+		private List<TimedEvent<?>>	events;
+		private boolean				timedOut;
+
+		private EventsRecordingImpl() {}
+
+		public EventsRecordingImpl(boolean timedOut, List<TimedEvent<?>> events) {
+			this();
+			this.timedOut = timedOut;
+			this.events = events;
+		}
+
+		@Override
+		public boolean isTimedOut() {
+			return timedOut;
+		}
+
+		@Override
+		public List<TimedEvent<?>> timedEvents() {
+			return events;
+		}
+
+		@Override
+		public String toString() {
+			return "EventsSnapshotImpl [events=" + events + ", timedOut=" + timedOut + "]";
+		}
+
+	}
+
+	static class TimedEvent<T> {
+		private T event;
+
+		public T getEvent() {
+			return event;
+		}
+
+		public Instant getInstant() {
+			return instant;
+		}
+
+		private Instant instant = Instant.now();
+
+		public TimedEvent(T event) {
+			this.event = event;
+		}
+
+		@Override
+		public String toString() {
+			return "TimedEvent [event=" + event + ", instant=" + instant + "]";
+		}
+
+	}
+
+	static EventRecording recordEvents(BundleContext bc, Runnable callable, Predicate<Object> predicate, int timeout)
+		throws Exception {
+		List<TimedEvent<?>> events = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch latch = new CountDownLatch(1);
+
+		BundleListener bListener = new BundleListener() {
+
+			@Override
+			public void bundleChanged(BundleEvent event) {
+				events.add(new TimedEvent<BundleEvent>(CloneUtil.clone(event)));
+				if (predicate.test(event)) {
+					latch.countDown();
+				}
+
+			}
+		};
+
+		FrameworkListener fListener = new FrameworkListener() {
+
+			@Override
+			public void frameworkEvent(FrameworkEvent event) {
+				events.add(new TimedEvent<FrameworkEvent>(CloneUtil.clone(event)));
+				if (predicate.test(event)) {
+					latch.countDown();
+				}
+			}
+		};
+
+		ServiceListener sListener = new ServiceListener() {
+			@Override
+			public void serviceChanged(ServiceEvent event) {
+				events.add(new TimedEvent<ServiceEvent>(CloneUtil.clone(event)));
+				if (predicate.test(event)) {
+					latch.countDown();
+				}
+			}
+		};
+
+		bc.addFrameworkListener(fListener);
+		bc.addBundleListener(bListener);
+		bc.addServiceListener(sListener);
+		callable.run();
+		boolean timedOut = !latch.await(timeout, TimeUnit.MILLISECONDS);
+		bc.removeServiceListener(sListener);
+		bc.removeBundleListener(bListener);
+		bc.removeFrameworkListener(fListener);
+
+		List<TimedEvent<?>> objects = Collections.unmodifiableList(events);
+
+		return new EventsRecordingImpl(timedOut, objects);
+	}
+}

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/event/Events.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/event/Events.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.common.event;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+public class Events {
+
+	public static <E> Predicate<E> any() {
+		return element -> true;
+	}
+
+	public static <E> Predicate<Optional<E>> isPresentAnd(final Predicate<E> predicate) {
+		return optional -> optional.isPresent() && predicate.test(optional.get());
+	}
+
+	public static <E> Predicate<List<E>> element(int index, final Predicate<E> predicate) {
+		return elements -> elements.size() > 0 && elements.size() >= index && predicate.test(elements.get(index));
+	}
+
+	public static <E> Predicate<List<E>> first(final Predicate<E> predicate) {
+		return elements -> element(0, predicate).test(elements);
+	}
+
+	public static <E> Predicate<List<E>> last(final Predicate<E> predicate) {
+		return elements -> element(elements.size() - 1, predicate).test(elements);
+	}
+
+	public static <E> Predicate<List<E>> all(final Predicate<E> predicate) {
+		return elements -> elements.stream()
+			.allMatch(predicate);
+	}
+
+	public static <E> Predicate<List<E>> any(final Predicate<E> predicate) {
+		return elements -> elements.stream()
+			.anyMatch(predicate);
+	}
+
+	public static <E> Predicate<List<E>> none(final Predicate<E> predicate) {
+		return elements -> elements.stream()
+			.noneMatch(predicate);
+	}
+
+	@SafeVarargs
+	public static <E> Predicate<List<E>> ordered(final Predicate<E> predicate, final Predicate<E>... predicatesNext) {
+		return elements -> {
+
+			List<Predicate<E>> predicates = new ArrayList<>();
+			predicates.add(predicate);
+			predicates.addAll(Arrays.asList(predicatesNext));
+
+			long skip = 0;
+			for (int i = 0; i <= predicatesNext.length - 1; i++) {
+				Predicate<E> predicateBefore = predicates.get(i);
+				Predicate<E> predicateAfter = predicates.get(i + 1);
+
+				Optional<E> before = elements.stream()
+					.skip(skip)
+					.filter(predicateBefore)
+					.findFirst();
+				Optional<E> after = elements.stream()
+					.skip(skip)
+					.filter(predicateAfter)
+					.findFirst();
+
+				if (before.isPresent() && after.isPresent()) {
+
+					int indexBefore = elements.indexOf(before.get());
+					int indexAfter = elements.indexOf(after.get());
+					if (indexBefore >= indexAfter) {
+						return false;
+					}
+					skip = indexBefore;
+				} else {
+					return false;
+				}
+			}
+			return true;
+		};
+	}
+
+	public static <E> Predicate<List<E>> hasSize(long size, final Predicate<E> predicate) {
+		return elements -> elements.stream()
+			.filter(predicate)
+			.count() == size;
+	}
+
+	public static <E> Predicate<List<E>> hasMoreThen(long size, final Predicate<E> predicate) {
+		return elements -> elements.stream()
+			.filter(predicate)
+			.count() > size;
+	}
+
+	public static <E> Predicate<List<E>> hasLessThen(long size, final Predicate<E> predicate) {
+		return elements -> elements.stream()
+			.filter(predicate)
+			.count() < size;
+	}
+}

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/event/FrameworkEvents.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/event/FrameworkEvents.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.common.event;
+
+import java.util.function.Predicate;
+
+import org.osgi.framework.FrameworkEvent;
+
+public class FrameworkEvents extends Events {
+
+	private FrameworkEvents() {
+		// TODO Auto-generated constructor stub
+	}
+
+	// FramworkEvents
+
+	public static Predicate<Object> isFrameworkEvent() {
+		return e -> e instanceof FrameworkEvent;
+	}
+
+	public static Predicate<Object> isFrameworkEventAnd(Predicate<FrameworkEvent> predicate) {
+		return e -> isFrameworkEvent().test(e) && predicate.test((FrameworkEvent) e);
+	}
+
+	static Predicate<FrameworkEvent> isType(final int eventTypeMask) {
+		return e -> (e.getType() & eventTypeMask) != 0;
+	}
+
+	static Predicate<FrameworkEvent> isTypeError() {
+		return e -> isType(FrameworkEvent.ERROR).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypeInfo() {
+		return e -> isType(FrameworkEvent.INFO).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypePackagesRefreshed() {
+		return e -> isType(FrameworkEvent.PACKAGES_REFRESHED).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypeStarted() {
+		return e -> isType(FrameworkEvent.STARTED).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypeStartlevelChanged() {
+		return e -> isType(FrameworkEvent.STARTLEVEL_CHANGED).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypeStopped() {
+		return e -> isType(FrameworkEvent.STOPPED).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypeStoppedBootclasspathModified() {
+		return e -> isType(FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypeStoppedUpdate() {
+		return e -> isType(FrameworkEvent.STOPPED_UPDATE).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypeWaitTimeout() {
+		return e -> isType(FrameworkEvent.WAIT_TIMEDOUT).test(e);
+	}
+
+	static Predicate<FrameworkEvent> isTypeWarning() {
+		return e -> isType(FrameworkEvent.WARNING).test(e);
+	}
+}

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/event/ServiceEvents.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/event/ServiceEvents.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.test.common.event;
+
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+public class ServiceEvents extends Events {
+
+	private ServiceEvents() {}
+
+	public static Predicate<Object> isServiceEvent() {
+		return e -> e instanceof ServiceEvent;
+	}
+
+	public static Predicate<Object> isServiceEventAnd(Predicate<ServiceEvent> predicate) {
+		return e -> isServiceEvent().test(e) && predicate.test((ServiceEvent) e);
+	}
+
+	// ServiceEvents
+	public static Predicate<ServiceEvent> isType(final int eventTypeMask) {
+		return e -> (e.getType() & eventTypeMask) != 0;
+	}
+
+	public static Predicate<ServiceEvent> isTypeRegistered() {
+		return e -> isType(ServiceEvent.REGISTERED).test(e);
+	}
+
+	public static Predicate<ServiceEvent> isTypeModified() {
+		return e -> isType(ServiceEvent.MODIFIED).test(e);
+	}
+
+	public static Predicate<ServiceEvent> isTypeModifiedEndmatch() {
+		return e -> isType(ServiceEvent.MODIFIED_ENDMATCH).test(e);
+	}
+
+	public static Predicate<ServiceEvent> isTypeUnregistering() {
+		return e -> isType(ServiceEvent.UNREGISTERING).test(e);
+	}
+
+	public static Predicate<ServiceEvent> hasObjectClass(final Class<?> objectClass) {
+
+		return e -> {
+			Object classes = e.getServiceReference()
+				.getProperty(Constants.OBJECTCLASS);
+
+			if (classes != null && classes instanceof String[]) {
+				return Stream.of((String[]) classes)
+					.filter(Objects::nonNull)
+					.anyMatch(objectClass.getName()::equals);
+			}
+			return false;
+		};
+
+	}
+
+	public static Predicate<ServiceEvent> containServiceProperty(final String key, Object value) {
+		return e -> containsServiceProperties(Dictionaries.dictionaryOf(key, value)).test(e);
+	}
+
+	public static Predicate<ServiceEvent> containsServiceProperties(Map<String, Object> map) {
+		return e -> {
+			ServiceReference<?> sr = e.getServiceReference();
+			List<String> keys = Stream.of(sr.getPropertyKeys())
+				.collect(Collectors.toList());
+			for (Entry<String, Object> entry : map.entrySet()) {
+				if (!keys.contains(entry.getKey())) {
+					return false;
+				}
+				if (!Objects.equals(sr.getProperty(entry.getKey()), entry.getValue())) {
+					return false;
+				}
+			}
+			return true;
+		};
+	}
+
+	public static Predicate<ServiceEvent> containsServiceProperties(Dictionary<String, Object> dictionary) {
+		return e -> containsServiceProperties(Dictionaries.asMap(dictionary)).test(e);
+	}
+
+	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass) {
+		return e -> isType(eventTypeMask).test(e) && (hasObjectClass(objectClass).test(e));
+	}
+
+	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
+		Map<String, Object> map) {
+		return e -> isType(eventTypeMask).test(e) && (hasObjectClass(objectClass).test(e))
+			&& containsServiceProperties(map).test(e);
+	}
+
+	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
+		Dictionary<String, Object> dictionary) {
+		return e -> matches(eventTypeMask, objectClass, Dictionaries.asMap(dictionary)).test(e);
+	}
+
+	public static Predicate<ServiceEvent> isTypeRegistered(final Class<?> objectClass) {
+		return matches(ServiceEvent.REGISTERED, objectClass);
+	}
+
+	public static Predicate<ServiceEvent> isTypeRegisteredWith(final Class<?> objectClass, Map<String, Object> map) {
+		return matches(ServiceEvent.REGISTERED, objectClass, map);
+	}
+
+	public static Predicate<ServiceEvent> isTypeRegisteredWith(final Class<?> objectClass,
+		Dictionary<String, Object> dictionary) {
+		return matches(ServiceEvent.REGISTERED, objectClass, dictionary);
+	}
+
+	public static Predicate<ServiceEvent> isTypeUnregistering(final Class<?> objectClass) {
+		return matches(ServiceEvent.UNREGISTERING, objectClass);
+	}
+
+	public static Predicate<ServiceEvent> isTypeModified(final Class<?> objectClass) {
+		return matches(ServiceEvent.MODIFIED, objectClass);
+	}
+
+	public static Predicate<ServiceEvent> isTypeModifiedEndmatch(final Class<?> objectClass) {
+		return matches(ServiceEvent.MODIFIED_ENDMATCH, objectClass);
+	}
+}

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/event/package-info.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/event/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("1.0.0")
+package org.osgi.test.common.event;

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/event/BundleEventsTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/event/BundleEventsTest.java
@@ -1,0 +1,27 @@
+package org.osgi.test.common.event;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+
+public class BundleEventsTest {
+
+	@Test
+	void testPredicateBundle() throws Exception {
+
+		SoftAssertions softly = new SoftAssertions();
+
+		//
+		Bundle bundle = Mockito.mock(Bundle.class);
+		BundleEvent event = new BundleEvent(BundleEvent.INSTALLED, bundle);
+
+		//
+		softly.assertThat(BundleEvents.isType(BundleEvent.INSTALLED)
+			.test(event))
+			.isTrue();
+
+		softly.assertAll();
+	}
+}

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/event/EventRecordingTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/event/EventRecordingTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.test.common.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.common.event.EventRecording.TimedEvent;
+
+public class EventRecordingTest {
+
+	static List<FrameworkListener>	frameworkListeners	= new ArrayList<>();
+	static List<ServiceListener>	serviceListeners	= new ArrayList<>();
+	static List<BundleListener>		bundleListeners		= new ArrayList<>();
+	static BundleContext			bundleContext;
+
+	static Bundle					bundle;
+
+	@BeforeAll
+	public static void beforeAll() {
+		bundle = mock(Bundle.class);
+
+		when(bundle.getSymbolicName()).thenReturn("test");
+
+		bundleContext = mock(BundleContext.class);
+
+		doAnswer(invocation -> {
+			Object listener = invocation.getArgument(0);
+			bundleListeners.add((BundleListener) listener);
+			return null;
+		}).when(bundleContext)
+			.addBundleListener(Mockito.any(BundleListener.class));
+
+		doAnswer(invocation -> {
+			Object listener = invocation.getArgument(0);
+			bundleListeners.remove(listener);
+			return null;
+		}).when(bundleContext)
+			.removeBundleListener(Mockito.any(BundleListener.class));
+
+		doAnswer(invocation -> {
+			Object listener = invocation.getArgument(0);
+			frameworkListeners.add((FrameworkListener) listener);
+			return null;
+		}).when(bundleContext)
+			.addFrameworkListener(Mockito.any(FrameworkListener.class));
+
+		doAnswer(invocation -> {
+			Object listener = invocation.getArgument(0);
+			frameworkListeners.remove(listener);
+			return null;
+		}).when(bundleContext)
+			.removeFrameworkListener(Mockito.any(FrameworkListener.class));
+
+		doAnswer(invocation -> {
+			Object listener = invocation.getArgument(0);
+			serviceListeners.add((ServiceListener) listener);
+			return null;
+		}).when(bundleContext)
+			.addServiceListener(Mockito.any(ServiceListener.class));
+		doAnswer(invocation -> {
+			Object listener = invocation.getArgument(0);
+			serviceListeners.remove(listener);
+			return null;
+		}).when(bundleContext)
+			.removeServiceListener(Mockito.any(ServiceListener.class));
+
+	}
+
+	@Test
+	public void test_takeSnapsot() throws Exception {
+
+		// Test any Match
+		Predicate<Object> matches = (event) -> {
+			if (event instanceof ServiceEvent) {
+				return ((ServiceEvent) event).getType() == ServiceEvent.REGISTERED;
+			}
+			return false;
+		};
+
+		Runnable ecexute = () -> {
+
+			assertThat(frameworkListeners).hasSize(1);
+
+			assertThat(bundleListeners).hasSize(1);
+
+			assertThat(serviceListeners).hasSize(1);
+
+			frameworkListeners
+				.forEach((l) -> l.frameworkEvent(new FrameworkEvent(FrameworkEvent.INFO, mock(Bundle.class), null)));
+
+			bundleListeners.forEach(
+				(l) -> l.bundleChanged(new BundleEvent(BundleEvent.INSTALLED, mock(Bundle.class), mock(Bundle.class))));
+
+			serviceListeners.forEach(
+				(l) -> l.serviceChanged(new ServiceEvent(ServiceEvent.REGISTERED, mock(ServiceReference.class))));
+
+		};
+		// Create an Obervator with the given count and Predicate-Matcher
+		EventRecording result = EventRecording.recordEvents(bundleContext, ecexute, matches, 0);
+
+		// Check that the event happened
+
+		assertThat(result).isNotNull();
+		assertThat(result.isTimedOut()).isFalse();
+		assertThat(result.timedEvents()).isNotNull();
+		assertThat(result.timedEvents()).hasSize(3);
+
+		assertThat(result.timedEvents()).element(0)
+			.extracting(TimedEvent::getEvent)
+			.isInstanceOf(FrameworkEvent.class);
+
+		assertThat(result.timedEvents()).element(1)
+			.extracting(TimedEvent::getEvent)
+			.isInstanceOf(BundleEvent.class);
+
+		assertThat(result.timedEvents()).element(2)
+			.extracting(TimedEvent::getEvent)
+			.isInstanceOf(ServiceEvent.class);
+
+		assertThat(bundleListeners).isEmpty();
+		assertThat(frameworkListeners).isEmpty();
+		assertThat(serviceListeners).isEmpty();
+
+	}
+
+	class A {}
+}

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/event/EventsTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/event/EventsTest.java
@@ -1,0 +1,106 @@
+package org.osgi.test.common.event;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+public class EventsTest {
+
+	@Test
+	void testListPredicate() throws Exception {
+
+		String first = "_first";
+		String second = "_second";
+		String third = "_third";
+
+		List<Object> list = new ArrayList<>();
+		list.add(first);
+		list.add(second);
+		list.add(third);
+
+		SoftAssertions softly = new SoftAssertions();
+
+		softly.assertThat(Events.all(e -> e.toString()
+			.startsWith("_"))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.any(e -> e.equals(second))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.element(0, e -> e.equals(first))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.element(1, e -> e.equals(second))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.element(2, e -> e.equals(third))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.ordered(e -> e.equals(first))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.ordered(e -> e.equals(first), e -> e.equals(second))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.ordered(e -> e.equals(first), e -> e.equals(third))
+			.test(list))
+			.isTrue();
+		softly.assertThat(Events.ordered(e -> e.equals(second), e -> e.equals(third))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.ordered(e -> e.equals(third))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.ordered(e -> e.equals(first), e -> e.equals(second), e -> e.equals(third))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.ordered(e -> e.equals(first), e -> e.equals(second), e -> e.equals("?"))
+			.test(list))
+			.isFalse();
+
+		softly.assertThat(Events.ordered(e -> e.equals(first), e -> e.equals(second), e -> e.equals(second))
+			.test(list))
+			.isFalse();
+
+		softly.assertThat(Events.first(e -> e.equals(first))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.last(e -> e.equals(third))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.none(e -> e.equals("?"))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.hasSize(3, e -> e.toString()
+			.startsWith("_"))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.hasLessThen(4, e -> e.toString()
+			.startsWith("_"))
+			.test(list))
+			.isTrue();
+
+		softly.assertThat(Events.hasMoreThen(2, e -> e.toString()
+			.startsWith("_"))
+			.test(list))
+			.isTrue();
+
+		softly.assertAll();
+	}
+}

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/event/FrameworkEventsTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/event/FrameworkEventsTest.java
@@ -1,0 +1,27 @@
+package org.osgi.test.common.event;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkEvent;
+
+public class FrameworkEventsTest {
+
+	@Test
+	void testPredicateFramework() throws Exception {
+
+		SoftAssertions softly = new SoftAssertions();
+
+		//
+		Bundle bundle = Mockito.mock(Bundle.class);
+		FrameworkEvent event = new FrameworkEvent(FrameworkEvent.STARTLEVEL_CHANGED, bundle, null);
+
+		//
+		softly.assertThat(FrameworkEvents.isType(FrameworkEvent.STARTLEVEL_CHANGED)
+			.test(event))
+			.isTrue();
+
+		softly.assertAll();
+	}
+}

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/event/ServiceEventsTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/event/ServiceEventsTest.java
@@ -1,0 +1,95 @@
+package org.osgi.test.common.event;
+
+import java.util.Collections;
+import java.util.Dictionary;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+public class ServiceEventsTest {
+
+	@Test
+	void testPredicateService() throws Exception {
+
+		SoftAssertions softly = new SoftAssertions();
+
+		//
+
+		Dictionary<String, Object> dict = Dictionaries.dictionaryOf(Constants.OBJECTCLASS, new String[] {
+			A.class.getName()
+		}, "key1", 1, "key2", 2);
+
+		ServiceReference<?> sr = Mockito.mock(ServiceReference.class);
+		Mockito.when(sr.getPropertyKeys())
+			.thenReturn(Collections.list(dict.keys())
+				.toArray(new String[3]));
+
+		Mockito.when(sr.getProperty(Mockito.any(String.class)))
+			.then(new Answer<Object>() {
+
+				@Override
+				public Object answer(InvocationOnMock invocation) throws Throwable {
+					String key = invocation.getArgument(0);
+					return dict.get(key);
+				}
+			});
+
+		ServiceEvent event = new ServiceEvent(ServiceEvent.REGISTERED, sr);
+
+		//
+		softly.assertThat(ServiceEvents.isType(ServiceEvent.REGISTERED)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEvents.containsServiceProperties(dict)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEvents.containsServiceProperties(Dictionaries.asMap(dict))
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEvents.containServiceProperty("key1", 1)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEvents.containServiceProperty("key1", 2)
+			.test(event))
+			.isFalse();
+
+		softly.assertThat(ServiceEvents.containServiceProperty("key3", 3)
+			.test(event))
+			.isFalse();
+
+		softly.assertThat(ServiceEvents.isTypeRegistered(A.class)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEvents.hasObjectClass(A.class)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEvents.isTypeModified(A.class)
+			.test(event))
+			.isFalse();
+
+		softly.assertThat(ServiceEvents.matches(ServiceEvent.REGISTERED, A.class, dict)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEvents.matches(ServiceEvent.REGISTERED, A.class, Dictionaries.dictionaryOf())
+			.test(event))
+			.isTrue();
+
+		softly.assertAll();
+	}
+
+	interface A {}
+}


### PR DESCRIPTION
`Events.class, BundleEvents.class, ServiceEvents.class, FrameworkEvents.class` provides some Predicats to test `Service-, Framework-  and BundleEvents`.


`Events.recordEvents` provides a mechanism to waitFor one or multiple Events that matches a Predicate. It generates a EventRecording stat stores all events.


`EventRecordingAssert` uses this mechanism to record events when executing an action.
'ServiceEventCondition' provides some `assertj.Conditions` (Predicates with an Test-Description)

```
      void exampleIntegrationTest() throws Exception {

        // Setup assert
        EventRecordingAssert eAssert = EventRecordingAssert.assertThatServiceEvent(() -> {
            ServiceRegistration<A> reg = null;
            reg = bc.registerService(A.class, new A() {}, dictionaryOf(k1, v1));
            reg.setProperties(dictionaryOf(k1, v1, k2, v2));
            reg.unregister();
        }, ServiceEvents.isTypeUnregistering(A.class), 20);

        // check whether the Predicate matches or the timeout
        eAssert.isNotTimedOut();

        // get ListAsserts and check them
        eAssert.events()
            .isNotEmpty();

        eAssert.frameworkEvents()
            .isEmpty();

        eAssert.bundleEvents()
            .isEmpty();

        // ListAsserts in combination with Conditions
        eAssert.serviceEvents()
            .areAtLeast(1, isTypeModified())
            .are(hasObjectClass(A.class))
            .areExactly(3, hasObjectClass(A.class))
            .areNot(isTypeModifiedEndmatch())
            .first()
            .isOfType(REGISTERED);

        eAssert.serviceEvents()
            .isNotEmpty()
            .hasSize(3);

        eAssert.serviceEvents()
            .element(0)
            .is(isTypeRegistered())
            .is(hasObjectClass(A.class))
            .is(isTypeRegistered(A.class))
            .is(containServiceProperty(k1, v1))
            .is(matches(REGISTERED, A.class, dictionaryOf(k1, v1)));

        eAssert.serviceEvents()
            .element(1)// ServiceEventAssert
            .is(isTypeModified(A.class))
            .is(containsServiceProperties(dictionaryOf(k1, v1, k2, v2)))
            .serviceReference()// ServiceReferenceAssert
            .serviceProperties()// DictionaryAssert
            .containsEntry(k1, v1);

        eAssert.serviceEvents()
            .element(2)
            .is(isTypeUnregistering(A.class));

``` 


@juergen-albert this is the `osgi-test`-style version of your [ServiceChecker](https://gitlab.com/gecko.io/geckoRuntime/-/blob/develop/org.gecko.core/src/org/gecko/core/tests/ServiceChecker.java)  or [ServiceCheckerCustomizer](https://gitlab.com/gecko.io/geckoRuntime/-/blob/develop/org.gecko.core/src/org/gecko/core/tests/ServiceCheckerCustomizer.java)  in your test-setup. We should talk 


@kriegfrj  Maybe this could also be useful for osgi-test. So here is the PR-Draft to talk about.


