### PR TITLE
[assertj] Conditions to test Objects and Lists

### DIFF
--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/BundleConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/BundleConditions.java
@@ -29,24 +29,26 @@ import org.osgi.framework.Bundle;
 /**
  * A Utility-Class thats Provides public static methods to create
  * {@link Condition}s for an {@link Bundle}
+ *
+ * @since 1.1
  */
 public final class BundleConditions {
 	/**
 	 * Creates a {@link Condition} to be met by an {@link Bundle}. Checking if a
-	 * {@link Bundle} is <b>equal</b> an other Bundle.
+	 * {@link Bundle} is <b>equal</b> to an other Bundle.
 	 * <p>
 	 * Example:
 	 *
 	 * <pre>
 	 * List<Bundle> bundles = null;
 	 *
-	 * public static void sameAs(Bundle bundle) {
+	 * public static void isEqualsTo(Bundle bundle) {
 	 *
 	 * 	assertThat(bundles)// created an {@link ListAssert}
-	 * 		.have(sameAs(bundle))
-	 * 		.filteredOn(sameAs(bundle))
+	 * 		.have(isEqualsTo(bundle))
+	 * 		.filteredOn(isEqualsTo(bundle))
 	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.is(sameAs(bundle));// used on {@link ObjectAssert}
+	 * 		.is(isEqualsTo(bundle));// used on {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -54,7 +56,7 @@ public final class BundleConditions {
 	 *            {@link Bundle}
 	 * @return the Condition<br>
 	 */
-	public static Condition<Bundle> sameAs(Bundle bundle) {
+	public static Condition<Bundle> isEqualsTo(Bundle bundle) {
 		Condition<Bundle> c = VerboseCondition.verboseCondition((b) -> Objects.equals(b, bundle), "bundle equals",
 			(b) -> " was <" + b.toString() + ">");
 		return c;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/BundleConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/BundleConditions.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.bundle;
+
+import java.util.Objects;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.condition.VerboseCondition;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * A Utility-Class thats Provides static methods to create {@link Condition}s
+ * for an {@link Bundle}
+ */
+public interface BundleConditions {
+	/**
+	 * Creates a {@link Condition} to be met by an {@link Bundle}. Checking if a
+	 * {@link Bundle} is <b>equal</b> an other Bundle.
+	 * <p>
+	 * Example:
+	 *
+	 * <pre>
+	 * List<Bundle> bundles = null;
+	 *
+	 * static void sameAs(Bundle bundle) {
+	 *
+	 * 	assertThat(bundles)// created an {@link ListAssert}
+	 * 		.have(sameAs(bundle))
+	 * 		.filteredOn(sameAs(bundle))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.is(sameAs(bundle));// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param serviceReferences - the expected serviceReferences that would be
+	 *            checked against other {@link ServiceReference}s
+	 * @return the Condition<br>
+	 */
+	static Condition<Bundle> sameAs(Bundle bundle) {
+		Condition<Bundle> c = VerboseCondition.verboseCondition((b) -> Objects.equals(b, bundle), "bundle equals",
+			(b) -> " was <" + b.toString() + ">");
+		return c;
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/BundleConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/BundleConditions.java
@@ -25,13 +25,12 @@ import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.condition.VerboseCondition;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.ServiceReference;
 
 /**
- * A Utility-Class thats Provides static methods to create {@link Condition}s
- * for an {@link Bundle}
+ * A Utility-Class thats Provides public static methods to create
+ * {@link Condition}s for an {@link Bundle}
  */
-public interface BundleConditions {
+public final class BundleConditions {
 	/**
 	 * Creates a {@link Condition} to be met by an {@link Bundle}. Checking if a
 	 * {@link Bundle} is <b>equal</b> an other Bundle.
@@ -41,7 +40,7 @@ public interface BundleConditions {
 	 * <pre>
 	 * List<Bundle> bundles = null;
 	 *
-	 * static void sameAs(Bundle bundle) {
+	 * public static void sameAs(Bundle bundle) {
 	 *
 	 * 	assertThat(bundles)// created an {@link ListAssert}
 	 * 		.have(sameAs(bundle))
@@ -51,11 +50,11 @@ public interface BundleConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param serviceReferences - the expected serviceReferences that would be
-	 *            checked against other {@link ServiceReference}s
+	 * @param bundle - the expected bundle that would be checked against other
+	 *            {@link Bundle}
 	 * @return the Condition<br>
 	 */
-	static Condition<Bundle> sameAs(Bundle bundle) {
+	public static Condition<Bundle> sameAs(Bundle bundle) {
 		Condition<Bundle> c = VerboseCondition.verboseCondition((b) -> Objects.equals(b, bundle), "bundle equals",
 			(b) -> " was <" + b.toString() + ">");
 		return c;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/package-info.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundle/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.assertj.bundle;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventConditions.java
@@ -33,6 +33,8 @@ import org.osgi.test.common.bitmaps.BundleEventType;
 /**
  * A Utility-Class thats Provides public static methods to create
  * {@link Condition}s for an {@link BundleEvent}
+ *
+ * @since 1.1
  */
 public final class BundleEventConditions {
 
@@ -62,7 +64,7 @@ public final class BundleEventConditions {
 	 */
 	public static Condition<BundleEvent> bundleEquals(Bundle bundle) {
 
-		return MappedCondition.mappedCondition(BundleEvent::getBundle, BundleConditions.sameAs(bundle),
+		return MappedCondition.mappedCondition(BundleEvent::getBundle, BundleConditions.isEqualsTo(bundle),
 			"BundleEvent::getBundle");
 	}
 
@@ -137,10 +139,9 @@ public final class BundleEventConditions {
 	 * 		.have(matches(typeMask, bundle, origin))
 	 * 		.filteredOn(matches(typeMask, bundle, origin))
 	 * 		.first()// map to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(matches(typeMask, bundle, origin));// used on {@link
-	 * 	// ObjectAssert}
+	 * 				// {@link ObjectAssert}
+	 * 		.has(matches(typeMask, bundle, origin));// used on
+	 * 			{@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -180,7 +181,7 @@ public final class BundleEventConditions {
 	 */
 	public static Condition<BundleEvent> originEquals(Bundle bundle) {
 
-		return MappedCondition.mappedCondition(BundleEvent::getOrigin, BundleConditions.sameAs(bundle),
+		return MappedCondition.mappedCondition(BundleEvent::getOrigin, BundleConditions.isEqualsTo(bundle),
 			"BundleEvent::getOrigin");
 	}
 
@@ -277,10 +278,9 @@ public final class BundleEventConditions {
 	 * 		.have(typeAndBundle(typeMask, bundle))
 	 * 		.filteredOn(typeAndBundle(typeMask, bundle))
 	 * 		.first()// map to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeAndBundle(typeMask, bundle));// used on {@link
-	 * 												// ObjectAssert}
+	 * 				// {@link ObjectAssert}
+	 * 		.has(typeAndBundle(typeMask, bundle));// used on
+	 * 				{@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventConditions.java
@@ -31,10 +31,10 @@ import org.osgi.test.common.bitmaps.Bitmap;
 import org.osgi.test.common.bitmaps.BundleEventType;
 
 /**
- * A Utility-Class thats Provides static methods to create {@link Condition}s
- * for an {@link BundleEvent}
+ * A Utility-Class thats Provides public static methods to create
+ * {@link Condition}s for an {@link BundleEvent}
  */
-public interface BundleEventConditions {
+public final class BundleEventConditions {
 
 	/**
 	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
@@ -46,7 +46,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_bundleEquals(Bundle bundle) {
+	 * public static void example_bundleEquals(Bundle bundle) {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(bundleEquals(bundle))
@@ -60,7 +60,7 @@ public interface BundleEventConditions {
 	 *            the {@link BundleEvent}
 	 * @return the Condition<br>
 	 */
-	static Condition<BundleEvent> bundleEquals(Bundle bundle) {
+	public static Condition<BundleEvent> bundleEquals(Bundle bundle) {
 
 		return MappedCondition.mappedCondition(BundleEvent::getBundle, BundleConditions.sameAs(bundle),
 			"BundleEvent::getBundle");
@@ -74,7 +74,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_bundleIsNotNull() {
+	 * public static void example_bundleIsNotNull() {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(bundleIsNotNull())
@@ -86,7 +86,7 @@ public interface BundleEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<BundleEvent> bundleIsNotNull() {
+	public static Condition<BundleEvent> bundleIsNotNull() {
 		return VerboseCondition.verboseCondition((be) -> be.getBundle() != null, "bundle is not <null>",
 			(be) -> " was <" + (be.getBundle() == null ? "null"
 				: be.getBundle()
@@ -102,7 +102,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_bundleIsNull() {
+	 * public static void example_bundleIsNull() {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(bundleIsNull())
@@ -114,7 +114,7 @@ public interface BundleEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<BundleEvent> bundleIsNull() {
+	public static Condition<BundleEvent> bundleIsNull() {
 		return VerboseCondition.verboseCondition((be) -> be.getBundle() == null, "bundle is <null>",
 			(be) -> " was <" + (be.getBundle() == null ? "null"
 				: be.getBundle()
@@ -131,7 +131,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_matches(int typeMask, Bundle bundle, Bundle origin) {
+	 * public static void example_matches(int typeMask, Bundle bundle, Bundle origin) {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(matches(typeMask, bundle, origin))
@@ -152,7 +152,7 @@ public interface BundleEventConditions {
 	 *            the {@link BundleEvent}
 	 * @return the Condition
 	 */
-	static Condition<BundleEvent> matches(int typeMask, Bundle bundle, Bundle origin) {
+	public static Condition<BundleEvent> matches(int typeMask, Bundle bundle, Bundle origin) {
 		return Assertions.allOf(type(typeMask), bundleEquals(bundle), originEquals(origin));
 	}
 
@@ -164,7 +164,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_originEquals(Bundle bundle) {
+	 * public static void example_originEquals(Bundle bundle) {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(originEquals(bundle))
@@ -178,7 +178,7 @@ public interface BundleEventConditions {
 	 *            the {@link BundleEvent}
 	 * @return the Condition
 	 */
-	static Condition<BundleEvent> originEquals(Bundle bundle) {
+	public static Condition<BundleEvent> originEquals(Bundle bundle) {
 
 		return MappedCondition.mappedCondition(BundleEvent::getOrigin, BundleConditions.sameAs(bundle),
 			"BundleEvent::getOrigin");
@@ -192,7 +192,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_originIsNotNull() {
+	 * public static void example_originIsNotNull() {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(originIsNotNull())
@@ -204,7 +204,7 @@ public interface BundleEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<BundleEvent> originIsNotNull() {
+	public static Condition<BundleEvent> originIsNotNull() {
 		return VerboseCondition.verboseCondition((be) -> be.getOrigin() != null, "origin is not <null>",
 			be -> " was" + be);
 	}
@@ -217,7 +217,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_originIsNull() {
+	 * public static void example_originIsNull() {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(originIsNull())
@@ -229,7 +229,7 @@ public interface BundleEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<BundleEvent> originIsNull() {
+	public static Condition<BundleEvent> originIsNull() {
 		return VerboseCondition.verboseCondition((be) -> be.getOrigin() == null, "origin is <null>",
 			be -> "was " + be);
 	}
@@ -242,7 +242,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_type(int typeMask) {
+	 * public static void example_type(int typeMask) {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(type(typeMask))
@@ -252,11 +252,11 @@ public interface BundleEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link BundleEvent}
+	 * @param expectedEventTypeMask - the typeMask that would be checked against
+	 *            the bundle type of the {@link BundleEvent}
 	 * @return the Condition
 	 */
-	static Condition<BundleEvent> type(final int expectedEventTypeMask) {
+	public static Condition<BundleEvent> type(final int expectedEventTypeMask) {
 		return VerboseCondition.verboseCondition(
 			(BundleEvent be) -> Bitmap.typeMatchesMask(be.getType(), expectedEventTypeMask),
 			"type matches mask <" + BundleEventType.BITMAP.maskToString(expectedEventTypeMask) + ">", //
@@ -271,7 +271,7 @@ public interface BundleEventConditions {
 	 * <pre>
 	 * List<BundleEvent> bundleEvents = null;
 	 *
-	 * static void example_typeAndBundle(int typeMask, Bundle bundle) {
+	 * public static void example_typeAndBundle(int typeMask, Bundle bundle) {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(typeAndBundle(typeMask, bundle))
@@ -290,540 +290,7 @@ public interface BundleEventConditions {
 	 *            the {@link BundleEvent}
 	 * @return the Condition
 	 */
-	static Condition<BundleEvent> typeAndBundle(int mask, Bundle bundle) {
-		return Assertions.allOf(type(mask), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.INSTALLED</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeInstalled()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeInstalled()))
-	 * 		.filteredOn(typeInstalled()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeInstalled());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeInstalled() {
-		return type(BundleEvent.INSTALLED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.INSTALLED</b>
-	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
-	 * lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeInstalledAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeInstalledAndBundleEquals(bundle))
-	 * 		.filteredOn(typeInstalledAndBundleEquals(bundle))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeInstalledAndBundleEquals(bundle));// used on {@link
-	 * 													// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeInstalledAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeInstalled(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches
-	 * BundleEvent.LAZY_ACTIVATION</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeLazyActivation()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeLazyActivation()))
-	 * 		.filteredOn(typeLazyActivation()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeLazyActivation());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeLazyActivation() {
-		return type(BundleEvent.LAZY_ACTIVATION);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is
-	 * <b>BundleEvent.LAZY_ACTIVATION</b> <i>and</i> the given {@link Bundle}
-	 * <b>equals</b> the Bundle of the of lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeLazyActivationAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeLazyActivationAndBundleEquals(bundle))
-	 * 		.filteredOn(typeLazyActivationAndBundleEquals(bundle))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeLazyActivationAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeLazyActivationAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeLazyActivation(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.RESOLVED</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeResolved()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeResolved()))
-	 * 		.filteredOn(typeResolved()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeResolved());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeResolved() {
-		return type(BundleEvent.RESOLVED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.RESOLVED</b>
-	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
-	 * lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeResolvedAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeResolvedAndBundleEquals(bundle))
-	 * 		.filteredOn(typeResolvedAndBundleEquals(bundle))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeResolvedAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeResolvedAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeResolved(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.STARTED</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeStarted()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeStarted()))
-	 * 		.filteredOn(typeStarted()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeStarted());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeStarted() {
-		return type(BundleEvent.STARTED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.STARTED</b>
-	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
-	 * lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeStartedAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeStartedAndBundleEquals(bundle))
-	 * 		.filteredOn(typeStartedAndBundleEquals(bundle))
-	 * 		.first()// map to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeStartedAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeStartedAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeStarted(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.STARTING</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeStarting()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeStarting()))
-	 * 		.filteredOn(typeStarting()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeStarting());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeStarting() {
-		return type(BundleEvent.STARTING);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.STARTING</b>
-	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
-	 * lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeStartingAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeStartingAndBundleEquals(bundle))
-	 * 		.filteredOn(typeStartingAndBundleEquals(bundle))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeStartingAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeStartingAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeStarting(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.STOPPED</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeStopped()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeStopped()))
-	 * 		.filteredOn(typeStopped()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeStopped());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeStopped() {
-		return type(BundleEvent.STOPPED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.STOPPED</b>
-	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
-	 * lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeStoppedAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeStoppedAndBundleEquals(bundle))
-	 * 		.filteredOn(typeStoppedAndBundleEquals(bundle))
-	 * 		.first()// map to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeStoppedAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeStoppedAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeStopped(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.STOPPING</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeStopping()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeStopping()))
-	 * 		.filteredOn(typeStopping()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeStopping());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeStopping() {
-		return type(BundleEvent.STOPPING);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.STOPPING</b>
-	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
-	 * lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeStoppingAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeStoppingAndBundleEquals(bundle))
-	 * 		.filteredOn(typeStoppingAndBundleEquals(bundle))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeStoppingAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeStoppingAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeStopping(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.UNINSTALLED</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeUninstalled()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeUninstalled()))
-	 * 		.filteredOn(typeUninstalled()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeUninstalled());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeUninstalled() {
-		return type(BundleEvent.UNINSTALLED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is
-	 * <b>BundleEvent.UNINSTALLED</b> <i>and</i> the given {@link Bundle}
-	 * <b>equals</b> the Bundle of the of lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeUninstalledAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeUninstalledAndBundleEquals(bundle))
-	 * 		.filteredOn(typeUninstalledAndBundleEquals(bundle))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeUninstalledAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeUninstalledAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeUninstalled(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.UNRESOLVED</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeUnresolved()) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeUnresolved()))
-	 * 		.filteredOn(typeUnresolved()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeUnresolved());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeUnresolved() {
-		return type(BundleEvent.UNRESOLVED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.UNRESOLVED</b>
-	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
-	 * lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeUnresolvedAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeUnresolvedAndBundleEquals(bundle))
-	 * 		.filteredOn(typeUnresolvedAndBundleEquals(bundle))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeUnresolvedAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeUnresolvedAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeUnresolved(), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if the {@link BundleEvent} type <b>matches BundleEvent.UPDATED</b>.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeUpdated() {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeUpdated()))
-	 * 		.filteredOn(typeUpdated()))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeUpdated());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeUpdated() {
-		return type(BundleEvent.UPDATED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
-	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.UPDATED</b>
-	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
-	 * lifecyle event.
-	 *
-	 * <pre>
-	 * List<BundleEvent> bundleEvents = null;
-	 *
-	 * static void example_typeUpdatedAndBundleEquals(Bundle bundle) {
-	 *
-	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
-	 * 		.have(typeUpdatedAndBundleEquals(bundle))
-	 * 		.filteredOn(typeUpdatedAndBundleEquals(bundle))
-	 * 		.first()// map to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeUpdatedAndBundleEquals(bundle));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param bundle - the bundle that would be checked against the bundle of
-	 *            the {@link BundleEvent}
-	 * @return the Condition
-	 */
-	static Condition<BundleEvent> typeUpdatedAndBundleEquals(Bundle bundle) {
-		return Assertions.allOf(typeUpdated(), bundleEquals(bundle));
+	public static Condition<BundleEvent> typeAndBundle(int typeMask, Bundle bundle) {
+		return Assertions.allOf(type(typeMask), bundleEquals(bundle));
 	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventConditions.java
@@ -1,0 +1,829 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.bundleevent;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.condition.MappedCondition;
+import org.assertj.core.condition.VerboseCondition;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.test.assertj.bundle.BundleConditions;
+import org.osgi.test.common.bitmaps.Bitmap;
+import org.osgi.test.common.bitmaps.BundleEventType;
+
+/**
+ * A Utility-Class thats Provides static methods to create {@link Condition}s
+ * for an {@link BundleEvent}
+ */
+public interface BundleEventConditions {
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a {@link Bundle} is <b>equal</b> the bundle of the {@link BundleEvent}
+	 * that had a change occur in its lifecycle.
+	 * <p>
+	 * Example:
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_bundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(bundleEquals(bundle))
+	 * 		.filteredOn(bundleEquals(bundle))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(bundleEquals(bundle));// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition<br>
+	 */
+	static Condition<BundleEvent> bundleEquals(Bundle bundle) {
+
+		return MappedCondition.mappedCondition(BundleEvent::getBundle, BundleConditions.sameAs(bundle),
+			"BundleEvent::getBundle");
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the bundle of the {@link BundleEvent} that had a change occur in its
+	 * lifecycle <b>is not null</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_bundleIsNotNull() {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(bundleIsNotNull())
+	 * 		.filteredOn(bundleIsNotNull())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(bundleIsNotNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> bundleIsNotNull() {
+		return VerboseCondition.verboseCondition((be) -> be.getBundle() != null, "bundle is not <null>",
+			(be) -> " was <" + (be.getBundle() == null ? "null"
+				: be.getBundle()
+					.toString())
+				+ ">");
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the bundle of the {@link BundleEvent} that had a change occur in its
+	 * lifecycle <b>is null</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_bundleIsNull() {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(bundleIsNull())
+	 * 		.filteredOn(bundleIsNull())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(bundleIsNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> bundleIsNull() {
+		return VerboseCondition.verboseCondition((be) -> be.getBundle() == null, "bundle is <null>",
+			(be) -> " was <" + (be.getBundle() == null ? "null"
+				: be.getBundle()
+					.toString())
+				+ ">");
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a given type-mask <b>matches</b> the type <i>and</i> the given
+	 * {@link Bundle} <b>equals</b> the Bundle and the other given
+	 * {@link Bundle} <b>equals</b> the origin of the of lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_matches(int typeMask, Bundle bundle, Bundle origin) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(matches(typeMask, bundle, origin))
+	 * 		.filteredOn(matches(typeMask, bundle, origin))
+	 * 		.first()// map to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(matches(typeMask, bundle, origin));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link BundleEvent}
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @param origin - the bundle that would be checked against the origin of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> matches(int typeMask, Bundle bundle, Bundle origin) {
+		return Assertions.allOf(type(typeMask), bundleEquals(bundle), originEquals(origin));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a {@link Bundle} is <b>equal</b> the bundle of the {@link BundleEvent}
+	 * that was the origin of the event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_originEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(originEquals(bundle))
+	 * 		.filteredOn(originEquals(bundle))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(originEquals(bundle));// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> originEquals(Bundle bundle) {
+
+		return MappedCondition.mappedCondition(BundleEvent::getOrigin, BundleConditions.sameAs(bundle),
+			"BundleEvent::getOrigin");
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the bundle of the {@link BundleEvent} that was the origin of the
+	 * event. <b>is not null</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_originIsNotNull() {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(originIsNotNull())
+	 * 		.filteredOn(originIsNotNull())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(originIsNotNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> originIsNotNull() {
+		return VerboseCondition.verboseCondition((be) -> be.getOrigin() != null, "origin is not <null>",
+			be -> " was" + be);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the bundle of the {@link BundleEvent} that was the origin of the
+	 * event. <b>is null</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_originIsNull() {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(originIsNull())
+	 * 		.filteredOn(originIsNull())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(originIsNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> originIsNull() {
+		return VerboseCondition.verboseCondition((be) -> be.getOrigin() == null, "origin is <null>",
+			be -> "was " + be);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a type-mask <b>matches</b> the {@link BundleEvent} type of lifecyle
+	 * event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_type(int typeMask) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(type(typeMask))
+	 * 		.filteredOn(type(typeMask))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(type(typeMask));// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> type(final int expectedEventTypeMask) {
+		return VerboseCondition.verboseCondition(
+			(BundleEvent be) -> Bitmap.typeMatchesMask(be.getType(), expectedEventTypeMask),
+			"type matches mask <" + BundleEventType.BITMAP.maskToString(expectedEventTypeMask) + ">", //
+			be -> " was <" + BundleEventType.BITMAP.toString(be.getType()) + ">");
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a given type-mask <b>matches</b> the type <i>and</i> the given
+	 * {@link Bundle} <b>equals</b> the Bundle of the of lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeAndBundle(int typeMask, Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeAndBundle(typeMask, bundle))
+	 * 		.filteredOn(typeAndBundle(typeMask, bundle))
+	 * 		.first()// map to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeAndBundle(typeMask, bundle));// used on {@link
+	 * 												// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link BundleEvent}
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeAndBundle(int mask, Bundle bundle) {
+		return Assertions.allOf(type(mask), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.INSTALLED</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeInstalled()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeInstalled()))
+	 * 		.filteredOn(typeInstalled()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeInstalled());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeInstalled() {
+		return type(BundleEvent.INSTALLED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.INSTALLED</b>
+	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
+	 * lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeInstalledAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeInstalledAndBundleEquals(bundle))
+	 * 		.filteredOn(typeInstalledAndBundleEquals(bundle))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeInstalledAndBundleEquals(bundle));// used on {@link
+	 * 													// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeInstalledAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeInstalled(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches
+	 * BundleEvent.LAZY_ACTIVATION</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeLazyActivation()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeLazyActivation()))
+	 * 		.filteredOn(typeLazyActivation()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeLazyActivation());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeLazyActivation() {
+		return type(BundleEvent.LAZY_ACTIVATION);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is
+	 * <b>BundleEvent.LAZY_ACTIVATION</b> <i>and</i> the given {@link Bundle}
+	 * <b>equals</b> the Bundle of the of lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeLazyActivationAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeLazyActivationAndBundleEquals(bundle))
+	 * 		.filteredOn(typeLazyActivationAndBundleEquals(bundle))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeLazyActivationAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeLazyActivationAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeLazyActivation(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.RESOLVED</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeResolved()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeResolved()))
+	 * 		.filteredOn(typeResolved()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeResolved());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeResolved() {
+		return type(BundleEvent.RESOLVED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.RESOLVED</b>
+	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
+	 * lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeResolvedAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeResolvedAndBundleEquals(bundle))
+	 * 		.filteredOn(typeResolvedAndBundleEquals(bundle))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeResolvedAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeResolvedAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeResolved(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.STARTED</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeStarted()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeStarted()))
+	 * 		.filteredOn(typeStarted()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeStarted());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeStarted() {
+		return type(BundleEvent.STARTED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.STARTED</b>
+	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
+	 * lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeStartedAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeStartedAndBundleEquals(bundle))
+	 * 		.filteredOn(typeStartedAndBundleEquals(bundle))
+	 * 		.first()// map to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeStartedAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeStartedAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeStarted(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.STARTING</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeStarting()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeStarting()))
+	 * 		.filteredOn(typeStarting()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeStarting());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeStarting() {
+		return type(BundleEvent.STARTING);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.STARTING</b>
+	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
+	 * lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeStartingAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeStartingAndBundleEquals(bundle))
+	 * 		.filteredOn(typeStartingAndBundleEquals(bundle))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeStartingAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeStartingAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeStarting(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.STOPPED</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeStopped()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeStopped()))
+	 * 		.filteredOn(typeStopped()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeStopped());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeStopped() {
+		return type(BundleEvent.STOPPED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.STOPPED</b>
+	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
+	 * lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeStoppedAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeStoppedAndBundleEquals(bundle))
+	 * 		.filteredOn(typeStoppedAndBundleEquals(bundle))
+	 * 		.first()// map to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeStoppedAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeStoppedAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeStopped(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.STOPPING</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeStopping()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeStopping()))
+	 * 		.filteredOn(typeStopping()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeStopping());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeStopping() {
+		return type(BundleEvent.STOPPING);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.STOPPING</b>
+	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
+	 * lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeStoppingAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeStoppingAndBundleEquals(bundle))
+	 * 		.filteredOn(typeStoppingAndBundleEquals(bundle))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeStoppingAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeStoppingAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeStopping(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.UNINSTALLED</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeUninstalled()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeUninstalled()))
+	 * 		.filteredOn(typeUninstalled()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeUninstalled());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeUninstalled() {
+		return type(BundleEvent.UNINSTALLED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is
+	 * <b>BundleEvent.UNINSTALLED</b> <i>and</i> the given {@link Bundle}
+	 * <b>equals</b> the Bundle of the of lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeUninstalledAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeUninstalledAndBundleEquals(bundle))
+	 * 		.filteredOn(typeUninstalledAndBundleEquals(bundle))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeUninstalledAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeUninstalledAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeUninstalled(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.UNRESOLVED</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeUnresolved()) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeUnresolved()))
+	 * 		.filteredOn(typeUnresolved()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeUnresolved());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeUnresolved() {
+		return type(BundleEvent.UNRESOLVED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.UNRESOLVED</b>
+	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
+	 * lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeUnresolvedAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeUnresolvedAndBundleEquals(bundle))
+	 * 		.filteredOn(typeUnresolvedAndBundleEquals(bundle))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeUnresolvedAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeUnresolvedAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeUnresolved(), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if the {@link BundleEvent} type <b>matches BundleEvent.UPDATED</b>.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeUpdated() {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeUpdated()))
+	 * 		.filteredOn(typeUpdated()))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeUpdated());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeUpdated() {
+		return type(BundleEvent.UPDATED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link BundleEvent}. Checking
+	 * if a the type of the {@link BundleEvent} is <b>BundleEvent.UPDATED</b>
+	 * <i>and</i> the given {@link Bundle} <b>equals</b> the Bundle of the of
+	 * lifecyle event.
+	 *
+	 * <pre>
+	 * List<BundleEvent> bundleEvents = null;
+	 *
+	 * static void example_typeUpdatedAndBundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(typeUpdatedAndBundleEquals(bundle))
+	 * 		.filteredOn(typeUpdatedAndBundleEquals(bundle))
+	 * 		.first()// map to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeUpdatedAndBundleEquals(bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link BundleEvent}
+	 * @return the Condition
+	 */
+	static Condition<BundleEvent> typeUpdatedAndBundleEquals(Bundle bundle) {
+		return Assertions.allOf(typeUpdated(), bundleEquals(bundle));
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/DictionaryConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/DictionaryConditions.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.dictionary;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.assertj.core.api.Condition;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+/**
+ * A Utility-Class thats Provides static methods to create {@link Condition}s
+ * for an {@link Dictionary}
+ */
+public interface DictionaryConditions {
+	static Condition<Dictionary<String, Object>> servicePropertiesContains(Dictionary<String, Object> dictionary) {
+		return servicePropertiesContains(Dictionaries.asMap(dictionary));
+	}
+
+	static Condition<Dictionary<String, Object>> servicePropertiesMatch(String filter) throws InvalidSyntaxException {
+		Filter f = FrameworkUtil.createFilter(filter);
+
+		return new Condition<Dictionary<String, Object>>(d -> {
+			return f.match(d);
+		}, "machts filter %s", filter);
+
+	}
+
+	static Condition<Dictionary<String, Object>> servicePropertiesContains(Map<String, Object> map) {
+		return new Condition<Dictionary<String, Object>>(d -> {
+			List<String> keys = Collections.list(d.keys());
+			for (Entry<String, Object> entry : map.entrySet()) {
+				if (!keys.contains(entry.getKey())) {
+					return false;
+				}
+				if (!Objects.equals(d.get(entry.getKey()), entry.getValue())) {
+					return false;
+				}
+			}
+			return true;
+		}, "contains ServiceProperties %s", map);
+	}
+
+	static Condition<Dictionary<String, Object>> servicePropertyContains(final String key, Object value) {
+		return servicePropertiesContains(Dictionaries.dictionaryOf(key, value));
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/package-info.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.assertj.dictionary;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventConditions.java
@@ -1,0 +1,708 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.frameworkevent;
+
+import static org.assertj.core.api.Assertions.allOf;
+import static org.assertj.core.api.Assertions.not;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.condition.MappedCondition;
+import org.assertj.core.condition.VerboseCondition;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.test.assertj.bundle.BundleConditions;
+import org.osgi.test.common.bitmaps.Bitmap;
+import org.osgi.test.common.bitmaps.FrameworkEventType;
+
+/**
+ * A Utility-Class thats Provides static methods to create
+ * {@link FrameworkEventConditions} for an {@link FrameworkEvent}
+ */
+public interface FrameworkEventConditions {
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if a {@link Bundle} is <b>equal</b> the bundle that is
+	 * associated with the event {@link BundleEvent}.
+	 * <p>
+	 * Example:
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_bundleEquals(Bundle bundle) {
+	 *
+	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
+	 * 		.have(bundleEquals(bundle))
+	 * 		.filteredOn(bundleEquals(bundle))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(bundleEquals(bundle));// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link FrameworkEvent}
+	 * @return the Condition<br>
+	 */
+	static Condition<FrameworkEvent> bundleEquals(Bundle bundle) {
+
+		return MappedCondition.mappedCondition(FrameworkEvent::getBundle, BundleConditions.sameAs(bundle),
+			"FrameworkEvent::getBundle");
+
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if the bundle that is associated with the eventof the
+	 * {@link FrameworkEvent} <b>is not null</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_bundleIsNotNull() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(bundleIsNotNull())
+	 * 		.filteredOn(bundleIsNotNull())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(bundleIsNotNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> bundleIsNotNull() {
+		return not(bundleIsNull());
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if the bundle that is associated with the eventof the
+	 * {@link FrameworkEvent} <b>is null</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_bundleIsNull() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(bundleIsNull())
+	 * 		.filteredOn(bundleIsNull())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(bundleIsNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> bundleIsNull() {
+		return VerboseCondition.verboseCondition((fe) -> fe.getBundle() == null, "bundle is <null>",
+			(fe) -> " was <" + fe.getBundle() + ">".toString());
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type <i>and</i> the
+	 * given {@link Bundle} <b>equals</b> the Bundle and the throwable is an
+	 * instanceof the throwableClass.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_matches(int typeMask, Bundle bundle, Class<? extends Throwable> throwableClass) {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(matches(typeMask, bundle, throwableClass))
+	 * 		.filteredOn(matches(typeMask, bundle, throwableClass))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(matches(typeMask, bundle, throwableClass));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link FrameworkEvent}
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link FrameworkEvent}
+	 * @param throwableClass - the Class that would be checked against the
+	 *            throwable of the {@link FrameworkEvent}
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> matches(final int eventTypeMask, Bundle bundle,
+		final Class<? extends Throwable> throwableClass) {
+		return Assertions.allOf(type(eventTypeMask), bundleEquals(bundle), throwableOfClass(throwableClass));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type <i>and</i> the
+	 * throwable is an instanceof the throwableClass.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_matches(int typeMask, Class<? extends Throwable> throwableClass) {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(matches(typeMask, throwableClass))
+	 * 		.filteredOn(matches(typeMask, throwableClass))
+	 * 		.first()// map to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(matches(typeMask, throwableClass));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link FrameworkEvent}
+	 * @param throwableClass - the Class that would be checked against the
+	 *            throwable of the {@link FrameworkEvent}
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> matches(final int eventTypeMask, final Class<? extends Throwable> throwableClass) {
+		return Assertions.allOf(type(eventTypeMask), throwableOfClass(throwableClass));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if a throwable is not null.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_throwableIsNotNull() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(throwableIsNotNull())
+	 * 		.filteredOn(throwableIsNotNull())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(throwableIsNotNull());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> throwableIsNotNull() {
+		return not(throwableIsNull());
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if a throwable is null.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_throwableIsNull() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(throwableIsNull())
+	 * 		.filteredOn(throwableIsNull())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(throwableIsNull());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> throwableIsNull() {
+		return VerboseCondition.verboseCondition((fe) -> fe.getThrowable() == null, "throwable is <null>",
+			(fe) -> fe.getThrowable()
+				.toString());
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if a throwable is an instanceof the throwableClass.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_throwableOfClass(Class<? extends Throwable> throwableClass) {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(throwableOfClass(throwableClass))
+	 * 		.filteredOn(throwableOfClass(throwableClass))
+	 * 		.first()// map to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(throwableOfClass(throwableClass));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param throwableClass - the Class that would be checked against the
+	 *            throwable of the {@link FrameworkEvent}
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> throwableOfClass(final Class<? extends Throwable> throwableClass) {
+
+		Condition<FrameworkEvent> cond = VerboseCondition.verboseCondition((fe) -> fe.getThrowable()
+			.getClass()
+			.isAssignableFrom(throwableClass), "throwable of class",
+			fe -> fe.getThrowable()
+				.toString());
+
+		return allOf(throwableIsNotNull(), cond);//
+
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_type(int typeMask) {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(type(type))
+	 * 		.filteredOn(type(typeMask))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(type(typeMask));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link FrameworkEvent}
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> type(final int eventTypeMask) {
+
+		return VerboseCondition.verboseCondition(
+			(FrameworkEvent fe) -> Bitmap.typeMatchesMask(fe.getType(), eventTypeMask),
+			"type matches mask <" + FrameworkEventType.BITMAP.maskToString(eventTypeMask) + ">", //
+			fe -> " was <" + FrameworkEventType.BITMAP.toString(fe.getType()) + ">");
+
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type <i>and</i> the
+	 * given {@link Bundle} <b>equals</b> the Bundle.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeAndBundle(int typeMask, Bundle bundle) {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeAndBundle(typeMask, bundles))
+	 * 		.filteredOn(typeAndBundle(typeMask, bundle))
+	 * 		.first()// map to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeAndBundle(typeMask, bundle));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link FrameworkEvent}
+	 * @param bundle - the bundle that would be checked against the bundle of
+	 *            the {@link FrameworkEvent}
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> typeAndBundle(final int eventTypeMask, Bundle bundle) {
+		return Assertions.allOf(type(eventTypeMask), bundleEquals(bundle));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.ERROR</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeError() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeError())
+	 * 		.filteredOn(typeError())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeError());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> typeError() {
+		return type(FrameworkEvent.ERROR);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.ERROR</b> and the throwable of the
+	 * {@link FrameworkEvent} is an instance of the given Class.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeErrorAndThrowableOfClass(Class<? extends Throwable> throwableClass) {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeErrorAndThrowableOfClass(throwableClass))
+	 * 		.filteredOn(typeErrorAndThrowableOfClass(throwableClass))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeErrorAndThrowableOfClass(throwableClass));// used on
+	 * 															// {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param throwableClass - the Class that would be checked against the
+	 *            throwable of the {@link FrameworkEvent}
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> typeErrorAndThrowableOfClass(final Class<? extends Throwable> throwableClass) {
+		return Assertions.allOf(typeError(), throwableOfClass(throwableClass));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.INFO</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeInfo() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeInfo())
+	 * 		.filteredOn(typeInfo())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeInfo());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+
+	static Condition<FrameworkEvent> typeInfo() {
+		return type(FrameworkEvent.INFO);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.INFO</b> and the throwable of the
+	 * {@link FrameworkEvent} is an instance of the given Class.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeInfoAndThrowableOfClass(Class<? extends Throwable> throwableClass) {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeInfoAndThrowableOfClass(throwableClass))
+	 * 		.filteredOn(typeInfoAndThrowableOfClass(throwableClass))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeInfoAndThrowableOfClass(throwableClass));// used on
+	 * 															// {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param throwableClass - the Class that would be checked against the
+	 *            throwable of the {@link FrameworkEvent}
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> typeInfoAndThrowableOfClass(final Class<? extends Throwable> throwableClass) {
+		return Assertions.allOf(typeInfo(), throwableOfClass(throwableClass));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.PACKAGES_REFRESHED</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typePackagesRefreshed() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typePackagesRefreshed())
+	 * 		.filteredOn(typePackagesRefreshed())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typePackagesRefreshed());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+
+	static Condition<FrameworkEvent> typePackagesRefreshed() {
+		return type(FrameworkEvent.PACKAGES_REFRESHED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.STARTED</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeStarted() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeStarted())
+	 * 		.filteredOn(typeStarted())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeStarted());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+
+	static Condition<FrameworkEvent> typeStarted() {
+		return type(FrameworkEvent.STARTED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.STARTLEVEL_CHANGED</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeStartLevelChanged() {
+	 *
+	 * 	assertThat(typeStartLevelChanged)// created an {@link ListAssert}
+	 * 		.have(typeError())
+	 * 		.filteredOn(typeStartLevelChanged())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeStartLevelChanged());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+
+	static Condition<FrameworkEvent> typeStartLevelChanged() {
+		return type(FrameworkEvent.STARTLEVEL_CHANGED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.STOPPED</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeStopped() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeStopped())
+	 * 		.filteredOn(typeStopped())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeStopped());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+
+	static Condition<FrameworkEvent> typeStopped() {
+		return type(FrameworkEvent.STOPPED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeStopped_BootClasspathModified() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeStopped_BootClasspathModified())
+	 * 		.filteredOn(typeStopped_BootClasspathModified())
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeStopped_BootClasspathModified());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+
+	static Condition<FrameworkEvent> typeStopped_BootClasspathModified() {
+		return type(FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED);
+	}
+
+	// /**
+	// * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	// * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	// * <b>FrameworkEvent.STOPPED_SYSTEM_REFRESHED</b>.
+	// *
+	// * <pre>
+	// * List<FrameworkEvent> frameworkEvents = null;
+	// *
+	// * static void example_typeStoppedSystemRefreshes() {
+	// *
+	// * assertThat(frameworkEvents)// created an {@link ListAssert}
+	// * .have(typeStoppedSystemRefreshes())
+	// * .filteredOn(typeStoppedSystemRefreshes())
+	// * .first()// map to {@link ObjectAssert}
+	// * .has(typeStoppedSystemRefreshes());// used on {@link
+	// * // ObjectAssert}
+	// * }
+	// * </pre>
+	// *
+	// * @return the Condition
+	// */
+	//
+	// static Condition<FrameworkEvent> typeStoppedSystemRefreshes() {
+	// return type(FrameworkEvent.STOPPED_SYSTEM_REFRESHED);
+	// }
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.STOPPED_UPDATE</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeUpdate() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeUpdate())
+	 * 		.filteredOn(typeUpdate())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeUpdate());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> typeStoppedUpdate() {
+		return type(FrameworkEvent.STOPPED_UPDATE);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.WAIT_TIMEDOUT</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeWaitTimeout() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeWaitTimeout())
+	 * 		.filteredOn(typeWaitTimeout())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeWaitTimeout());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+
+	static Condition<FrameworkEvent> typeWaitTimeout() {
+		return type(FrameworkEvent.WAIT_TIMEDOUT);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.WARNING</b>.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeWarning() {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeWarning())
+	 * 		.filteredOn(typeWarning())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeWarning());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> typeWarning() {
+		return type(FrameworkEvent.WARNING);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
+	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
+	 * <b>FrameworkEvent.WARNING</b> and the throwable of the
+	 * {@link FrameworkEvent} is an instance of the given Class.
+	 *
+	 * <pre>
+	 * List<FrameworkEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeInfoAndThrowableOfClass(Class<? extends Throwable> throwableClass) {
+	 *
+	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
+	 * 		.have(typeInfoAndThrowableOfClass(throwableClass))
+	 * 		.filteredOn(typeInfoAndThrowableOfClass(throwableClass))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeInfoAndThrowableOfClass(throwableClass));// used on
+	 * 															// {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param throwableClass - the Class that would be checked against the
+	 *            throwable of the {@link FrameworkEvent}
+	 * @return the Condition
+	 */
+	static Condition<FrameworkEvent> typeWarningAndThrowableOfClass(final Class<? extends Throwable> throwableClass) {
+		return Assertions.allOf(typeWarning(), throwableOfClass(throwableClass));
+	}
+
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventConditions.java
@@ -35,10 +35,10 @@ import org.osgi.test.common.bitmaps.Bitmap;
 import org.osgi.test.common.bitmaps.FrameworkEventType;
 
 /**
- * A Utility-Class thats Provides static methods to create
+ * A Utility-Class thats Provides public static methods to create
  * {@link FrameworkEventConditions} for an {@link FrameworkEvent}
  */
-public interface FrameworkEventConditions {
+public final class FrameworkEventConditions {
 
 	/**
 	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
@@ -50,7 +50,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_bundleEquals(Bundle bundle) {
+	 * public static void example_bundleEquals(Bundle bundle) {
 	 *
 	 * 	assertThat(bundleEvents)// created an {@link ListAssert}
 	 * 		.have(bundleEquals(bundle))
@@ -64,7 +64,7 @@ public interface FrameworkEventConditions {
 	 *            the {@link FrameworkEvent}
 	 * @return the Condition<br>
 	 */
-	static Condition<FrameworkEvent> bundleEquals(Bundle bundle) {
+	public static Condition<FrameworkEvent> bundleEquals(Bundle bundle) {
 
 		return MappedCondition.mappedCondition(FrameworkEvent::getBundle, BundleConditions.sameAs(bundle),
 			"FrameworkEvent::getBundle");
@@ -79,7 +79,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_bundleIsNotNull() {
+	 * public static void example_bundleIsNotNull() {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(bundleIsNotNull())
@@ -91,7 +91,7 @@ public interface FrameworkEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> bundleIsNotNull() {
+	public static Condition<FrameworkEvent> bundleIsNotNull() {
 		return not(bundleIsNull());
 	}
 
@@ -103,7 +103,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_bundleIsNull() {
+	 * public static void example_bundleIsNull() {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(bundleIsNull())
@@ -115,7 +115,7 @@ public interface FrameworkEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> bundleIsNull() {
+	public static Condition<FrameworkEvent> bundleIsNull() {
 		return VerboseCondition.verboseCondition((fe) -> fe.getBundle() == null, "bundle is <null>",
 			(fe) -> " was <" + fe.getBundle() + ">".toString());
 	}
@@ -129,7 +129,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_matches(int typeMask, Bundle bundle, Class<? extends Throwable> throwableClass) {
+	 * public static void example_matches(int typeMask, Bundle bundle, Class<? extends Throwable> throwableClass) {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(matches(typeMask, bundle, throwableClass))
@@ -140,15 +140,15 @@ public interface FrameworkEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link FrameworkEvent}
+	 * @param eventTypeMask - the typeMask that would be checked against the
+	 *            bundle type of the {@link FrameworkEvent}
 	 * @param bundle - the bundle that would be checked against the bundle of
 	 *            the {@link FrameworkEvent}
 	 * @param throwableClass - the Class that would be checked against the
 	 *            throwable of the {@link FrameworkEvent}
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> matches(final int eventTypeMask, Bundle bundle,
+	public static Condition<FrameworkEvent> matches(final int eventTypeMask, Bundle bundle,
 		final Class<? extends Throwable> throwableClass) {
 		return Assertions.allOf(type(eventTypeMask), bundleEquals(bundle), throwableOfClass(throwableClass));
 	}
@@ -161,7 +161,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_matches(int typeMask, Class<? extends Throwable> throwableClass) {
+	 * public static void example_matches(int typeMask, Class<? extends Throwable> throwableClass) {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(matches(typeMask, throwableClass))
@@ -174,13 +174,13 @@ public interface FrameworkEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link FrameworkEvent}
+	 * @param eventTypeMask - the typeMask that would be checked against the
+	 *            bundle type of the {@link FrameworkEvent}
 	 * @param throwableClass - the Class that would be checked against the
 	 *            throwable of the {@link FrameworkEvent}
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> matches(final int eventTypeMask, final Class<? extends Throwable> throwableClass) {
+	public static Condition<FrameworkEvent> matches(final int eventTypeMask, final Class<? extends Throwable> throwableClass) {
 		return Assertions.allOf(type(eventTypeMask), throwableOfClass(throwableClass));
 	}
 
@@ -191,7 +191,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_throwableIsNotNull() {
+	 * public static void example_throwableIsNotNull() {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(throwableIsNotNull())
@@ -204,7 +204,7 @@ public interface FrameworkEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> throwableIsNotNull() {
+	public static Condition<FrameworkEvent> throwableIsNotNull() {
 		return not(throwableIsNull());
 	}
 
@@ -215,7 +215,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_throwableIsNull() {
+	 * public static void example_throwableIsNull() {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(throwableIsNull())
@@ -228,7 +228,7 @@ public interface FrameworkEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> throwableIsNull() {
+	public static Condition<FrameworkEvent> throwableIsNull() {
 		return VerboseCondition.verboseCondition((fe) -> fe.getThrowable() == null, "throwable is <null>",
 			(fe) -> fe.getThrowable()
 				.toString());
@@ -241,7 +241,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_throwableOfClass(Class<? extends Throwable> throwableClass) {
+	 * public static void example_throwableOfClass(Class<? extends Throwable> throwableClass) {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(throwableOfClass(throwableClass))
@@ -258,7 +258,7 @@ public interface FrameworkEventConditions {
 	 *            throwable of the {@link FrameworkEvent}
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> throwableOfClass(final Class<? extends Throwable> throwableClass) {
+	public static Condition<FrameworkEvent> throwableOfClass(final Class<? extends Throwable> throwableClass) {
 
 		Condition<FrameworkEvent> cond = VerboseCondition.verboseCondition((fe) -> fe.getThrowable()
 			.getClass()
@@ -277,7 +277,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_type(int typeMask) {
+	 * public static void example_type(int typeMask) {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(type(type))
@@ -288,11 +288,11 @@ public interface FrameworkEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link FrameworkEvent}
+	 * @param eventTypeMask - the typeMask that would be checked against the
+	 *            bundle type of the {@link FrameworkEvent}
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> type(final int eventTypeMask) {
+	public static Condition<FrameworkEvent> type(final int eventTypeMask) {
 
 		return VerboseCondition.verboseCondition(
 			(FrameworkEvent fe) -> Bitmap.typeMatchesMask(fe.getType(), eventTypeMask),
@@ -309,7 +309,7 @@ public interface FrameworkEventConditions {
 	 * <pre>
 	 * List<FrameworkEvent> frameworkEvents = null;
 	 *
-	 * static void example_typeAndBundle(int typeMask, Bundle bundle) {
+	 * public static void example_typeAndBundle(int typeMask, Bundle bundle) {
 	 *
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(typeAndBundle(typeMask, bundles))
@@ -322,387 +322,14 @@ public interface FrameworkEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link FrameworkEvent}
+	 * @param eventTypeMask - the typeMask that would be checked against the
+	 *            bundle type of the {@link FrameworkEvent}
 	 * @param bundle - the bundle that would be checked against the bundle of
 	 *            the {@link FrameworkEvent}
 	 * @return the Condition
 	 */
-	static Condition<FrameworkEvent> typeAndBundle(final int eventTypeMask, Bundle bundle) {
+	public static Condition<FrameworkEvent> typeAndBundle(final int eventTypeMask, Bundle bundle) {
 		return Assertions.allOf(type(eventTypeMask), bundleEquals(bundle));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.ERROR</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeError() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeError())
-	 * 		.filteredOn(typeError())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeError());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<FrameworkEvent> typeError() {
-		return type(FrameworkEvent.ERROR);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.ERROR</b> and the throwable of the
-	 * {@link FrameworkEvent} is an instance of the given Class.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeErrorAndThrowableOfClass(Class<? extends Throwable> throwableClass) {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeErrorAndThrowableOfClass(throwableClass))
-	 * 		.filteredOn(typeErrorAndThrowableOfClass(throwableClass))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeErrorAndThrowableOfClass(throwableClass));// used on
-	 * 															// {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param throwableClass - the Class that would be checked against the
-	 *            throwable of the {@link FrameworkEvent}
-	 * @return the Condition
-	 */
-	static Condition<FrameworkEvent> typeErrorAndThrowableOfClass(final Class<? extends Throwable> throwableClass) {
-		return Assertions.allOf(typeError(), throwableOfClass(throwableClass));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.INFO</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeInfo() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeInfo())
-	 * 		.filteredOn(typeInfo())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeInfo());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-
-	static Condition<FrameworkEvent> typeInfo() {
-		return type(FrameworkEvent.INFO);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.INFO</b> and the throwable of the
-	 * {@link FrameworkEvent} is an instance of the given Class.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeInfoAndThrowableOfClass(Class<? extends Throwable> throwableClass) {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeInfoAndThrowableOfClass(throwableClass))
-	 * 		.filteredOn(typeInfoAndThrowableOfClass(throwableClass))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeInfoAndThrowableOfClass(throwableClass));// used on
-	 * 															// {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param throwableClass - the Class that would be checked against the
-	 *            throwable of the {@link FrameworkEvent}
-	 * @return the Condition
-	 */
-	static Condition<FrameworkEvent> typeInfoAndThrowableOfClass(final Class<? extends Throwable> throwableClass) {
-		return Assertions.allOf(typeInfo(), throwableOfClass(throwableClass));
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.PACKAGES_REFRESHED</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typePackagesRefreshed() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typePackagesRefreshed())
-	 * 		.filteredOn(typePackagesRefreshed())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typePackagesRefreshed());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-
-	static Condition<FrameworkEvent> typePackagesRefreshed() {
-		return type(FrameworkEvent.PACKAGES_REFRESHED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.STARTED</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeStarted() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeStarted())
-	 * 		.filteredOn(typeStarted())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeStarted());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-
-	static Condition<FrameworkEvent> typeStarted() {
-		return type(FrameworkEvent.STARTED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.STARTLEVEL_CHANGED</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeStartLevelChanged() {
-	 *
-	 * 	assertThat(typeStartLevelChanged)// created an {@link ListAssert}
-	 * 		.have(typeError())
-	 * 		.filteredOn(typeStartLevelChanged())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeStartLevelChanged());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-
-	static Condition<FrameworkEvent> typeStartLevelChanged() {
-		return type(FrameworkEvent.STARTLEVEL_CHANGED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.STOPPED</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeStopped() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeStopped())
-	 * 		.filteredOn(typeStopped())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeStopped());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-
-	static Condition<FrameworkEvent> typeStopped() {
-		return type(FrameworkEvent.STOPPED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeStopped_BootClasspathModified() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeStopped_BootClasspathModified())
-	 * 		.filteredOn(typeStopped_BootClasspathModified())
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeStopped_BootClasspathModified());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-
-	static Condition<FrameworkEvent> typeStopped_BootClasspathModified() {
-		return type(FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED);
-	}
-
-	// /**
-	// * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	// * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	// * <b>FrameworkEvent.STOPPED_SYSTEM_REFRESHED</b>.
-	// *
-	// * <pre>
-	// * List<FrameworkEvent> frameworkEvents = null;
-	// *
-	// * static void example_typeStoppedSystemRefreshes() {
-	// *
-	// * assertThat(frameworkEvents)// created an {@link ListAssert}
-	// * .have(typeStoppedSystemRefreshes())
-	// * .filteredOn(typeStoppedSystemRefreshes())
-	// * .first()// map to {@link ObjectAssert}
-	// * .has(typeStoppedSystemRefreshes());// used on {@link
-	// * // ObjectAssert}
-	// * }
-	// * </pre>
-	// *
-	// * @return the Condition
-	// */
-	//
-	// static Condition<FrameworkEvent> typeStoppedSystemRefreshes() {
-	// return type(FrameworkEvent.STOPPED_SYSTEM_REFRESHED);
-	// }
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.STOPPED_UPDATE</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeUpdate() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeUpdate())
-	 * 		.filteredOn(typeUpdate())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeUpdate());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<FrameworkEvent> typeStoppedUpdate() {
-		return type(FrameworkEvent.STOPPED_UPDATE);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.WAIT_TIMEDOUT</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeWaitTimeout() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeWaitTimeout())
-	 * 		.filteredOn(typeWaitTimeout())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeWaitTimeout());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-
-	static Condition<FrameworkEvent> typeWaitTimeout() {
-		return type(FrameworkEvent.WAIT_TIMEDOUT);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.WARNING</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeWarning() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeWarning())
-	 * 		.filteredOn(typeWarning())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeWarning());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<FrameworkEvent> typeWarning() {
-		return type(FrameworkEvent.WARNING);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if type of {@link FrameworkEvent} <b>matches</b>
-	 * <b>FrameworkEvent.WARNING</b> and the throwable of the
-	 * {@link FrameworkEvent} is an instance of the given Class.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeInfoAndThrowableOfClass(Class<? extends Throwable> throwableClass) {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(typeInfoAndThrowableOfClass(throwableClass))
-	 * 		.filteredOn(typeInfoAndThrowableOfClass(throwableClass))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeInfoAndThrowableOfClass(throwableClass));// used on
-	 * 															// {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param throwableClass - the Class that would be checked against the
-	 *            throwable of the {@link FrameworkEvent}
-	 * @return the Condition
-	 */
-	static Condition<FrameworkEvent> typeWarningAndThrowableOfClass(final Class<? extends Throwable> throwableClass) {
-		return Assertions.allOf(typeWarning(), throwableOfClass(throwableClass));
 	}
 
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventConditions.java
@@ -37,6 +37,8 @@ import org.osgi.test.common.bitmaps.FrameworkEventType;
 /**
  * A Utility-Class thats Provides public static methods to create
  * {@link FrameworkEventConditions} for an {@link FrameworkEvent}
+ *
+ * @since 1.1
  */
 public final class FrameworkEventConditions {
 
@@ -66,34 +68,11 @@ public final class FrameworkEventConditions {
 	 */
 	public static Condition<FrameworkEvent> bundleEquals(Bundle bundle) {
 
-		return MappedCondition.mappedCondition(FrameworkEvent::getBundle, BundleConditions.sameAs(bundle),
+		return MappedCondition.mappedCondition(FrameworkEvent::getBundle, BundleConditions.isEqualsTo(bundle),
 			"FrameworkEvent::getBundle");
 
 	}
 
-	/**
-	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
-	 * Checking if the bundle that is associated with the eventof the
-	 * {@link FrameworkEvent} <b>is not null</b>.
-	 *
-	 * <pre>
-	 * List<FrameworkEvent> frameworkEvents = null;
-	 *
-	 * public static void example_bundleIsNotNull() {
-	 *
-	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
-	 * 		.have(bundleIsNotNull())
-	 * 		.filteredOn(bundleIsNotNull())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(bundleIsNotNull());// used on {@link ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	public static Condition<FrameworkEvent> bundleIsNotNull() {
-		return not(bundleIsNull());
-	}
 
 	/**
 	 * Creates a {@link Condition} to be met by an {@link FrameworkEvent}.
@@ -135,8 +114,8 @@ public final class FrameworkEventConditions {
 	 * 		.have(matches(typeMask, bundle, throwableClass))
 	 * 		.filteredOn(matches(typeMask, bundle, throwableClass))
 	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(matches(typeMask, bundle, throwableClass));// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.has(matches(typeMask, bundle, throwableClass)); //used
+	 *  			on {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -166,11 +145,9 @@ public final class FrameworkEventConditions {
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(matches(typeMask, throwableClass))
 	 * 		.filteredOn(matches(typeMask, throwableClass))
-	 * 		.first()// map to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(matches(typeMask, throwableClass));// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(matches(typeMask, throwableClass));// used on
+	 * 				{@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -197,8 +174,7 @@ public final class FrameworkEventConditions {
 	 * 		.have(throwableIsNotNull())
 	 * 		.filteredOn(throwableIsNotNull())
 	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(throwableIsNotNull());// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.has(throwableIsNotNull());// used on {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -221,8 +197,7 @@ public final class FrameworkEventConditions {
 	 * 		.have(throwableIsNull())
 	 * 		.filteredOn(throwableIsNull())
 	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(throwableIsNull());// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.has(throwableIsNull());// used on {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -246,11 +221,9 @@ public final class FrameworkEventConditions {
 	 * 	assertThat(frameworkEvents)// created an {@link ListAssert}
 	 * 		.have(throwableOfClass(throwableClass))
 	 * 		.filteredOn(throwableOfClass(throwableClass))
-	 * 		.first()// map to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(throwableOfClass(throwableClass));// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(throwableOfClass(throwableClass));// used on
+	 * 			{@link  ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -283,8 +256,7 @@ public final class FrameworkEventConditions {
 	 * 		.have(type(type))
 	 * 		.filteredOn(type(typeMask))
 	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(type(typeMask));// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.has(type(typeMask));// used on {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -315,10 +287,9 @@ public final class FrameworkEventConditions {
 	 * 		.have(typeAndBundle(typeMask, bundles))
 	 * 		.filteredOn(typeAndBundle(typeMask, bundle))
 	 * 		.first()// map to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeAndBundle(typeMask, bundle));// used on {@link
-	 * 	// ObjectAssert}
+	 * 				// {@link ObjectAssert}
+	 * 		.has(typeAndBundle(typeMask, bundle));// used on
+	 * 	{@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/package-info.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.assertj.frameworkevent;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventConditions.java
@@ -32,17 +32,17 @@ import org.assertj.core.condition.VerboseCondition;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceEvent;
 import org.osgi.framework.ServiceReference;
-import org.osgi.test.assertj.dictionary.DictionaryConditions;
+import org.osgi.test.assertj.servicereference.ServicePropertiesConditions;
 import org.osgi.test.assertj.servicereference.ServiceReferenceConditions;
 import org.osgi.test.common.bitmaps.Bitmap;
 import org.osgi.test.common.bitmaps.ServiceEventType;
 import org.osgi.test.common.dictionary.Dictionaries;
 
 /**
- * A Utility-Class thats Provides static methods to create {@link Condition}s
+ * A Utility-Class thats Provides public public static methods to create {@link Condition}s
  * for an {@link ServiceEvent}
  */
-public interface ServiceEventConditions {
+public final class ServiceEventConditions {
 
 	/**
 	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
@@ -52,7 +52,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvents = null;
 	 *
-	 * static void example_matches(int eventTypeMask, Class<?> objectClass) {
+	 * public public static void example_matches(int eventTypeMask, Class<?> objectClass) {
 	 *
 	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
 	 * 		.have(matches(eventTypeMask, objectClass))
@@ -66,13 +66,13 @@ public interface ServiceEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
+	 * @param eventTypeMask - the typeMask that would be checked against the bundle
 	 *            type of the {@link ServiceEvent}
 	 * @param objectClass - the objectClass that would be tested against the
 	 *            ServiceReference
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass) {
+	public static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass) {
 		Condition<ServiceEvent> cType = type(eventTypeMask);
 		Condition<ServiceEvent> cObjectClass = serviceReferenceHas(ServiceReferenceConditions.objectClass(objectClass));
 		return Assertions.allOf(cType, cObjectClass);
@@ -86,7 +86,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvents = null;
 	 *
-	 * static void example_matches(int eventTypeMask, String filter) {
+	 * public public static void example_matches(int eventTypeMask, String filter) {
 	 *
 	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
 	 * 		.have(matches(eventTypeMask, filter))
@@ -100,13 +100,13 @@ public interface ServiceEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
+	 * @param eventTypeMask - the typeMask that would be checked against the bundle
 	 *            type of the {@link ServiceEvent}
 	 * @param filter - the filter String would be tested against the
 	 *            ServiceReference
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> matches(int eventTypeMask, final String filter) throws InvalidSyntaxException {
+	public static Condition<ServiceEvent> matches(int eventTypeMask, final String filter) throws InvalidSyntaxException {
 		Condition<ServiceEvent> cType = type(eventTypeMask);
 		Condition<ServiceEvent> cObjectClass = serviceReferenceHas(
 			ServiceReferenceConditions.serviceReferenceMatch(filter));
@@ -123,7 +123,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvents = null;
 	 *
-	 * static void example_matches(int eventTypeMask, Class<?> objectClass, Dictionary<String, Object> dictionary) {
+	 * public public static void example_matches(int eventTypeMask, Class<?> objectClass, Dictionary<String, Object> dictionary) {
 	 *
 	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
 	 * 		.have(matches(eventTypeMask, objectClass, dictionary))
@@ -135,7 +135,7 @@ public interface ServiceEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
+	 * @param eventTypeMask - the typeMask that would be checked against the bundle
 	 *            type of the {@link ServiceEvent}
 	 * @param objectClass - the objectClass that would be tested against the
 	 *            ServiceReference
@@ -143,7 +143,7 @@ public interface ServiceEventConditions {
 	 *            the ServiceReference serviceProperties
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
+	public static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
 		Dictionary<String, Object> dictionary) {
 		return matches(eventTypeMask, objectClass, Dictionaries.asMap(dictionary));
 	}
@@ -158,7 +158,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvents = null;
 	 *
-	 * static void example_matches(int eventTypeMask, Class<?> objectClass, Map<String, Object> map) {
+	 * public public static void example_matches(int eventTypeMask, Class<?> objectClass, Map<String, Object> map) {
 	 *
 	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
 	 * 		.have(matches(eventTypeMask, objectClass, map))
@@ -169,7 +169,7 @@ public interface ServiceEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
+	 * @param eventTypeMask - the typeMask that would be checked against the bundle
 	 *            type of the {@link ServiceEvent}
 	 * @param objectClass - the objectClass that would be tested against the
 	 *            ServiceReference
@@ -177,11 +177,11 @@ public interface ServiceEventConditions {
 	 *            ServiceReference serviceProperties
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass, Map<String, Object> map) {
+	public static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass, Map<String, Object> map) {
 		Condition<ServiceEvent> cType = type(eventTypeMask);
 		Condition<ServiceEvent> cObjectClass = serviceReferenceHas(ServiceReferenceConditions.objectClass(objectClass));
 		Condition<ServiceEvent> cProperties = serviceReferenceHas(
-			ServiceReferenceConditions.servicePropertiesHas(DictionaryConditions.servicePropertiesContains(map)));
+			ServiceReferenceConditions.servicePropertiesHas(ServicePropertiesConditions.servicePropertiesContains(map)));
 		return Assertions.allOf(cType, cObjectClass, cProperties);
 	}
 
@@ -193,7 +193,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvent = null;
 	 *
-	 * static void example_serviceReferenceEquals(ServiceReference<?> serviceReference) {
+	 * public public static void example_serviceReferenceEquals(ServiceReference<?> serviceReference) {
 	 *
 	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
 	 * 		.have(serviceReferenceEquals(serviceReference))
@@ -206,7 +206,7 @@ public interface ServiceEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> serviceReferenceEquals(ServiceReference<?> serviceReference) {
+	public static Condition<ServiceEvent> serviceReferenceEquals(ServiceReference<?> serviceReference) {
 
 		return MappedCondition.mappedCondition(ServiceEvent::getServiceReference,
 			ServiceReferenceConditions.sameAs(serviceReference), "ServiceEvent::getServiceReference");
@@ -220,7 +220,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvent = null;
 	 *
-	 * static void example_serviceReferenceHas(Condition<ServiceReference<?>> serviceReferenceCondition) {
+	 * public public static void example_serviceReferenceHas(Condition<ServiceReference<?>> serviceReferenceCondition) {
 	 *
 	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
 	 * 		.have(serviceReferenceHas(serviceReferenceCondition))
@@ -234,7 +234,7 @@ public interface ServiceEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> serviceReferenceHas(Condition<ServiceReference<?>> serviceReferenceCondition) {
+	public static Condition<ServiceEvent> serviceReferenceHas(Condition<ServiceReference<?>> serviceReferenceCondition) {
 		Condition<ServiceEvent> mc = MappedCondition.mappedCondition(ServiceEvent::getServiceReference,
 			serviceReferenceCondition, "ServiceEvent to ServiceReference using ServiceEvent::getServiceReference");
 		return Assertions.allOf(serviceReferenceIsNotNull(), mc);
@@ -248,7 +248,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvent = null;
 	 *
-	 * static void example_serviceReferenceIsNull() {
+	 * public public static void example_serviceReferenceIsNull() {
 	 *
 	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
 	 * 		.have(serviceReferenceIsNotNull())
@@ -261,7 +261,7 @@ public interface ServiceEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> serviceReferenceIsNotNull() {
+	public static Condition<ServiceEvent> serviceReferenceIsNotNull() {
 		return not(serviceReferenceIsNull());
 	}
 
@@ -273,7 +273,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvent = null;
 	 *
-	 * static void example_serviceReferenceIsNull() {
+	 * public public static void example_serviceReferenceIsNull() {
 	 *
 	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
 	 * 		.have(serviceReferenceIsNull())
@@ -286,7 +286,7 @@ public interface ServiceEventConditions {
 	 *
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> serviceReferenceIsNull() {
+	public static Condition<ServiceEvent> serviceReferenceIsNull() {
 
 		return VerboseCondition.verboseCondition((sericeEvent) -> sericeEvent.getServiceReference() == null,
 			"serviceReference is <null>", (se) -> se.getServiceReference()
@@ -301,7 +301,7 @@ public interface ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvents = null;
 	 *
-	 * static void example_type(int typeMask) {
+	 * public public static void example_type(int typeMask) {
 	 *
 	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
 	 * 		.have(type(type))
@@ -312,11 +312,11 @@ public interface ServiceEventConditions {
 	 * }
 	 * </pre>
 	 *
-	 * @param typeMask - the typeMask that would be checked against the bundle
+	 * @param eventTypeMask - the typeMask that would be checked against the bundle
 	 *            type of the {@link ServiceEvent}
 	 * @return the Condition
 	 */
-	static Condition<ServiceEvent> type(final int eventTypeMask) {
+	public static Condition<ServiceEvent> type(final int eventTypeMask) {
 
 		return VerboseCondition.verboseCondition(
 			(ServiceEvent se) -> Bitmap.typeMatchesMask(se.getType(), eventTypeMask),
@@ -324,282 +324,4 @@ public interface ServiceEventConditions {
 			se -> " but was <" + ServiceEventType.BITMAP.toString(se.getType()) + ">");
 	}
 
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.MODIFIED</b>.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeModified() {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeModified())
-	 * 		.filteredOn(typeModified())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeModified());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeModified() {
-		return type(ServiceEvent.MODIFIED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.MODIFIED</b> and the given Class<?> objectClass matches a
-	 * objectClass of the ServiceReference.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> serviceEvents = null;
-	 *
-	 * static void example_typeModifiedAndObjectClassClass<?> objectClass) {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeModifiedAndObjectClass(objectClass))
-	 * 		.filteredOn(typeModifiedAndObjectClass(objectClass))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeModifiedAndObjectClass(objectClass));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param objectClass - the objectClass that would be tested against the
-	 *            ServiceReference
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeModifiedAndObjectClass(final Class<?> objectClass) {
-		return matches(ServiceEvent.MODIFIED, objectClass);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.MODIFIED_ENDMATCH</b>.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> frameworkEvents = null;
-	 *
-	 * static void example_typeModifiedEndmatch() {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeModifiedEndmatch())
-	 * 		.filteredOn(typeModifiedEndmatch())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeModifiedEndmatch());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeModifiedEndmatch() {
-		return type(ServiceEvent.MODIFIED_ENDMATCH);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.MODIFIED_ENDMATCH</b> and the given Class<?> objectClass
-	 * matches a objectClass of the ServiceReference.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> serviceEvents = null;
-	 *
-	 * static void example_typeUnregisteringAndObjectClass(Class<?> objectClass) {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeModifiedEndmatchAndObjectClass(objectClass))
-	 * 		.filteredOn(typeModifiedEndmatchAndObjectClass(objectClass))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeModifiedEndmatchAndObjectClass(objectClass));// used on
-	 * 																// {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param objectClass - the objectClass that would be tested against the
-	 *            ServiceReference
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeModifiedEndmatchAndObjectClass(final Class<?> objectClass) {
-		return matches(ServiceEvent.MODIFIED_ENDMATCH, objectClass);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.REGISTERED</b>.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> serviceEvents = null;
-	 *
-	 * static void example_typeRegistered() {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeRegistered())
-	 * 		.filteredOn(typeRegistered())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeRegistered());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeRegistered() {
-		return type(ServiceEvent.REGISTERED);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.REGISTERED</b> and the given Class<?> objectClass matches
-	 * a objectClass of the ServiceReference.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> serviceEvents = null;
-	 *
-	 * static void example_typeRegisteredAndObjectClass(Class<?> objectClass) {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeRegisteredAndObjectClass(objectClass))
-	 * 		.filteredOn(typeRegisteredAndObjectClass(objectClass))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeRegisteredAndObjectClass(objectClass));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param objectClass - the objectClass that would be tested against the
-	 *            ServiceReference
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeRegisteredAndObjectClass(final Class<?> objectClass) {
-		return matches(ServiceEvent.REGISTERED, objectClass);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.REGISTERED</b> and the given Class<?> objectClass matches
-	 * a objectClass of the ServiceReference and the given dictionary contained
-	 * in the serviceProperties.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> serviceEvents = null;
-	 *
-	 * static void example_typeRegisteredWith(Class<?> objectClass, Dictionary<String, Object> dictionary) {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeRegisteredWith(objectClass, dictionary))
-	 * 		.filteredOn(typeRegisteredWith(objectClass, dictionary))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeRegisteredWith(objectClass, dictionary));// used on
-	 * 															// {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param dictionary - dictionary must contain in the serviceProperties
-	 * @param objectClass - the objectClass that would be tested against the
-	 *            ServiceReference
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeRegisteredWith(final Class<?> objectClass,
-		Dictionary<String, Object> dictionary) {
-		return matches(ServiceEvent.REGISTERED, objectClass, dictionary);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.REGISTERED</b> and the given Class<?> objectClass matches
-	 * a objectClass of the ServiceReference and the given dictionary contained
-	 * in the serviceProperties.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> serviceEvents = null;
-	 *
-	 * static void example_typeRegisteredWith(Class<?> objectClass, Map<String, Object> map) {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeRegisteredWith(objectClass, map))
-	 * 		.filteredOn(typeRegisteredWith(objectClass, map))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(typeRegisteredWith(objectClass, map));// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param map - dictionary must contain in the serviceProperties
-	 * @param objectClass - the objectClass that would be tested against the
-	 *            ServiceReference
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeRegisteredWith(final Class<?> objectClass, Map<String, Object> map) {
-		return matches(ServiceEvent.REGISTERED, objectClass, map);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.UNREGISTERING</b>.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> serviceEvents = null;
-	 *
-	 * static void example_typeUnregistering() {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeUnregistering())
-	 * 		.filteredOn(typeUnregistering())
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeUnregistering());// used on {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeUnregistering() {
-		return type(ServiceEvent.UNREGISTERING);
-	}
-
-	/**
-	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
-	 * Checking if type of {@link ServiceEvent} <b>matches</b>
-	 * <b>ServiceEvent.UNREGISTERING</b> and the given Class<?> objectClass
-	 * matches a objectClass of the ServiceReference.
-	 *
-	 * <pre>
-	 * List<ServiceEvent> serviceEvents = null;
-	 *
-	 * static void example_typeUnregisteringAndObjectClass(Class<?> objectClass) {
-	 *
-	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
-	 * 		.have(typeUnregisteringAndObjectClass(objectClass))
-	 * 		.filteredOn(typeUnregisteringAndObjectClass(objectClass))
-	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(typeUnregisteringAndObjectClass(objectClass));// used on
-	 * 															// {@link
-	 * 	// ObjectAssert}
-	 * }
-	 * </pre>
-	 *
-	 * @param objectClass - the objectClass that would be tested against the
-	 *            ServiceReference
-	 * @return the Condition
-	 */
-	static Condition<ServiceEvent> typeUnregisteringAndObjectClass(final Class<?> objectClass) {
-		return matches(ServiceEvent.UNREGISTERING, objectClass);
-	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventConditions.java
@@ -1,0 +1,605 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.serviceevent;
+
+import static org.assertj.core.api.Assertions.not;
+
+import java.util.Dictionary;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.condition.MappedCondition;
+import org.assertj.core.condition.VerboseCondition;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.assertj.dictionary.DictionaryConditions;
+import org.osgi.test.assertj.servicereference.ServiceReferenceConditions;
+import org.osgi.test.common.bitmaps.Bitmap;
+import org.osgi.test.common.bitmaps.ServiceEventType;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+/**
+ * A Utility-Class thats Provides static methods to create {@link Condition}s
+ * for an {@link ServiceEvent}
+ */
+public interface ServiceEventConditions {
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type and the given
+	 * Class<?> objectClass matches a objectClass of the ServiceReference.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_matches(int eventTypeMask, Class<?> objectClass) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(matches(eventTypeMask, objectClass))
+	 * 		.filteredOn(matches(eventTypeMask, objectClass))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(matches(eventTypeMask, objectClass));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link ServiceEvent}
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass) {
+		Condition<ServiceEvent> cType = type(eventTypeMask);
+		Condition<ServiceEvent> cObjectClass = serviceReferenceHas(ServiceReferenceConditions.objectClass(objectClass));
+		return Assertions.allOf(cType, cObjectClass);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type and the given
+	 * String filter matches the ServiceReference.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_matches(int eventTypeMask, String filter) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(matches(eventTypeMask, filter))
+	 * 		.filteredOn(matches(eventTypeMask, filter))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(matches(eventTypeMask, filter));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link ServiceEvent}
+	 * @param filter - the filter String would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> matches(int eventTypeMask, final String filter) throws InvalidSyntaxException {
+		Condition<ServiceEvent> cType = type(eventTypeMask);
+		Condition<ServiceEvent> cObjectClass = serviceReferenceHas(
+			ServiceReferenceConditions.serviceReferenceMatch(filter));
+		return Assertions.allOf(cType, cObjectClass);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type and the given
+	 * Class<?> objectClass matches a objectClass of the serviceReference and
+	 * given dictionary's entries are contained in the serviceProperties of the
+	 * ServiceReverence of the {@link ServiceEvent}
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_matches(int eventTypeMask, Class<?> objectClass, Dictionary<String, Object> dictionary) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(matches(eventTypeMask, objectClass, dictionary))
+	 * 		.filteredOn(matches(eventTypeMask, objectClass, dictionary))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(matches(eventTypeMask, objectClass, dictionary));// used on
+	 * 																// {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link ServiceEvent}
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @param dictionary - the dictionary's entries that would be tested against
+	 *            the ServiceReference serviceProperties
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
+		Dictionary<String, Object> dictionary) {
+		return matches(eventTypeMask, objectClass, Dictionaries.asMap(dictionary));
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type and the given
+	 * Class<?> objectClass matches a objectClass of the serviceReference and
+	 * given Map's entries are contained in the serviceProperties of the
+	 * ServiceReverence of the {@link ServiceEvent}
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_matches(int eventTypeMask, Class<?> objectClass, Map<String, Object> map) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(matches(eventTypeMask, objectClass, map))
+	 * 		.filteredOn(matches(eventTypeMask, objectClass, map))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(matches(eventTypeMask, objectClass, map));
+	 * 	// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link ServiceEvent}
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @param map - the maps entries that would be tested against the
+	 *            ServiceReference serviceProperties
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass, Map<String, Object> map) {
+		Condition<ServiceEvent> cType = type(eventTypeMask);
+		Condition<ServiceEvent> cObjectClass = serviceReferenceHas(ServiceReferenceConditions.objectClass(objectClass));
+		Condition<ServiceEvent> cProperties = serviceReferenceHas(
+			ServiceReferenceConditions.servicePropertiesHas(DictionaryConditions.servicePropertiesContains(map)));
+		return Assertions.allOf(cType, cObjectClass, cProperties);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if the serviceReference of the {@link ServiceEvent}
+	 * <b>equals</b> the given serviceReference.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvent = null;
+	 *
+	 * static void example_serviceReferenceEquals(ServiceReference<?> serviceReference) {
+	 *
+	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
+	 * 		.have(serviceReferenceEquals(serviceReference))
+	 * 		.filteredOn(serviceReferenceEquals(serviceReference))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(serviceReferenceEquals(serviceReference));// used on {@link
+	 * 														// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> serviceReferenceEquals(ServiceReference<?> serviceReference) {
+
+		return MappedCondition.mappedCondition(ServiceEvent::getServiceReference,
+			ServiceReferenceConditions.sameAs(serviceReference), "ServiceEvent::getServiceReference");
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if the serviceReference of the {@link ServiceEvent}
+	 * <b>matches</b> the given serviceReferenceCondition {@link Condition}.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvent = null;
+	 *
+	 * static void example_serviceReferenceHas(Condition<ServiceReference<?>> serviceReferenceCondition) {
+	 *
+	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
+	 * 		.have(serviceReferenceHas(serviceReferenceCondition))
+	 * 		.filteredOn(serviceReferenceHas(serviceReferenceCondition))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(serviceReferenceHas(serviceReferenceCondition));// used on
+	 * 																// {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> serviceReferenceHas(Condition<ServiceReference<?>> serviceReferenceCondition) {
+		Condition<ServiceEvent> mc = MappedCondition.mappedCondition(ServiceEvent::getServiceReference,
+			serviceReferenceCondition, "ServiceEvent to ServiceReference using ServiceEvent::getServiceReference");
+		return Assertions.allOf(serviceReferenceIsNotNull(), mc);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if the serviceReference of the {@link ServiceEvent} <b>is not
+	 * null</b>.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvent = null;
+	 *
+	 * static void example_serviceReferenceIsNull() {
+	 *
+	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
+	 * 		.have(serviceReferenceIsNotNull())
+	 * 		.filteredOn(serviceReferenceIsNotNull())
+	 * 		.first()// map to {@link
+	 * 				// ObjectAssert}
+	 * 		.has(serviceReferenceIsNotNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> serviceReferenceIsNotNull() {
+		return not(serviceReferenceIsNull());
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if the serviceReference of the {@link ServiceEvent} <b>is
+	 * null</b>.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvent = null;
+	 *
+	 * static void example_serviceReferenceIsNull() {
+	 *
+	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
+	 * 		.have(serviceReferenceIsNull())
+	 * 		.filteredOn(serviceReferenceIsNull())
+	 * 		.first()// map to {@link
+	 * 				// ObjectAssert}
+	 * 		.has(serviceReferenceIsNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> serviceReferenceIsNull() {
+
+		return VerboseCondition.verboseCondition((sericeEvent) -> sericeEvent.getServiceReference() == null,
+			"serviceReference is <null>", (se) -> se.getServiceReference()
+				.toString());
+
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if a given type-mask <b>matches</b> the type.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_type(int typeMask) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(type(type))
+	 * 		.filteredOn(type(typeMask))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(type(typeMask));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param typeMask - the typeMask that would be checked against the bundle
+	 *            type of the {@link ServiceEvent}
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> type(final int eventTypeMask) {
+
+		return VerboseCondition.verboseCondition(
+			(ServiceEvent se) -> Bitmap.typeMatchesMask(se.getType(), eventTypeMask),
+			"type matches mask <" + ServiceEventType.BITMAP.maskToString(eventTypeMask) + ">", //
+			se -> " but was <" + ServiceEventType.BITMAP.toString(se.getType()) + ">");
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.MODIFIED</b>.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeModified() {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeModified())
+	 * 		.filteredOn(typeModified())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeModified());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeModified() {
+		return type(ServiceEvent.MODIFIED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.MODIFIED</b> and the given Class<?> objectClass matches a
+	 * objectClass of the ServiceReference.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_typeModifiedAndObjectClassClass<?> objectClass) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeModifiedAndObjectClass(objectClass))
+	 * 		.filteredOn(typeModifiedAndObjectClass(objectClass))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeModifiedAndObjectClass(objectClass));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeModifiedAndObjectClass(final Class<?> objectClass) {
+		return matches(ServiceEvent.MODIFIED, objectClass);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.MODIFIED_ENDMATCH</b>.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> frameworkEvents = null;
+	 *
+	 * static void example_typeModifiedEndmatch() {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeModifiedEndmatch())
+	 * 		.filteredOn(typeModifiedEndmatch())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeModifiedEndmatch());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeModifiedEndmatch() {
+		return type(ServiceEvent.MODIFIED_ENDMATCH);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.MODIFIED_ENDMATCH</b> and the given Class<?> objectClass
+	 * matches a objectClass of the ServiceReference.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_typeUnregisteringAndObjectClass(Class<?> objectClass) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeModifiedEndmatchAndObjectClass(objectClass))
+	 * 		.filteredOn(typeModifiedEndmatchAndObjectClass(objectClass))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeModifiedEndmatchAndObjectClass(objectClass));// used on
+	 * 																// {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeModifiedEndmatchAndObjectClass(final Class<?> objectClass) {
+		return matches(ServiceEvent.MODIFIED_ENDMATCH, objectClass);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.REGISTERED</b>.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_typeRegistered() {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeRegistered())
+	 * 		.filteredOn(typeRegistered())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeRegistered());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeRegistered() {
+		return type(ServiceEvent.REGISTERED);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.REGISTERED</b> and the given Class<?> objectClass matches
+	 * a objectClass of the ServiceReference.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_typeRegisteredAndObjectClass(Class<?> objectClass) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeRegisteredAndObjectClass(objectClass))
+	 * 		.filteredOn(typeRegisteredAndObjectClass(objectClass))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeRegisteredAndObjectClass(objectClass));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeRegisteredAndObjectClass(final Class<?> objectClass) {
+		return matches(ServiceEvent.REGISTERED, objectClass);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.REGISTERED</b> and the given Class<?> objectClass matches
+	 * a objectClass of the ServiceReference and the given dictionary contained
+	 * in the serviceProperties.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_typeRegisteredWith(Class<?> objectClass, Dictionary<String, Object> dictionary) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeRegisteredWith(objectClass, dictionary))
+	 * 		.filteredOn(typeRegisteredWith(objectClass, dictionary))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeRegisteredWith(objectClass, dictionary));// used on
+	 * 															// {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param dictionary - dictionary must contain in the serviceProperties
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeRegisteredWith(final Class<?> objectClass,
+		Dictionary<String, Object> dictionary) {
+		return matches(ServiceEvent.REGISTERED, objectClass, dictionary);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.REGISTERED</b> and the given Class<?> objectClass matches
+	 * a objectClass of the ServiceReference and the given dictionary contained
+	 * in the serviceProperties.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_typeRegisteredWith(Class<?> objectClass, Map<String, Object> map) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeRegisteredWith(objectClass, map))
+	 * 		.filteredOn(typeRegisteredWith(objectClass, map))
+	 * 		.first()// map
+	 * 				// to
+	 * 				// {@link
+	 * 				// ObjectAssert}
+	 * 		.has(typeRegisteredWith(objectClass, map));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param map - dictionary must contain in the serviceProperties
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeRegisteredWith(final Class<?> objectClass, Map<String, Object> map) {
+		return matches(ServiceEvent.REGISTERED, objectClass, map);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.UNREGISTERING</b>.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_typeUnregistering() {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeUnregistering())
+	 * 		.filteredOn(typeUnregistering())
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeUnregistering());// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeUnregistering() {
+		return type(ServiceEvent.UNREGISTERING);
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceEvent}.
+	 * Checking if type of {@link ServiceEvent} <b>matches</b>
+	 * <b>ServiceEvent.UNREGISTERING</b> and the given Class<?> objectClass
+	 * matches a objectClass of the ServiceReference.
+	 *
+	 * <pre>
+	 * List<ServiceEvent> serviceEvents = null;
+	 *
+	 * static void example_typeUnregisteringAndObjectClass(Class<?> objectClass) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(typeUnregisteringAndObjectClass(objectClass))
+	 * 		.filteredOn(typeUnregisteringAndObjectClass(objectClass))
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(typeUnregisteringAndObjectClass(objectClass));// used on
+	 * 															// {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+	static Condition<ServiceEvent> typeUnregisteringAndObjectClass(final Class<?> objectClass) {
+		return matches(ServiceEvent.UNREGISTERING, objectClass);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventConditions.java
@@ -39,8 +39,10 @@ import org.osgi.test.common.bitmaps.ServiceEventType;
 import org.osgi.test.common.dictionary.Dictionaries;
 
 /**
- * A Utility-Class thats Provides public public static methods to create {@link Condition}s
- * for an {@link ServiceEvent}
+ * A Utility-Class thats Provides public public static methods to create
+ * {@link Condition}s for an {@link ServiceEvent}
+ *
+ * @since 1.1
  */
 public final class ServiceEventConditions {
 
@@ -57,17 +59,14 @@ public final class ServiceEventConditions {
 	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
 	 * 		.have(matches(eventTypeMask, objectClass))
 	 * 		.filteredOn(matches(eventTypeMask, objectClass))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(matches(eventTypeMask, objectClass));// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(matches(eventTypeMask, objectClass));// used on
+	 * 	// {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
-	 * @param eventTypeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link ServiceEvent}
+	 * @param eventTypeMask - the typeMask that would be checked against the
+	 *            bundle type of the {@link ServiceEvent}
 	 * @param objectClass - the objectClass that would be tested against the
 	 *            ServiceReference
 	 * @return the Condition
@@ -91,17 +90,14 @@ public final class ServiceEventConditions {
 	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
 	 * 		.have(matches(eventTypeMask, filter))
 	 * 		.filteredOn(matches(eventTypeMask, filter))
-	 * 		.first()// map
-	 * 				// to
-	 * 				// {@link
-	 * 				// ObjectAssert}
-	 * 		.has(matches(eventTypeMask, filter));// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.first()// map to {@link ObjectAssert}
+	 * 		.has(matches(eventTypeMask, filter));// used on
+	 * 	// {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
-	 * @param eventTypeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link ServiceEvent}
+	 * @param eventTypeMask - the typeMask that would be checked against the
+	 *            bundle type of the {@link ServiceEvent}
 	 * @param filter - the filter String would be tested against the
 	 *            ServiceReference
 	 * @return the Condition
@@ -123,20 +119,20 @@ public final class ServiceEventConditions {
 	 * <pre>
 	 * List<ServiceEvent> serviceEvents = null;
 	 *
-	 * public public static void example_matches(int eventTypeMask, Class<?> objectClass, Dictionary<String, Object> dictionary) {
+	 * public public static void example_matches(int eventTypeMask, Class<?> objectClass,
+	 * 	Dictionary<String, Object> dictionary) {
 	 *
 	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
 	 * 		.have(matches(eventTypeMask, objectClass, dictionary))
 	 * 		.filteredOn(matches(eventTypeMask, objectClass, dictionary))
 	 * 		.first()// map to {@link ObjectAssert}
 	 * 		.has(matches(eventTypeMask, objectClass, dictionary));// used on
-	 * 																// {@link
-	 * 	// ObjectAssert}
+	 * 	// {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
-	 * @param eventTypeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link ServiceEvent}
+	 * @param eventTypeMask - the typeMask that would be checked against the
+	 *            bundle type of the {@link ServiceEvent}
 	 * @param objectClass - the objectClass that would be tested against the
 	 *            ServiceReference
 	 * @param dictionary - the dictionary's entries that would be tested against
@@ -199,8 +195,8 @@ public final class ServiceEventConditions {
 	 * 		.have(serviceReferenceEquals(serviceReference))
 	 * 		.filteredOn(serviceReferenceEquals(serviceReference))
 	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(serviceReferenceEquals(serviceReference));// used on {@link
-	 * 														// ObjectAssert}
+	 * 		.has(serviceReferenceEquals(serviceReference));// used on
+	 * 	// {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -209,7 +205,7 @@ public final class ServiceEventConditions {
 	public static Condition<ServiceEvent> serviceReferenceEquals(ServiceReference<?> serviceReference) {
 
 		return MappedCondition.mappedCondition(ServiceEvent::getServiceReference,
-			ServiceReferenceConditions.sameAs(serviceReference), "ServiceEvent::getServiceReference");
+			ServiceReferenceConditions.isEqualsTo(serviceReference), "ServiceEvent::getServiceReference");
 	}
 
 	/**
@@ -227,8 +223,7 @@ public final class ServiceEventConditions {
 	 * 		.filteredOn(serviceReferenceHas(serviceReferenceCondition))
 	 * 		.first()// map to {@link ObjectAssert}
 	 * 		.has(serviceReferenceHas(serviceReferenceCondition));// used on
-	 * 																// {@link
-	 * 	// ObjectAssert}
+	 * 	// {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
@@ -253,8 +248,7 @@ public final class ServiceEventConditions {
 	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
 	 * 		.have(serviceReferenceIsNotNull())
 	 * 		.filteredOn(serviceReferenceIsNotNull())
-	 * 		.first()// map to {@link
-	 * 				// ObjectAssert}
+	 * 		.first()// map to {@link ObjectAssert}
 	 * 		.has(serviceReferenceIsNotNull());// used on {@link ObjectAssert}
 	 * }
 	 * </pre>
@@ -278,8 +272,7 @@ public final class ServiceEventConditions {
 	 * 	assertThat(serviceEvent)// created an {@link ListAssert}
 	 * 		.have(serviceReferenceIsNull())
 	 * 		.filteredOn(serviceReferenceIsNull())
-	 * 		.first()// map to {@link
-	 * 				// ObjectAssert}
+	 * 		.first()// map to {@link ObjectAssert}
 	 * 		.has(serviceReferenceIsNull());// used on {@link ObjectAssert}
 	 * }
 	 * </pre>
@@ -307,13 +300,12 @@ public final class ServiceEventConditions {
 	 * 		.have(type(type))
 	 * 		.filteredOn(type(typeMask))
 	 * 		.first()// map to {@link ObjectAssert}
-	 * 		.has(type(typeMask));// used on {@link
-	 * 	// ObjectAssert}
+	 * 		.has(type(typeMask));// used on {@link ObjectAssert}
 	 * }
 	 * </pre>
 	 *
-	 * @param eventTypeMask - the typeMask that would be checked against the bundle
-	 *            type of the {@link ServiceEvent}
+	 * @param eventTypeMask - the typeMask that would be checked against the
+	 *            bundle type of the {@link ServiceEvent}
 	 * @return the Condition
 	 */
 	public static Condition<ServiceEvent> type(final int eventTypeMask) {

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/package-info.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.assertj.serviceevent;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/ServicePropertiesConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/ServicePropertiesConditions.java
@@ -34,6 +34,8 @@ import org.osgi.test.common.dictionary.Dictionaries;
 /**
  * A Utility-Class thats Provides public static methods to create
  * {@link Condition}s for ServiceProperties
+ *
+ * @since 1.2
  */
 public final class ServicePropertiesConditions {
 	public static Condition<Dictionary<String, Object>> servicePropertiesContains(

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/ServicePropertiesConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/ServicePropertiesConditions.java
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
-package org.osgi.test.assertj.dictionary;
+package org.osgi.test.assertj.servicereference;
 
 import java.util.Collections;
 import java.util.Dictionary;
@@ -32,15 +32,17 @@ import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.test.common.dictionary.Dictionaries;
 
 /**
- * A Utility-Class thats Provides static methods to create {@link Condition}s
- * for an {@link Dictionary}
+ * A Utility-Class thats Provides public static methods to create
+ * {@link Condition}s for ServiceProperties
  */
-public interface DictionaryConditions {
-	static Condition<Dictionary<String, Object>> servicePropertiesContains(Dictionary<String, Object> dictionary) {
+public final class ServicePropertiesConditions {
+	public static Condition<Dictionary<String, Object>> servicePropertiesContains(
+		Dictionary<String, Object> dictionary) {
 		return servicePropertiesContains(Dictionaries.asMap(dictionary));
 	}
 
-	static Condition<Dictionary<String, Object>> servicePropertiesMatch(String filter) throws InvalidSyntaxException {
+	public static Condition<Dictionary<String, Object>> servicePropertiesMatch(String filter)
+		throws InvalidSyntaxException {
 		Filter f = FrameworkUtil.createFilter(filter);
 
 		return new Condition<Dictionary<String, Object>>(d -> {
@@ -49,7 +51,7 @@ public interface DictionaryConditions {
 
 	}
 
-	static Condition<Dictionary<String, Object>> servicePropertiesContains(Map<String, Object> map) {
+	public static Condition<Dictionary<String, Object>> servicePropertiesContains(Map<String, Object> map) {
 		return new Condition<Dictionary<String, Object>>(d -> {
 			List<String> keys = Collections.list(d.keys());
 			for (Entry<String, Object> entry : map.entrySet()) {
@@ -64,7 +66,7 @@ public interface DictionaryConditions {
 		}, "contains ServiceProperties %s", map);
 	}
 
-	static Condition<Dictionary<String, Object>> servicePropertyContains(final String key, Object value) {
+	public static Condition<Dictionary<String, Object>> servicePropertyContains(final String key, Object value) {
 		return servicePropertiesContains(Dictionaries.dictionaryOf(key, value));
 	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/ServiceReferenceConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/ServiceReferenceConditions.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.servicereference;
+
+import java.util.Dictionary;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.condition.MappedCondition;
+import org.assertj.core.condition.VerboseCondition;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+/**
+ * A Utility-Class thats Provides static methods to create {@link Condition}s
+ * for an {@link ServiceReference}
+ */
+public interface ServiceReferenceConditions {
+
+	static Condition<ServiceReference<?>> serviceReferenceMatch(String filter) throws InvalidSyntaxException {
+		Filter f = FrameworkUtil.createFilter(filter);
+
+		return new Condition<ServiceReference<?>>(sr -> {
+			return f.match(sr);
+
+		}, "machts filter %s", filter);
+
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceReference}.
+	 * Checking if a {@link ServiceReference} is <b>equal</b> an other
+	 * ServiceReference.
+	 * <p>
+	 * Example:
+	 *
+	 * <pre>
+	 * List<ServiceReference> serviceReferences = null;
+	 *
+	 * static void sameAs(ServiceReference serviceReference) {
+	 *
+	 * 	assertThat(serviceReferences)// created an {@link ListAssert}
+	 * 		.have(sameAs(serviceReference))
+	 * 		.filteredOn(sameAs(serviceReference))
+	 * 		.first()// map to {@link
+	 * 				// ObjectAssert}
+	 * 		.is(sameAs(serviceReference));// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param serviceReferences - the expected serviceReferences that would be
+	 *            checked against other {@link ServiceReference}s
+	 * @return the Condition<br>
+	 */
+	static Condition<ServiceReference<?>> sameAs(ServiceReference<?> serviceReference) {
+		Condition<ServiceReference<?>> c = VerboseCondition.verboseCondition(sr -> sr.equals(serviceReference),
+			"serviceReference equals", ServiceReference::toString);
+		return c;
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceReference}.
+	 * Checking if type of {@link ServiceReference} <b>matches</b> the given
+	 * Class<?> objectClass matches a objectClass of the ServiceReference.
+	 *
+	 * <pre>
+	 * List<ServiceReference<?>> serviceEvents = null;
+	 *
+	 * static void example_objectClass(Class<?> objectClass) {
+	 *
+	 * 	assertThat(serviceEvents)// created an {@link ListAssert}
+	 * 		.have(objectClass(objectClass))
+	 * 		.filteredOn(objectClass(objectClass))
+	 * 		.first()// map to {@link // ObjectAssert}
+	 * 		.has(objectClass(objectClass));// used on {@link
+	 * 	// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @param objectClass - the objectClass that would be tested against the
+	 *            ServiceReference
+	 * @return the Condition
+	 */
+
+	static Condition<ServiceReference<?>> objectClass(final Class<?> objectClass) {
+		return new Condition<ServiceReference<?>>(sr -> {
+			Object classes = sr.getProperty(Constants.OBJECTCLASS);
+			if (classes != null && classes instanceof String[]) {
+				return Stream.of((String[]) classes)
+					.filter(Objects::nonNull)
+					.anyMatch(objectClass.getName()::equals);
+			}
+			return false;
+		}, "has Objectclass %s", objectClass.getName());
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceReference}.
+	 * Checking if the serviceProperties of the {@link ServiceReference}
+	 * <b>matches</b> the given Condition<Dictionary<String, Object>>.
+	 *
+	 * <pre>
+	 * List<ServiceReference> serviceReference = null;
+	 *
+	 * static void servicePropertiesHas(Condition<Dictionary<String,Object>> condition)) {
+	 *
+	 * assertThat(serviceReference)// created an {@link ListAssert}
+	 *   .have(servicePropertiesHas(condition))
+	 *   .filteredOn(servicePropertiesHas(condition))
+	 *   .first()// map to {@link ObjectAssert}
+	 *   .has(servicePropertiesHas(condition));// used on {@link
+	 ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	static Condition<ServiceReference<?>> servicePropertiesHas(Condition<Dictionary<String, Object>> condition) {
+		return MappedCondition.mappedCondition(sr -> Dictionaries.asDictionary(sr), condition,
+			"ServiceReference to Dictionary");
+	}
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceReference}.
+	 * Checking if the serviceProperties of the {@link ServiceReference} <b>is
+	 * not null</b>.
+	 *
+	 * <pre>
+	 * List<ServiceReference> serviceReference = null;
+	 *
+	 * static void example_servicePropertiesIsNotNull() {
+	 *
+	 * 	assertThat(serviceReference)// created an {@link ListAssert}
+	 * 		.have(servicePropertiesIsNotNull())
+	 * 		.filteredOn(servicePropertiesIsNotNull())
+	 * 		.first()// map to {@link
+	 * 				// ObjectAssert}
+	 * 		.has(servicePropertiesIsNotNull());// used on {@link
+	 * 											// ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+
+	/**
+	 * TODO: with switch to osgi.core R7 static Condition<ServiceReference<?>>
+	 * servicePropertiesIsNotNull() { return not(servicePropertiesIsNull()); }
+	 */
+
+	/**
+	 * Creates a {@link Condition} to be met by an {@link ServiceReference}.
+	 * Checking if the serviceProperties of the {@link ServiceReference} <b>is
+	 * null</b>.
+	 *
+	 * <pre>
+	 * List<ServiceReference> serviceReference = null;
+	 *
+	 * static void example_servicePropertiesIsNull() {
+	 *
+	 * 	assertThat(serviceReference)// created an {@link ListAssert}
+	 * 		.have(servicePropertiesIsNull())
+	 * 		.filteredOn(servicePropertiesIsNull())
+	 * 		.first()// map to {@link
+	 * 				// ObjectAssert}
+	 * 		.has(servicePropertiesIsNull());// used on {@link ObjectAssert}
+	 * }
+	 * </pre>
+	 *
+	 * @return the Condition
+	 */
+	/**
+	 * TODO: with switch to osgi.core R7 static Condition<ServiceReference<?>>
+	 * servicePropertiesIsNull() { return
+	 * Descriptive.descriptive((Dictionary<String, Object>) null, (sr, d) ->
+	 * Dictionaries.asDictionary(sr) == d, "serviceProperties is"); }
+	 */
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/ServiceReferenceConditions.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/ServiceReferenceConditions.java
@@ -37,6 +37,8 @@ import org.osgi.test.common.dictionary.Dictionaries;
 /**
  * A Utility-Class thats Provides static methods to create {@link Condition}s
  * for an {@link ServiceReference}
+ *
+ * @since 1.2
  */
 public interface ServiceReferenceConditions {
 
@@ -63,10 +65,9 @@ public interface ServiceReferenceConditions {
 	 * static void sameAs(ServiceReference serviceReference) {
 	 *
 	 * 	assertThat(serviceReferences)// created an {@link ListAssert}
-	 * 		.have(sameAs(serviceReference))
-	 * 		.filteredOn(sameAs(serviceReference))
-	 * 		.first()// map to {@link
-	 * 				// ObjectAssert}
+	 * 		.have(isEqualsTo(serviceReference))
+	 * 		.filteredOn(isEqualsTo(serviceReference))
+	 * 		.first()// map to {@link ObjectAssert}
 	 * 		.is(sameAs(serviceReference));// used on {@link ObjectAssert}
 	 * }
 	 * </pre>
@@ -75,7 +76,7 @@ public interface ServiceReferenceConditions {
 	 *            checked against other {@link ServiceReference}s
 	 * @return the Condition<br>
 	 */
-	static Condition<ServiceReference<?>> sameAs(ServiceReference<?> serviceReference) {
+	static Condition<ServiceReference<?>> isEqualsTo(ServiceReference<?> serviceReference) {
 		Condition<ServiceReference<?>> c = VerboseCondition.verboseCondition(sr -> sr.equals(serviceReference),
 			"serviceReference equals", ServiceReference::toString);
 		return c;
@@ -164,11 +165,10 @@ public interface ServiceReferenceConditions {
 	 * </pre>
 	 *
 	 * @return the Condition
-	 */
-
-	/**
-	 * TODO: with switch to osgi.core R7 static Condition<ServiceReference<?>>
-	 * servicePropertiesIsNotNull() { return not(servicePropertiesIsNull()); }
+	 *         <p>
+	 *         TODO: with switch to osgi.core R7 static
+	 *         Condition<ServiceReference<?>> servicePropertiesIsNotNull() {
+	 *         return not(servicePropertiesIsNull()); }
 	 */
 
 	/**
@@ -191,11 +191,11 @@ public interface ServiceReferenceConditions {
 	 * </pre>
 	 *
 	 * @return the Condition
-	 */
-	/**
-	 * TODO: with switch to osgi.core R7 static Condition<ServiceReference<?>>
-	 * servicePropertiesIsNull() { return
-	 * Descriptive.descriptive((Dictionary<String, Object>) null, (sr, d) ->
-	 * Dictionaries.asDictionary(sr) == d, "serviceProperties is"); }
+	 * <p>
+	 * TODO: with switch to osgi.core R7 static
+	 *         Condition<ServiceReference<?>> servicePropertiesIsNull() { return
+	 *         Descriptive.descriptive((Dictionary<String, Object>) null, (sr,
+	 *         d) -> Dictionaries.asDictionary(sr) == d, "serviceProperties
+	 *         is"); }
 	 */
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/package-info.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/servicereference/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.2.0")
 package org.osgi.test.assertj.servicereference;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventConditionsTests.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventConditionsTests.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.bundleevent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.test.assertj.bundleevent.BundleEventConditions;
+import org.osgi.test.assertj.test.testutil.ConditionAssert;
+import org.osgi.test.common.bitmaps.BundleEventType;
+
+class BundleEventConditionsTests implements ConditionAssert {
+
+	Bundle		bundle;
+	BundleEvent	bundleEvent;
+	Bundle		otherbundle;
+
+	@BeforeEach
+	private void beforEach() {
+		bundleEvent = mock(BundleEvent.class, "theBundleEvent");
+		bundle = mock(Bundle.class, "theBundle");
+		otherbundle = mock(Bundle.class, "otherbundle");
+	}
+
+	@Test
+	void bundleEquals() throws Exception {
+
+		when(bundleEvent.getBundle()).thenReturn(bundle);
+		passingHas(BundleEventConditions.bundleEquals(bundle), bundleEvent);
+
+		failingHas(BundleEventConditions.bundleEquals(otherbundle), bundleEvent, "bundle equals", otherbundle);
+	}
+
+	@Test
+	void originEquals() throws Exception {
+
+		when(bundleEvent.getOrigin()).thenReturn(bundle);
+		passingHas(BundleEventConditions.originEquals(bundle), bundleEvent);
+
+		failingHas(BundleEventConditions.originEquals(otherbundle), bundleEvent, "::getOrigin.*bundle equals",
+			otherbundle);
+	}
+
+	@Test
+	void matches() throws Exception {
+
+		when(bundleEvent.getOrigin()).thenReturn(bundle);
+		when(bundleEvent.getBundle()).thenReturn(bundle);
+		when(bundleEvent.getType()).thenReturn(BundleEvent.INSTALLED);
+
+		passingHas(BundleEventConditions.matches(BundleEvent.INSTALLED, bundle, bundle), bundleEvent);
+
+		failingHas(BundleEventConditions.matches(BundleEvent.STOPPED, bundle, bundle), bundleEvent);
+
+		failingHas(BundleEventConditions.matches(BundleEvent.INSTALLED, otherbundle, bundle), bundleEvent);
+
+		failingHas(BundleEventConditions.matches(BundleEvent.INSTALLED, bundle, otherbundle), bundleEvent);
+	}
+
+	@Test
+	void bundleIsNotNull() throws Exception {
+
+		failingHas(BundleEventConditions.bundleIsNotNull(), bundleEvent, "bundle is not <null>");
+
+		when(bundleEvent.getBundle()).thenReturn(bundle);
+		passingHas(BundleEventConditions.bundleIsNotNull(), bundleEvent);
+	}
+
+	@Test
+	void originIsNull() throws Exception {
+
+		passingHas(BundleEventConditions.originIsNull(), bundleEvent);
+
+		when(bundleEvent.getOrigin()).thenReturn(bundle);
+		failingHas(BundleEventConditions.originIsNull(), bundleEvent, "origin is <null>");
+	}
+
+	@Test
+	void originIsNotNull() throws Exception {
+
+		failingHas(BundleEventConditions.originIsNotNull(), bundleEvent, "origin is not <null>");
+
+		when(bundleEvent.getOrigin()).thenReturn(bundle);
+		passingHas(BundleEventConditions.originIsNotNull(), bundleEvent);
+	}
+
+	@Test
+	void bundleIsNull() throws Exception {
+
+		passingHas(BundleEventConditions.bundleIsNull(), bundleEvent);
+
+		when(bundleEvent.getBundle()).thenReturn(bundle);
+		failingHas(BundleEventConditions.bundleIsNull(), bundleEvent, "bundle is <null>");
+	}
+
+	@Test
+	void type() throws Exception {
+
+		when(bundleEvent.getBundle()).thenReturn(bundle);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.INSTALLED);
+		passingHas(BundleEventConditions.type(BundleEvent.INSTALLED), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.UPDATED);
+		failingHas(BundleEventConditions.type(BundleEvent.INSTALLED), bundleEvent, "type matches mask <%s>",
+			BundleEventType.BITMAP.maskToString(BundleEvent.INSTALLED));
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.INSTALLED);
+		passingHas(BundleEventConditions.typeInstalled(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.LAZY_ACTIVATION);
+		passingHas(BundleEventConditions.typeLazyActivation(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.RESOLVED);
+		passingHas(BundleEventConditions.typeResolved(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.STARTED);
+		passingHas(BundleEventConditions.typeStarted(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.STARTING);
+		passingHas(BundleEventConditions.typeStarting(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.STOPPED);
+		passingHas(BundleEventConditions.typeStopped(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.STOPPING);
+		passingHas(BundleEventConditions.typeStopping(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.UNINSTALLED);
+		passingHas(BundleEventConditions.typeUninstalled(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.UNRESOLVED);
+		passingHas(BundleEventConditions.typeUnresolved(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.UPDATED);
+		passingHas(BundleEventConditions.typeUpdated(), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.INSTALLED);
+		passingHas(BundleEventConditions.typeAndBundle(BundleEvent.INSTALLED, bundle), bundleEvent);
+
+		passingHas(BundleEventConditions.typeInstalledAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.LAZY_ACTIVATION);
+		passingHas(BundleEventConditions.typeLazyActivationAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.RESOLVED);
+		passingHas(BundleEventConditions.typeResolvedAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.STARTED);
+		passingHas(BundleEventConditions.typeStartedAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.STARTING);
+		passingHas(BundleEventConditions.typeStartingAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.STOPPED);
+		passingHas(BundleEventConditions.typeStoppedAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.STOPPING);
+		passingHas(BundleEventConditions.typeStoppingAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.UNINSTALLED);
+		passingHas(BundleEventConditions.typeUninstalledAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.UNRESOLVED);
+		passingHas(BundleEventConditions.typeUnresolvedAndBundleEquals(bundle), bundleEvent);
+
+		when(bundleEvent.getType()).thenReturn(BundleEvent.UPDATED);
+		passingHas(BundleEventConditions.typeUpdatedAndBundleEquals(bundle), bundleEvent);
+
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventConditionsTests.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventConditionsTests.java
@@ -126,66 +126,7 @@ class BundleEventConditionsTests implements ConditionAssert {
 			BundleEventType.BITMAP.maskToString(BundleEvent.INSTALLED));
 
 		when(bundleEvent.getType()).thenReturn(BundleEvent.INSTALLED);
-		passingHas(BundleEventConditions.typeInstalled(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.LAZY_ACTIVATION);
-		passingHas(BundleEventConditions.typeLazyActivation(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.RESOLVED);
-		passingHas(BundleEventConditions.typeResolved(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.STARTED);
-		passingHas(BundleEventConditions.typeStarted(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.STARTING);
-		passingHas(BundleEventConditions.typeStarting(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.STOPPED);
-		passingHas(BundleEventConditions.typeStopped(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.STOPPING);
-		passingHas(BundleEventConditions.typeStopping(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.UNINSTALLED);
-		passingHas(BundleEventConditions.typeUninstalled(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.UNRESOLVED);
-		passingHas(BundleEventConditions.typeUnresolved(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.UPDATED);
-		passingHas(BundleEventConditions.typeUpdated(), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.INSTALLED);
 		passingHas(BundleEventConditions.typeAndBundle(BundleEvent.INSTALLED, bundle), bundleEvent);
-
-		passingHas(BundleEventConditions.typeInstalledAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.LAZY_ACTIVATION);
-		passingHas(BundleEventConditions.typeLazyActivationAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.RESOLVED);
-		passingHas(BundleEventConditions.typeResolvedAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.STARTED);
-		passingHas(BundleEventConditions.typeStartedAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.STARTING);
-		passingHas(BundleEventConditions.typeStartingAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.STOPPED);
-		passingHas(BundleEventConditions.typeStoppedAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.STOPPING);
-		passingHas(BundleEventConditions.typeStoppingAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.UNINSTALLED);
-		passingHas(BundleEventConditions.typeUninstalledAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.UNRESOLVED);
-		passingHas(BundleEventConditions.typeUnresolvedAndBundleEquals(bundle), bundleEvent);
-
-		when(bundleEvent.getType()).thenReturn(BundleEvent.UPDATED);
-		passingHas(BundleEventConditions.typeUpdatedAndBundleEquals(bundle), bundleEvent);
 
 	}
 }

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/dictionary/DictionaryConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/dictionary/DictionaryConditionsTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.dictionary;
+
+import org.junit.jupiter.api.Test;
+import org.osgi.test.assertj.dictionary.DictionaryConditions;
+import org.osgi.test.assertj.test.testutil.ConditionAssert;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+class DictionaryConditionsTest implements ConditionAssert {
+	String	k1	= "k1";
+	String	k2	= "k2";
+	String	v1	= "v1";
+	String	v2	= "v2";
+
+	@Test
+	void serviceProperties() throws Exception {
+		passingHas(DictionaryConditions.servicePropertiesContains(Dictionaries.dictionaryOf(k1, v1)),
+			Dictionaries.dictionaryOf(k1, v1));
+		passingHas(
+			DictionaryConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k1, v1))),
+			Dictionaries.dictionaryOf(k1, v1));
+
+
+
+		failingHas(DictionaryConditions.servicePropertiesContains(Dictionaries.dictionaryOf(k2, v2)),
+			Dictionaries.dictionaryOf(k1, v1));
+		failingHas(
+			DictionaryConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k2, v2))),
+			Dictionaries.dictionaryOf(k1, v1));
+		failingHas(
+			DictionaryConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k2, v2))),
+			Dictionaries.dictionaryOf(k1, "z"));
+
+		passingHas(DictionaryConditions.servicePropertyContains(k1, v1), Dictionaries.dictionaryOf(k1, v1));
+		failingHas(DictionaryConditions.servicePropertyContains(k1, "Z"), Dictionaries.dictionaryOf(k1, v1));
+
+		passingHas(DictionaryConditions.servicePropertiesMatch("(k1=v1)"), Dictionaries.dictionaryOf(k1, v1));
+		failingHas(DictionaryConditions.servicePropertiesMatch("(k1=v1)"), Dictionaries.dictionaryOf(k1, v2));
+	}
+
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventConditionsTest.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.frameworkevent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.test.assertj.frameworkevent.FrameworkEventConditions;
+import org.osgi.test.assertj.test.testutil.ConditionAssert;
+import org.osgi.test.common.bitmaps.FrameworkEventType;
+
+class FrameworkEventConditionsTest implements ConditionAssert {
+
+	Bundle			bundle;
+	FrameworkEvent	frameworkEvent;
+	Bundle			otherbundle;
+	Throwable		throwable;
+
+	@BeforeEach
+	private void beforEach() {
+		frameworkEvent = mock(FrameworkEvent.class, "theFrameworkEvent");
+		bundle = mock(Bundle.class, "theBundle");
+		otherbundle = mock(Bundle.class, "otherbundle");
+		throwable = new NullPointerException("NullPointerException");
+	}
+
+	@Test
+	void bundleIsNotNull() throws Exception {
+
+		failingHas(FrameworkEventConditions.bundleIsNotNull(), frameworkEvent, "bundle is <null>");
+
+		when(frameworkEvent.getBundle()).thenReturn(bundle);
+		passingHas(FrameworkEventConditions.bundleIsNotNull(), frameworkEvent);
+	}
+
+	@Test
+	void throwableIsNotNull() throws Exception {
+
+		failingHas(FrameworkEventConditions.throwableIsNotNull(), frameworkEvent, "throwable is <null>");
+
+		when(frameworkEvent.getThrowable()).thenReturn(throwable);
+		passingHas(FrameworkEventConditions.throwableIsNotNull(), frameworkEvent);
+
+	}
+
+	@Test
+	void throwableIsNull() throws Exception {
+
+		passingHas(FrameworkEventConditions.throwableIsNull(), frameworkEvent);
+
+		when(frameworkEvent.getThrowable()).thenReturn(throwable);
+		failingHas(FrameworkEventConditions.throwableIsNull(), frameworkEvent, "throwable is <null>");
+	}
+
+	@Test
+	void throwableOfClass() throws Exception {
+
+		when(frameworkEvent.getThrowable()).thenReturn(throwable);
+
+		passingHas(FrameworkEventConditions.throwableOfClass(NullPointerException.class), frameworkEvent);
+
+		failingHas(FrameworkEventConditions.throwableOfClass(IllegalArgumentException.class), frameworkEvent,
+			"throwable of Class");
+	}
+
+	@Test
+	void matches() throws Exception {
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.ERROR);
+		when(frameworkEvent.getThrowable()).thenReturn(throwable);
+		when(frameworkEvent.getBundle()).thenReturn(bundle);
+
+		passingHas(FrameworkEventConditions.matches(FrameworkEvent.ERROR, NullPointerException.class), frameworkEvent);
+
+		failingHas(FrameworkEventConditions.matches(FrameworkEvent.ERROR, IllegalArgumentException.class),
+			frameworkEvent);
+
+		failingHas(FrameworkEventConditions.matches(FrameworkEvent.INFO, NullPointerException.class), frameworkEvent);
+
+		passingHas(FrameworkEventConditions.matches(FrameworkEvent.ERROR, bundle, NullPointerException.class),
+			frameworkEvent);
+
+		failingHas(FrameworkEventConditions.matches(FrameworkEvent.ERROR, bundle, IllegalArgumentException.class),
+			frameworkEvent);
+
+		failingHas(FrameworkEventConditions.matches(FrameworkEvent.INFO, bundle, NullPointerException.class),
+			frameworkEvent);
+
+		failingHas(FrameworkEventConditions.matches(FrameworkEvent.ERROR, otherbundle, NullPointerException.class),
+			frameworkEvent);
+
+	}
+
+	@Test
+	void typeAnd() throws Exception {
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.ERROR);
+		when(frameworkEvent.getThrowable()).thenReturn(throwable);
+		when(frameworkEvent.getBundle()).thenReturn(bundle);
+		passingHas(FrameworkEventConditions.typeAndBundle(FrameworkEvent.ERROR, bundle), frameworkEvent);
+
+		failingHas(FrameworkEventConditions.typeAndBundle(FrameworkEvent.INFO, bundle), frameworkEvent);
+		failingHas(FrameworkEventConditions.typeAndBundle(FrameworkEvent.ERROR, otherbundle), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.ERROR);
+		passingHas(FrameworkEventConditions.typeErrorAndThrowableOfClass(NullPointerException.class), frameworkEvent);
+		failingHas(FrameworkEventConditions.typeErrorAndThrowableOfClass(IllegalArgumentException.class),
+			frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.INFO);
+		passingHas(FrameworkEventConditions.typeInfoAndThrowableOfClass(NullPointerException.class), frameworkEvent);
+		failingHas(FrameworkEventConditions.typeInfoAndThrowableOfClass(IllegalArgumentException.class),
+			frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.WARNING);
+		passingHas(FrameworkEventConditions.typeWarningAndThrowableOfClass(NullPointerException.class), frameworkEvent);
+		failingHas(FrameworkEventConditions.typeWarningAndThrowableOfClass(IllegalArgumentException.class),
+			frameworkEvent);
+	}
+
+	@Test
+	void bundleEquals() throws Exception {
+
+		when(frameworkEvent.getBundle()).thenReturn(bundle);
+
+		passingHas(FrameworkEventConditions.bundleEquals(bundle), frameworkEvent);
+
+		failingHas(FrameworkEventConditions.bundleEquals(otherbundle), frameworkEvent);
+	}
+
+	@Test
+	void type() throws Exception {
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.ERROR);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.ERROR), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeError(), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.INFO);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.INFO), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeInfo(), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.PACKAGES_REFRESHED);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.PACKAGES_REFRESHED), frameworkEvent);
+		passingHas(FrameworkEventConditions.typePackagesRefreshed(), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STARTED);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.STARTED), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeStarted(), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STARTLEVEL_CHANGED);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.STARTLEVEL_CHANGED), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeStartLevelChanged(), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STOPPED);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.STOPPED), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeStopped(), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeStopped_BootClasspathModified(), frameworkEvent);
+
+		// TODO: R7
+		// when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STOPPED_SYSTEM_REFRESHED);
+		// passingHas(FrameworkEventConditions.type(FrameworkEvent.STOPPED_SYSTEM_REFRESHED),
+		// frameworkEvent);
+		// passingHas(FrameworkEventConditions.typeStoppedSystemRefreshes(),
+		// frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STOPPED_UPDATE);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.STOPPED_UPDATE), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeStoppedUpdate(), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.WAIT_TIMEDOUT);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.WAIT_TIMEDOUT), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeWaitTimeout(), frameworkEvent);
+
+		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.WARNING);
+		passingHas(FrameworkEventConditions.type(FrameworkEvent.WARNING), frameworkEvent);
+		passingHas(FrameworkEventConditions.typeWarning(), frameworkEvent);
+
+		failingHas(FrameworkEventConditions.type(FrameworkEvent.INFO), frameworkEvent, "type matches mask <%s>",
+			FrameworkEventType.BITMAP.maskToString(FrameworkEvent.INFO));
+	}
+
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventConditionsTest.java
@@ -121,20 +121,6 @@ class FrameworkEventConditionsTest implements ConditionAssert {
 		failingHas(FrameworkEventConditions.typeAndBundle(FrameworkEvent.INFO, bundle), frameworkEvent);
 		failingHas(FrameworkEventConditions.typeAndBundle(FrameworkEvent.ERROR, otherbundle), frameworkEvent);
 
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.ERROR);
-		passingHas(FrameworkEventConditions.typeErrorAndThrowableOfClass(NullPointerException.class), frameworkEvent);
-		failingHas(FrameworkEventConditions.typeErrorAndThrowableOfClass(IllegalArgumentException.class),
-			frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.INFO);
-		passingHas(FrameworkEventConditions.typeInfoAndThrowableOfClass(NullPointerException.class), frameworkEvent);
-		failingHas(FrameworkEventConditions.typeInfoAndThrowableOfClass(IllegalArgumentException.class),
-			frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.WARNING);
-		passingHas(FrameworkEventConditions.typeWarningAndThrowableOfClass(NullPointerException.class), frameworkEvent);
-		failingHas(FrameworkEventConditions.typeWarningAndThrowableOfClass(IllegalArgumentException.class),
-			frameworkEvent);
 	}
 
 	@Test
@@ -149,53 +135,8 @@ class FrameworkEventConditionsTest implements ConditionAssert {
 
 	@Test
 	void type() throws Exception {
+
 		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.ERROR);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.ERROR), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeError(), frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.INFO);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.INFO), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeInfo(), frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.PACKAGES_REFRESHED);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.PACKAGES_REFRESHED), frameworkEvent);
-		passingHas(FrameworkEventConditions.typePackagesRefreshed(), frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STARTED);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.STARTED), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeStarted(), frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STARTLEVEL_CHANGED);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.STARTLEVEL_CHANGED), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeStartLevelChanged(), frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STOPPED);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.STOPPED), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeStopped(), frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.STOPPED_BOOTCLASSPATH_MODIFIED), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeStopped_BootClasspathModified(), frameworkEvent);
-
-		// TODO: R7
-		// when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STOPPED_SYSTEM_REFRESHED);
-		// passingHas(FrameworkEventConditions.type(FrameworkEvent.STOPPED_SYSTEM_REFRESHED),
-		// frameworkEvent);
-		// passingHas(FrameworkEventConditions.typeStoppedSystemRefreshes(),
-		// frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.STOPPED_UPDATE);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.STOPPED_UPDATE), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeStoppedUpdate(), frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.WAIT_TIMEDOUT);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.WAIT_TIMEDOUT), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeWaitTimeout(), frameworkEvent);
-
-		when(frameworkEvent.getType()).thenReturn(FrameworkEvent.WARNING);
-		passingHas(FrameworkEventConditions.type(FrameworkEvent.WARNING), frameworkEvent);
-		passingHas(FrameworkEventConditions.typeWarning(), frameworkEvent);
-
 		failingHas(FrameworkEventConditions.type(FrameworkEvent.INFO), frameworkEvent, "type matches mask <%s>",
 			FrameworkEventType.BITMAP.maskToString(FrameworkEvent.INFO));
 	}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventConditionsTest.java
@@ -44,14 +44,6 @@ class FrameworkEventConditionsTest implements ConditionAssert {
 		throwable = new NullPointerException("NullPointerException");
 	}
 
-	@Test
-	void bundleIsNotNull() throws Exception {
-
-		failingHas(FrameworkEventConditions.bundleIsNotNull(), frameworkEvent, "bundle is <null>");
-
-		when(frameworkEvent.getBundle()).thenReturn(bundle);
-		passingHas(FrameworkEventConditions.bundleIsNotNull(), frameworkEvent);
-	}
 
 	@Test
 	void throwableIsNotNull() throws Exception {

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventConditionsTest.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.serviceevent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.assertj.serviceevent.ServiceEventConditions;
+import org.osgi.test.assertj.servicereference.ServiceReferenceConditions;
+import org.osgi.test.assertj.test.testutil.ConditionAssert;
+import org.osgi.test.common.bitmaps.ServiceEventType;
+
+class ServiceEventConditionsTest implements ConditionAssert {
+
+	@SuppressWarnings("rawtypes")
+	ServiceReference	otherServiceReference;
+
+	ServiceEvent		serviceEvent;
+
+	@SuppressWarnings("rawtypes")
+	ServiceReference	serviceReference;
+
+	@BeforeEach
+	private void beforEach() {
+		serviceEvent = mock(ServiceEvent.class, "theServiceEvent");
+		serviceReference = mock(ServiceReference.class, "serviceReference");
+		otherServiceReference = mock(ServiceReference.class, "otherServiceReference");
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void serviceReferenceEquals() throws Exception {
+
+		when(serviceEvent.getServiceReference()).thenReturn(serviceReference);
+		passingHas(ServiceEventConditions.serviceReferenceEquals(serviceReference), serviceEvent);
+
+		failingHas(ServiceEventConditions.serviceReferenceEquals(otherServiceReference), serviceEvent,
+			"serviceReference equals");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void serviceReferenceHas() throws Exception {
+		Condition<ServiceReference<?>> c = ServiceReferenceConditions.sameAs(mock(ServiceReference.class));
+
+		when(serviceEvent.getServiceReference()).thenReturn(serviceReference);
+		failingHas(ServiceEventConditions.serviceReferenceHas(c), serviceEvent, "serviceReference equals");
+
+		c = ServiceReferenceConditions.sameAs(serviceReference);
+		passingHas(ServiceEventConditions.serviceReferenceHas(c), serviceEvent);
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void serviceReferenceIsNotNull() throws Exception {
+
+		failingHas(ServiceEventConditions.serviceReferenceIsNotNull(), serviceEvent, "not.*serviceReference is <null>");
+
+		when(serviceEvent.getServiceReference()).thenReturn(serviceReference);
+		passingHas(ServiceEventConditions.serviceReferenceIsNotNull(), serviceEvent);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void serviceReferenceIsNull() throws Exception {
+
+		passingHas(ServiceEventConditions.serviceReferenceIsNull(), serviceEvent);
+
+		when(serviceEvent.getServiceReference()).thenReturn(serviceReference);
+		failingHas(ServiceEventConditions.serviceReferenceIsNull(), serviceEvent, "serviceReference is <null>");
+	}
+
+	@Test
+	void type() throws Exception {
+
+		when(serviceEvent.getServiceReference()).thenReturn(serviceReference);
+		when(serviceReference.getProperty("objectClass")).thenReturn(new String[] {
+			A.class.getName()
+		});
+		when(serviceReference.getProperty("k")).thenReturn("v");
+		when(serviceReference.getPropertyKeys()).thenReturn(new String[] {
+			"k", "objectClass"
+		});
+
+		when(serviceEvent.getType()).thenReturn(ServiceEvent.MODIFIED);
+		passingHas(ServiceEventConditions.type(ServiceEvent.MODIFIED), serviceEvent);
+
+		passingHas(ServiceEventConditions.matches(ServiceEvent.MODIFIED, A.class), serviceEvent);
+		failingHas(ServiceEventConditions.matches(ServiceEvent.UNREGISTERING, A.class), serviceEvent);
+		failingHas(ServiceEventConditions.matches(ServiceEvent.MODIFIED, B.class), serviceEvent);
+
+		passingHas(ServiceEventConditions.matches(ServiceEvent.MODIFIED, "(k=v)"), serviceEvent);
+		failingHas(ServiceEventConditions.matches(ServiceEvent.UNREGISTERING, "(k=v)"), serviceEvent);
+		failingHas(ServiceEventConditions.matches(ServiceEvent.MODIFIED, "(k=fail)"), serviceEvent);
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("k", "v");
+		passingHas(ServiceEventConditions.matches(ServiceEvent.MODIFIED, A.class, map), serviceEvent);
+		failingHas(ServiceEventConditions.matches(ServiceEvent.UNREGISTERING, A.class, map), serviceEvent);
+		failingHas(ServiceEventConditions.matches(ServiceEvent.MODIFIED, B.class, map), serviceEvent);
+
+		map.put("kk", "vv");
+		failingHas(ServiceEventConditions.matches(ServiceEvent.MODIFIED, A.class, map), serviceEvent);
+
+		when(serviceEvent.getType()).thenReturn(ServiceEvent.MODIFIED_ENDMATCH);
+		failingHas(ServiceEventConditions.type(ServiceEvent.MODIFIED), serviceEvent, "type matches mask <%s>",
+			ServiceEventType.BITMAP.maskToString(ServiceEvent.MODIFIED));
+
+		when(serviceEvent.getType()).thenReturn(ServiceEvent.MODIFIED);
+		passingHas(ServiceEventConditions.typeModified(), serviceEvent);
+		failingHas(ServiceEventConditions.typeModifiedEndmatch(), serviceEvent, "type matches mask <%s>",
+			ServiceEventType.BITMAP.maskToString(ServiceEvent.MODIFIED_ENDMATCH));
+		passingHas(ServiceEventConditions.typeModifiedAndObjectClass(A.class), serviceEvent);
+		failingHas(ServiceEventConditions.typeModifiedAndObjectClass(B.class), serviceEvent);
+
+		when(serviceEvent.getType()).thenReturn(ServiceEvent.MODIFIED_ENDMATCH);
+		passingHas(ServiceEventConditions.typeModifiedEndmatch(), serviceEvent);
+		failingHas(ServiceEventConditions.typeModified(), serviceEvent, "type matches mask <%s>",
+			ServiceEventType.BITMAP.maskToString(ServiceEvent.MODIFIED));
+
+
+		when(serviceEvent.getType()).thenReturn(ServiceEvent.REGISTERED);
+		passingHas(ServiceEventConditions.typeRegistered(), serviceEvent);
+		failingHas(ServiceEventConditions.typeUnregistering(), serviceEvent, "type matches mask <%s>",
+			ServiceEventType.BITMAP.maskToString(ServiceEvent.UNREGISTERING));
+		passingHas(ServiceEventConditions.typeRegisteredAndObjectClass(A.class), serviceEvent);
+		failingHas(ServiceEventConditions.typeRegisteredAndObjectClass(B.class), serviceEvent);
+
+		when(serviceEvent.getType()).thenReturn(ServiceEvent.UNREGISTERING);
+		passingHas(ServiceEventConditions.typeUnregistering(), serviceEvent);
+		failingHas(ServiceEventConditions.typeRegistered(), serviceEvent, "type matches mask <%s>",
+			ServiceEventType.BITMAP.maskToString(ServiceEvent.REGISTERED));
+		passingHas(ServiceEventConditions.typeUnregisteringAndObjectClass(A.class), serviceEvent);
+		failingHas(ServiceEventConditions.typeUnregisteringAndObjectClass(B.class), serviceEvent);
+
+
+	}
+
+	class A {
+
+	}
+
+	class B {
+
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventConditionsTest.java
@@ -132,34 +132,6 @@ class ServiceEventConditionsTest implements ConditionAssert {
 		failingHas(ServiceEventConditions.type(ServiceEvent.MODIFIED), serviceEvent, "type matches mask <%s>",
 			ServiceEventType.BITMAP.maskToString(ServiceEvent.MODIFIED));
 
-		when(serviceEvent.getType()).thenReturn(ServiceEvent.MODIFIED);
-		passingHas(ServiceEventConditions.typeModified(), serviceEvent);
-		failingHas(ServiceEventConditions.typeModifiedEndmatch(), serviceEvent, "type matches mask <%s>",
-			ServiceEventType.BITMAP.maskToString(ServiceEvent.MODIFIED_ENDMATCH));
-		passingHas(ServiceEventConditions.typeModifiedAndObjectClass(A.class), serviceEvent);
-		failingHas(ServiceEventConditions.typeModifiedAndObjectClass(B.class), serviceEvent);
-
-		when(serviceEvent.getType()).thenReturn(ServiceEvent.MODIFIED_ENDMATCH);
-		passingHas(ServiceEventConditions.typeModifiedEndmatch(), serviceEvent);
-		failingHas(ServiceEventConditions.typeModified(), serviceEvent, "type matches mask <%s>",
-			ServiceEventType.BITMAP.maskToString(ServiceEvent.MODIFIED));
-
-
-		when(serviceEvent.getType()).thenReturn(ServiceEvent.REGISTERED);
-		passingHas(ServiceEventConditions.typeRegistered(), serviceEvent);
-		failingHas(ServiceEventConditions.typeUnregistering(), serviceEvent, "type matches mask <%s>",
-			ServiceEventType.BITMAP.maskToString(ServiceEvent.UNREGISTERING));
-		passingHas(ServiceEventConditions.typeRegisteredAndObjectClass(A.class), serviceEvent);
-		failingHas(ServiceEventConditions.typeRegisteredAndObjectClass(B.class), serviceEvent);
-
-		when(serviceEvent.getType()).thenReturn(ServiceEvent.UNREGISTERING);
-		passingHas(ServiceEventConditions.typeUnregistering(), serviceEvent);
-		failingHas(ServiceEventConditions.typeRegistered(), serviceEvent, "type matches mask <%s>",
-			ServiceEventType.BITMAP.maskToString(ServiceEvent.REGISTERED));
-		passingHas(ServiceEventConditions.typeUnregisteringAndObjectClass(A.class), serviceEvent);
-		failingHas(ServiceEventConditions.typeUnregisteringAndObjectClass(B.class), serviceEvent);
-
-
 	}
 
 	class A {

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventConditionsTest.java
@@ -66,12 +66,12 @@ class ServiceEventConditionsTest implements ConditionAssert {
 	@SuppressWarnings("unchecked")
 	@Test
 	void serviceReferenceHas() throws Exception {
-		Condition<ServiceReference<?>> c = ServiceReferenceConditions.sameAs(mock(ServiceReference.class));
+		Condition<ServiceReference<?>> c = ServiceReferenceConditions.isEqualsTo(mock(ServiceReference.class));
 
 		when(serviceEvent.getServiceReference()).thenReturn(serviceReference);
 		failingHas(ServiceEventConditions.serviceReferenceHas(c), serviceEvent, "serviceReference equals");
 
-		c = ServiceReferenceConditions.sameAs(serviceReference);
+		c = ServiceReferenceConditions.isEqualsTo(serviceReference);
 		passingHas(ServiceEventConditions.serviceReferenceHas(c), serviceEvent);
 
 	}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/servicereference/ServicePropertiesConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/servicereference/ServicePropertiesConditionsTest.java
@@ -16,14 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
-package org.osgi.test.assertj.test.dictionary;
+package org.osgi.test.assertj.test.servicereference;
 
 import org.junit.jupiter.api.Test;
-import org.osgi.test.assertj.dictionary.DictionaryConditions;
+import org.osgi.test.assertj.servicereference.ServicePropertiesConditions;
 import org.osgi.test.assertj.test.testutil.ConditionAssert;
 import org.osgi.test.common.dictionary.Dictionaries;
 
-class DictionaryConditionsTest implements ConditionAssert {
+class ServicePropertiesConditionsTest implements ConditionAssert {
 	String	k1	= "k1";
 	String	k2	= "k2";
 	String	v1	= "v1";
@@ -31,28 +31,28 @@ class DictionaryConditionsTest implements ConditionAssert {
 
 	@Test
 	void serviceProperties() throws Exception {
-		passingHas(DictionaryConditions.servicePropertiesContains(Dictionaries.dictionaryOf(k1, v1)),
+		passingHas(ServicePropertiesConditions.servicePropertiesContains(Dictionaries.dictionaryOf(k1, v1)),
 			Dictionaries.dictionaryOf(k1, v1));
 		passingHas(
-			DictionaryConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k1, v1))),
+			ServicePropertiesConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k1, v1))),
 			Dictionaries.dictionaryOf(k1, v1));
 
 
 
-		failingHas(DictionaryConditions.servicePropertiesContains(Dictionaries.dictionaryOf(k2, v2)),
-			Dictionaries.dictionaryOf(k1, v1));
-		failingHas(
-			DictionaryConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k2, v2))),
+		failingHas(ServicePropertiesConditions.servicePropertiesContains(Dictionaries.dictionaryOf(k2, v2)),
 			Dictionaries.dictionaryOf(k1, v1));
 		failingHas(
-			DictionaryConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k2, v2))),
+			ServicePropertiesConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k2, v2))),
+			Dictionaries.dictionaryOf(k1, v1));
+		failingHas(
+			ServicePropertiesConditions.servicePropertiesContains(Dictionaries.asMap(Dictionaries.dictionaryOf(k2, v2))),
 			Dictionaries.dictionaryOf(k1, "z"));
 
-		passingHas(DictionaryConditions.servicePropertyContains(k1, v1), Dictionaries.dictionaryOf(k1, v1));
-		failingHas(DictionaryConditions.servicePropertyContains(k1, "Z"), Dictionaries.dictionaryOf(k1, v1));
+		passingHas(ServicePropertiesConditions.servicePropertyContains(k1, v1), Dictionaries.dictionaryOf(k1, v1));
+		failingHas(ServicePropertiesConditions.servicePropertyContains(k1, "Z"), Dictionaries.dictionaryOf(k1, v1));
 
-		passingHas(DictionaryConditions.servicePropertiesMatch("(k1=v1)"), Dictionaries.dictionaryOf(k1, v1));
-		failingHas(DictionaryConditions.servicePropertiesMatch("(k1=v1)"), Dictionaries.dictionaryOf(k1, v2));
+		passingHas(ServicePropertiesConditions.servicePropertiesMatch("(k1=v1)"), Dictionaries.dictionaryOf(k1, v1));
+		failingHas(ServicePropertiesConditions.servicePropertiesMatch("(k1=v1)"), Dictionaries.dictionaryOf(k1, v2));
 	}
 
 }

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/servicereference/ServiceReferenceConditionsTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/servicereference/ServiceReferenceConditionsTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.servicereference;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.assertj.servicereference.ServiceReferenceConditions;
+import org.osgi.test.assertj.test.testutil.ConditionAssert;
+
+class ServiceReferenceConditionsTest implements ConditionAssert {
+
+	class A {}
+
+	@SuppressWarnings("rawtypes")
+	ServiceReference	otherServiceReference;
+
+	@SuppressWarnings("rawtypes")
+	ServiceReference	serviceReference;
+
+	@BeforeEach
+	private void beforEach() {
+		serviceReference = mock(ServiceReference.class, "serviceReference");
+		otherServiceReference = mock(ServiceReference.class, "otherServiceReference");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void serviceReferenceIsNotNull() throws Exception {
+
+		when(serviceReference.getProperty(Constants.OBJECTCLASS)).thenReturn(new String[] {
+			A.class.getName()
+		});
+
+		passingHas(ServiceReferenceConditions.objectClass(A.class), serviceReference);
+		failingHas(ServiceReferenceConditions.objectClass(A.class), otherServiceReference)
+			.hasMessageMatching((regex_startWith_Expecting + "has Objectclass .*"));
+
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/testutil/ConditionAssert.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/testutil/ConditionAssert.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.testutil;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.ObjectAssertFactory;
+
+public interface ConditionAssert {
+	String regex_startWith_Expecting = "(?si).*Expecting.*";
+
+	default <T> AbstractThrowableAssert<?, ?> failingHas(Condition<T> condition, T actual, String msg, Object... args) {
+		return failingHas(condition, actual, String.format(msg, args));
+	}
+
+	default <T> AbstractThrowableAssert<?, ?> failingHas(Condition<T> condition, T actual, String msg) {
+		String regex = regex_expecting_X_M_Y(actual, ConditionMethod.Has, msg);
+		return failingHas(condition, actual).hasMessageMatching(regex);
+	}
+
+	default <T> AbstractThrowableAssert<?, ?> failingHas(Condition<T> condition, T actual) {
+		return assertThatThrownBy(() -> passingHas(condition, actual)).isInstanceOf(AssertionError.class);
+	}
+
+	default <T> AbstractThrowableAssert<?, ?> failingIs(Condition<T> condition, T actual, String msg, Object... args) {
+		return failingIs(condition, actual, String.format(msg, args));
+	}
+
+	default <T> AbstractThrowableAssert<?, ?> failingIs(Condition<T> condition, T actual, String msg) {
+		String regex = regex_expecting_X_M_Y(actual, ConditionMethod.Is, msg);
+		return assertThatThrownBy(() -> passingIs(condition, actual)).isInstanceOf(AssertionError.class)
+			.hasMessageMatching(regex);
+	}
+
+	default <T> void passingHas(Condition<T> condition, T actual) {
+		ObjectAssertFactory<T> factory = new ObjectAssertFactory<>();
+		factory.createAssert(actual)
+			.has(condition);
+	}
+
+	default <T> void passingIs(Condition<T> condition, T actual) {
+		ObjectAssertFactory<T> factory = new ObjectAssertFactory<>();
+		factory.createAssert(actual)
+			.is(condition);
+	}
+
+	default String regex_expecting_X_M_Y(Object x, ConditionMethod m, Object y) {
+		return String.format(regex_startWith_Expecting + "%s.*" + m + ".*%s.*", Pattern.quote(x.toString()), y);
+	}
+
+	default String regex_expecting_X_M_Y_Z(Object x, ConditionMethod m, Object y, Object z) {
+		return regex_expecting_X_M_Y(x, m, String.format("%s.*%s", y, z));
+	}
+
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/testutil/ConditionMethod.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/testutil/ConditionMethod.java
@@ -16,6 +16,24 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
-@org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
-package org.osgi.test.assertj.bundleevent;
+package org.osgi.test.assertj.test.testutil;
+
+public enum ConditionMethod {
+
+	Has("to have"),
+	DoesNotHas("not to have"),
+	Is("to be"),
+	IsNot("not to be");
+
+	private String text;
+
+	ConditionMethod(String text) {
+		this.text = text;
+	}
+
+	@Override
+	public String toString() {
+
+		return text;
+	}
+}


### PR DESCRIPTION
AssertJ provides an way to Extend Asserations [see AssertJ](https://assertj.github.io/doc/#assertj-core-conditions)

Conditions helpes to test Objects and Lists using is/has, isNot/hasNot, contains, doesNotContain ...
They are kind of a described Predicate.

This PR provides a these Conditions.

Would be nice to get some FeedbackThe
The output-message of join-Conditions will look better in next assertj version. [fix in assertj](https://github.com/assertj/assertj-core/pull/2074)

```java
       List<ServiceEvents> serviceEvents;
    
        // ListAsserts in combination with Conditions
        serviceEvents
            .areAtLeast(1, typeModified())
            .are(hasObjectClass(A.class))
            .areExactly(3, objectClass(A.class))
            .areNot(typeModifiedEndmatch())

           serviceEvents
            .element(0)
            .is(typeRegistered())
            .is(objectClass(A.class))
            .is(typeRegistered(A.class))
            .is(containServiceProperty(k1, v1))
            .is(matches(REGISTERED, A.class, dictionaryOf(k1, v1)));
``` 