### PR TITLE
Same toString methodName in all bitmaps

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/bitmaps/FrameworkEventType.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/bitmaps/FrameworkEventType.java
@@ -29,7 +29,7 @@ import static org.osgi.framework.FrameworkEvent.WARNING;
 
 public class FrameworkEventType {
 
-	public static String typeToString(int type) {
+	public static String toString(int type) {
 		switch (type) {
 			case STARTED :
 				return "STARTED";
@@ -62,5 +62,5 @@ public class FrameworkEventType {
 	};
 
 	public static final Bitmap	BITMAP	= new Bitmap(TYPES,
-		FrameworkEventType::typeToString);
+		FrameworkEventType::toString);
 }

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/bitmaps/ServiceEventType.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/bitmaps/ServiceEventType.java
@@ -23,7 +23,7 @@ import static org.osgi.framework.ServiceEvent.UNREGISTERING;
 
 public class ServiceEventType {
 
-	public static String typeToString(int type) {
+	public static String toString(int type) {
 		switch (type) {
 			case REGISTERED :
 				return "REGISTERED";
@@ -41,5 +41,5 @@ public class ServiceEventType {
 	public static final int[]	TYPES	= {
 		REGISTERED, MODIFIED, UNREGISTERING, MODIFIED_ENDMATCH
 	};
-	public static final Bitmap	BITMAP	= new Bitmap(TYPES, ServiceEventType::typeToString);
+	public static final Bitmap	BITMAP	= new Bitmap(TYPES, ServiceEventType::toString);
 }


### PR DESCRIPTION
`BundleEventType.class` and `BundleSate.class` uses `toString(int type)` to get a readable name.

`ServiceEventType.class` and `FrameworkEventType.class` have `typeToString(int type)`

we should take the same name for all.