### PR TITLE
Predicates for Service, Bundle, and Framework Events

### DIFF
--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventPredicates.java
@@ -24,8 +24,10 @@ import org.osgi.framework.BundleEvent;
 
 /**
  * The Interface BundleEventPredicates.
+ *
+ * @since 1.1
  */
-public class BundleEventPredicates {
+public final class BundleEventPredicates {
 
 	private BundleEventPredicates() {}
 
@@ -36,7 +38,7 @@ public class BundleEventPredicates {
 	 *
 	 * @return the predicate
 	 */
-	public static Predicate<Object> bundleEvent() {
+	public static <T> Predicate<T> bundleEvent() {
 		return e -> e instanceof BundleEvent;
 	}
 

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventPredicates.java
@@ -41,17 +41,6 @@ public class BundleEventPredicates {
 	}
 
 	/**
-	 * Returns a predicate that tests if the object Bundle event and matches the
-	 * given eventTypeMask.
-	 *
-	 * @param predicate the predicate
-	 * @return the predicate
-	 */
-	public static Predicate<Object> bundleEventAnd(Predicate<BundleEvent> predicate) {
-		return e -> bundleEvent().test(e) && predicate.test((BundleEvent) e);
-	}
-
-	/**
 	 * Returns a predicate that tests if the event-type matches the given
 	 * eventTypeMask.
 	 *
@@ -60,96 +49,5 @@ public class BundleEventPredicates {
 	 */
 	public static Predicate<BundleEvent> type(final int eventTypeMask) {
 		return e -> (e.getType() & eventTypeMask) != 0;
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is installed.
-	 *
-	 * @return the predicate
-	 */
-	// BundleEvents - by type
-	public static Predicate<BundleEvent> typeInstalled() {
-		return e -> type(BundleEvent.INSTALLED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is lazy activation.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeLazyActivation() {
-		return e -> type(BundleEvent.LAZY_ACTIVATION).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is resolved.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeResolved() {
-		return e -> type(BundleEvent.RESOLVED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is started.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeStarted() {
-		return e -> type(BundleEvent.STARTED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is starting.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeStarting() {
-		return e -> type(BundleEvent.STARTING).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is stopped.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeStopped() {
-		return e -> type(BundleEvent.STOPPED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is stopping.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeStopping() {
-		return e -> type(BundleEvent.STOPPING).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is uninstalled.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeUninstalled() {
-		return e -> type(BundleEvent.UNINSTALLED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is unresolved.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeUnresolved() {
-		return e -> type(BundleEvent.UNRESOLVED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is updated.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<BundleEvent> typeUpdated() {
-		return e -> type(BundleEvent.UPDATED).test(e);
 	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/BundleEventPredicates.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.bundleevent;
+
+import java.util.function.Predicate;
+
+import org.osgi.framework.BundleEvent;
+
+/**
+ * The Interface BundleEventPredicates.
+ */
+public class BundleEventPredicates {
+
+	private BundleEventPredicates() {}
+
+	// BundleEvents
+
+	/**
+	 * Returns a predicate that tests if the object Bundle event.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<Object> bundleEvent() {
+		return e -> e instanceof BundleEvent;
+	}
+
+	/**
+	 * Returns a predicate that tests if the object Bundle event and matches the
+	 * given eventTypeMask.
+	 *
+	 * @param predicate the predicate
+	 * @return the predicate
+	 */
+	public static Predicate<Object> bundleEventAnd(Predicate<BundleEvent> predicate) {
+		return e -> bundleEvent().test(e) && predicate.test((BundleEvent) e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type matches the given
+	 * eventTypeMask.
+	 *
+	 * @param eventTypeMask the event type mask
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> type(final int eventTypeMask) {
+		return e -> (e.getType() & eventTypeMask) != 0;
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is installed.
+	 *
+	 * @return the predicate
+	 */
+	// BundleEvents - by type
+	public static Predicate<BundleEvent> typeInstalled() {
+		return e -> type(BundleEvent.INSTALLED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is lazy activation.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeLazyActivation() {
+		return e -> type(BundleEvent.LAZY_ACTIVATION).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is resolved.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeResolved() {
+		return e -> type(BundleEvent.RESOLVED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is started.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeStarted() {
+		return e -> type(BundleEvent.STARTED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is starting.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeStarting() {
+		return e -> type(BundleEvent.STARTING).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is stopped.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeStopped() {
+		return e -> type(BundleEvent.STOPPED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is stopping.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeStopping() {
+		return e -> type(BundleEvent.STOPPING).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is uninstalled.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeUninstalled() {
+		return e -> type(BundleEvent.UNINSTALLED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is unresolved.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeUnresolved() {
+		return e -> type(BundleEvent.UNRESOLVED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is updated.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<BundleEvent> typeUpdated() {
+		return e -> type(BundleEvent.UPDATED).test(e);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/package-info.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/bundleevent/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.assertj.bundleevent;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventPredicates.java
@@ -38,17 +38,6 @@ public class FrameworkEventPredicates {
 	}
 
 	/**
-	 * Returns a predicate that tests if the object is a framework event and the
-	 * given predicate also matches.
-	 *
-	 * @param predicate the predicate
-	 * @return the predicate
-	 */
-	public static Predicate<Object> frameworkEventAnd(Predicate<FrameworkEvent> predicate) {
-		return e -> frameworkEvent().test(e) && predicate.test((FrameworkEvent) e);
-	}
-
-	/**
 	 * Returns a predicate that tests if the event-type matches the
 	 * eventTypeMask.
 	 *
@@ -59,84 +48,4 @@ public class FrameworkEventPredicates {
 		return e -> (e.getType() & eventTypeMask) != 0;
 	}
 
-	/**
-	 * Returns a predicate that tests if the event-type is error.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typeError() {
-		return e -> type(FrameworkEvent.ERROR).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is info.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typeInfo() {
-		return e -> type(FrameworkEvent.INFO).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is packages refreshed.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typePackagesRefreshed() {
-		return e -> type(FrameworkEvent.PACKAGES_REFRESHED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is started.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typeStarted() {
-		return e -> type(FrameworkEvent.STARTED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is startlevel changed.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typeStartlevelChanged() {
-		return e -> type(FrameworkEvent.STARTLEVEL_CHANGED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is stopped.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typeStopped() {
-		return e -> type(FrameworkEvent.STOPPED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is stopped update.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typeStoppedUpdate() {
-		return e -> type(FrameworkEvent.STOPPED_UPDATE).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is wait-timeout.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typeWaitTimeout() {
-		return e -> type(FrameworkEvent.WAIT_TIMEDOUT).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is warning.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<FrameworkEvent> typeWarning() {
-		return e -> type(FrameworkEvent.WARNING).test(e);
-	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventPredicates.java
@@ -24,8 +24,10 @@ import org.osgi.framework.FrameworkEvent;
 
 /**
  * The Class FrameworkEventPredicates.
+ *
+ * @since 1.1
  */
-public class FrameworkEventPredicates {
+public final class FrameworkEventPredicates {
 
 	private FrameworkEventPredicates() {}
 	/**

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/FrameworkEventPredicates.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.frameworkevent;
+
+import java.util.function.Predicate;
+
+import org.osgi.framework.FrameworkEvent;
+
+/**
+ * The Class FrameworkEventPredicates.
+ */
+public class FrameworkEventPredicates {
+
+	private FrameworkEventPredicates() {}
+	/**
+	 * Returns a predicate that tests if the object is a framework event.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<Object> frameworkEvent() {
+		return e -> e instanceof FrameworkEvent;
+	}
+
+	/**
+	 * Returns a predicate that tests if the object is a framework event and the
+	 * given predicate also matches.
+	 *
+	 * @param predicate the predicate
+	 * @return the predicate
+	 */
+	public static Predicate<Object> frameworkEventAnd(Predicate<FrameworkEvent> predicate) {
+		return e -> frameworkEvent().test(e) && predicate.test((FrameworkEvent) e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type matches the
+	 * eventTypeMask.
+	 *
+	 * @param eventTypeMask the event type mask
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> type(final int eventTypeMask) {
+		return e -> (e.getType() & eventTypeMask) != 0;
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is error.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typeError() {
+		return e -> type(FrameworkEvent.ERROR).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is info.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typeInfo() {
+		return e -> type(FrameworkEvent.INFO).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is packages refreshed.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typePackagesRefreshed() {
+		return e -> type(FrameworkEvent.PACKAGES_REFRESHED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is started.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typeStarted() {
+		return e -> type(FrameworkEvent.STARTED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is startlevel changed.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typeStartlevelChanged() {
+		return e -> type(FrameworkEvent.STARTLEVEL_CHANGED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is stopped.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typeStopped() {
+		return e -> type(FrameworkEvent.STOPPED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is stopped update.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typeStoppedUpdate() {
+		return e -> type(FrameworkEvent.STOPPED_UPDATE).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is wait-timeout.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typeWaitTimeout() {
+		return e -> type(FrameworkEvent.WAIT_TIMEDOUT).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is warning.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<FrameworkEvent> typeWarning() {
+		return e -> type(FrameworkEvent.WARNING).test(e);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/package-info.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/frameworkevent/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.assertj.frameworkevent;

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventPredicates.java
@@ -48,16 +48,6 @@ public class ServiceEventPredicates {
 	}
 
 	/**
-	 * Returns a predicate that tests if the object matches the given predicate.
-	 *
-	 * @param predicate the predicate
-	 * @return the predicate
-	 */
-	public static Predicate<Object> serviceEventAnd(Predicate<ServiceEvent> predicate) {
-		return e -> serviceEvent().test(e) && predicate.test((ServiceEvent) e);
-	}
-
-	/**
 	 * Returns a predicate that tests if the event-type matches the
 	 * eventTypeMask.
 	 *
@@ -69,41 +59,6 @@ public class ServiceEventPredicates {
 		return e -> (e.getType() & eventTypeMask) != 0;
 	}
 
-	/**
-	 * Returns a predicate that tests if the event-type is registered.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeRegistered() {
-		return e -> type(ServiceEvent.REGISTERED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is modified.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeModified() {
-		return e -> type(ServiceEvent.MODIFIED).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is modified-endmatch.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeModifiedEndmatch() {
-		return e -> type(ServiceEvent.MODIFIED_ENDMATCH).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is unregistering.
-	 *
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeUnregistering() {
-		return e -> type(ServiceEvent.UNREGISTERING).test(e);
-	}
 
 	/**
 	 * Returns a predicate that tests if the Service of the event matches the
@@ -214,74 +169,5 @@ public class ServiceEventPredicates {
 	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
 		Dictionary<String, ?> properties) {
 		return e -> matches(eventTypeMask, objectClass, Dictionaries.asMap(properties)).test(e);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is registered and
-	 * matches the given objectClass.
-	 *
-	 * @param objectClass the objectClass
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeRegistered(final Class<?> objectClass) {
-		return matches(ServiceEvent.REGISTERED, objectClass);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is registered with the
-	 * given objectClass and properties.
-	 *
-	 * @param objectClass the objectClass
-	 * @param properties the properties
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeRegisteredWith(final Class<?> objectClass, Map<String, ?> properties) {
-		return matches(ServiceEvent.REGISTERED, objectClass, properties);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is registered with the
-	 * given objectClass and properties.
-	 *
-	 * @param objectClass the objectClass
-	 * @param dictionary the dictionary
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeRegisteredWith(final Class<?> objectClass,
-		Dictionary<String, ?> dictionary) {
-		return matches(ServiceEvent.REGISTERED, objectClass, dictionary);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is unregistering and
-	 * matches the given objectClass.
-	 *
-	 * @param objectClass the objectClass
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeUnregistering(final Class<?> objectClass) {
-		return matches(ServiceEvent.UNREGISTERING, objectClass);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is modified and matches
-	 * the given objectClass.
-	 *
-	 * @param objectClass the objectClass
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeModified(final Class<?> objectClass) {
-		return matches(ServiceEvent.MODIFIED, objectClass);
-	}
-
-	/**
-	 * Returns a predicate that tests if the event-type is modified endmatch and
-	 * matches the given objectClass.
-	 *
-	 * @param objectClass the objectClass
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> typeModifiedEndmatch(final Class<?> objectClass) {
-		return matches(ServiceEvent.MODIFIED_ENDMATCH, objectClass);
 	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventPredicates.java
@@ -1,0 +1,287 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.serviceevent;
+
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+/**
+ * The Class ServiceEventPredicates.
+ */
+public class ServiceEventPredicates {
+
+	private ServiceEventPredicates() {}
+	/**
+	 * Returns a predicate that tests if the object Service event.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<Object> serviceEvent() {
+		return e -> e instanceof ServiceEvent;
+	}
+
+	/**
+	 * Returns a predicate that tests if the object matches the given predicate.
+	 *
+	 * @param predicate the predicate
+	 * @return the predicate
+	 */
+	public static Predicate<Object> serviceEventAnd(Predicate<ServiceEvent> predicate) {
+		return e -> serviceEvent().test(e) && predicate.test((ServiceEvent) e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type matches the
+	 * eventTypeMask.
+	 *
+	 * @param eventTypeMask the event type mask
+	 * @return the predicate
+	 */
+	// ServiceEvents
+	public static Predicate<ServiceEvent> type(final int eventTypeMask) {
+		return e -> (e.getType() & eventTypeMask) != 0;
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is registered.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeRegistered() {
+		return e -> type(ServiceEvent.REGISTERED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is modified.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeModified() {
+		return e -> type(ServiceEvent.MODIFIED).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is modified-endmatch.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeModifiedEndmatch() {
+		return e -> type(ServiceEvent.MODIFIED_ENDMATCH).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is unregistering.
+	 *
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeUnregistering() {
+		return e -> type(ServiceEvent.UNREGISTERING).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the Service of the event matches the
+	 * objectClass.
+	 *
+	 * @param objectClass the objectClass
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> objectClass(final Class<?> objectClass) {
+
+		return e -> {
+			Object classes = e.getServiceReference()
+				.getProperty(Constants.OBJECTCLASS);
+
+			if (classes != null && classes instanceof String[]) {
+				return Stream.of((String[]) classes)
+					.filter(Objects::nonNull)
+					.anyMatch(objectClass.getName()::equals);
+			}
+			return false;
+		};
+
+	}
+
+	/**
+	 * Returns a predicate that tests if the object Contain the service
+	 * property.
+	 *
+	 * @param key the key
+	 * @param value the value
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> containServiceProperty(final String key, Object value) {
+		return e -> containsServiceProperties(Dictionaries.dictionaryOf(key, value)).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the object Contains the service
+	 * properties.
+	 *
+	 * @param map the map
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> containsServiceProperties(Map<String, ?> map) {
+		return e -> {
+			ServiceReference<?> sr = e.getServiceReference();
+			List<String> keys = Stream.of(sr.getPropertyKeys())
+				.collect(Collectors.toList());
+			for (Entry<String, ?> entry : map.entrySet()) {
+				if (!keys.contains(entry.getKey())) {
+					return false;
+				}
+				if (!Objects.equals(sr.getProperty(entry.getKey()), entry.getValue())) {
+					return false;
+				}
+			}
+			return true;
+		};
+	}
+
+	/**
+	 * Returns a predicate that tests if the object Contains the service
+	 * properties.
+	 *
+	 * @param properties the properties
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> containsServiceProperties(Dictionary<String, ?> properties) {
+		return e -> containsServiceProperties(Dictionaries.asMap(properties)).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the object Matches matches the given
+	 * parameters.
+	 *
+	 * @param eventTypeMask the event type mask
+	 * @param objectClass the objectClass
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass) {
+		return e -> type(eventTypeMask).test(e) && (objectClass(objectClass).test(e));
+	}
+
+	/**
+	 * Returns a predicate that tests if the object matches the given
+	 * parameters.
+	 *
+	 * @param eventTypeMask the event type mask
+	 * @param objectClass the objectClass
+	 * @param properties the properties
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
+		Map<String, ?> properties) {
+		return e -> type(eventTypeMask).test(e) && (objectClass(objectClass).test(e))
+			&& containsServiceProperties(properties).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the object Matches the given
+	 * parameters.
+	 *
+	 * @param eventTypeMask the event type mask
+	 * @param objectClass the objectClass
+	 * @param properties the properties
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
+		Dictionary<String, ?> properties) {
+		return e -> matches(eventTypeMask, objectClass, Dictionaries.asMap(properties)).test(e);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is registered and
+	 * matches the given objectClass.
+	 *
+	 * @param objectClass the objectClass
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeRegistered(final Class<?> objectClass) {
+		return matches(ServiceEvent.REGISTERED, objectClass);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is registered with the
+	 * given objectClass and properties.
+	 *
+	 * @param objectClass the objectClass
+	 * @param properties the properties
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeRegisteredWith(final Class<?> objectClass, Map<String, ?> properties) {
+		return matches(ServiceEvent.REGISTERED, objectClass, properties);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is registered with the
+	 * given objectClass and properties.
+	 *
+	 * @param objectClass the objectClass
+	 * @param dictionary the dictionary
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeRegisteredWith(final Class<?> objectClass,
+		Dictionary<String, ?> dictionary) {
+		return matches(ServiceEvent.REGISTERED, objectClass, dictionary);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is unregistering and
+	 * matches the given objectClass.
+	 *
+	 * @param objectClass the objectClass
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeUnregistering(final Class<?> objectClass) {
+		return matches(ServiceEvent.UNREGISTERING, objectClass);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is modified and matches
+	 * the given objectClass.
+	 *
+	 * @param objectClass the objectClass
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeModified(final Class<?> objectClass) {
+		return matches(ServiceEvent.MODIFIED, objectClass);
+	}
+
+	/**
+	 * Returns a predicate that tests if the event-type is modified endmatch and
+	 * matches the given objectClass.
+	 *
+	 * @param objectClass the objectClass
+	 * @return the predicate
+	 */
+	public static Predicate<ServiceEvent> typeModifiedEndmatch(final Class<?> objectClass) {
+		return matches(ServiceEvent.MODIFIED_ENDMATCH, objectClass);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventPredicates.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/ServiceEventPredicates.java
@@ -18,13 +18,13 @@
 
 package org.osgi.test.assertj.serviceevent;
 
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.osgi.framework.Constants;
@@ -34,8 +34,10 @@ import org.osgi.test.common.dictionary.Dictionaries;
 
 /**
  * The Class ServiceEventPredicates.
+ *
+ * @since 1.1
  */
-public class ServiceEventPredicates {
+public final class ServiceEventPredicates {
 
 	private ServiceEventPredicates() {}
 	/**
@@ -73,7 +75,7 @@ public class ServiceEventPredicates {
 			Object classes = e.getServiceReference()
 				.getProperty(Constants.OBJECTCLASS);
 
-			if (classes != null && classes instanceof String[]) {
+			if (classes instanceof String[]) {
 				return Stream.of((String[]) classes)
 					.filter(Objects::nonNull)
 					.anyMatch(objectClass.getName()::equals);
@@ -81,18 +83,6 @@ public class ServiceEventPredicates {
 			return false;
 		};
 
-	}
-
-	/**
-	 * Returns a predicate that tests if the object Contain the service
-	 * property.
-	 *
-	 * @param key the key
-	 * @param value the value
-	 * @return the predicate
-	 */
-	public static Predicate<ServiceEvent> containServiceProperty(final String key, Object value) {
-		return e -> containsServiceProperties(Dictionaries.dictionaryOf(key, value)).test(e);
 	}
 
 	/**
@@ -105,8 +95,7 @@ public class ServiceEventPredicates {
 	public static Predicate<ServiceEvent> containsServiceProperties(Map<String, ?> map) {
 		return e -> {
 			ServiceReference<?> sr = e.getServiceReference();
-			List<String> keys = Stream.of(sr.getPropertyKeys())
-				.collect(Collectors.toList());
+			List<String> keys = Arrays.asList(sr.getPropertyKeys());
 			for (Entry<String, ?> entry : map.entrySet()) {
 				if (!keys.contains(entry.getKey())) {
 					return false;
@@ -127,7 +116,7 @@ public class ServiceEventPredicates {
 	 * @return the predicate
 	 */
 	public static Predicate<ServiceEvent> containsServiceProperties(Dictionary<String, ?> properties) {
-		return e -> containsServiceProperties(Dictionaries.asMap(properties)).test(e);
+		return containsServiceProperties(Dictionaries.asMap(properties));
 	}
 
 	/**
@@ -139,7 +128,7 @@ public class ServiceEventPredicates {
 	 * @return the predicate
 	 */
 	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass) {
-		return e -> type(eventTypeMask).test(e) && (objectClass(objectClass).test(e));
+		return type(eventTypeMask).and((objectClass(objectClass)));
 	}
 
 	/**
@@ -153,8 +142,8 @@ public class ServiceEventPredicates {
 	 */
 	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
 		Map<String, ?> properties) {
-		return e -> type(eventTypeMask).test(e) && (objectClass(objectClass).test(e))
-			&& containsServiceProperties(properties).test(e);
+		return type(eventTypeMask).and(objectClass(objectClass))
+			.and(containsServiceProperties(properties));
 	}
 
 	/**
@@ -168,6 +157,6 @@ public class ServiceEventPredicates {
 	 */
 	public static Predicate<ServiceEvent> matches(int eventTypeMask, final Class<?> objectClass,
 		Dictionary<String, ?> properties) {
-		return e -> matches(eventTypeMask, objectClass, Dictionaries.asMap(properties)).test(e);
+		return matches(eventTypeMask, objectClass, Dictionaries.asMap(properties));
 	}
 }

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/package-info.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/serviceevent/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.assertj.serviceevent;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventPredicatesTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventPredicatesTest.java
@@ -20,9 +20,6 @@ package org.osgi.test.assertj.test.bundleevent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Predicate;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -50,86 +47,6 @@ public class BundleEventPredicatesTest {
 			.test(new BundleEvent(BundleEvent.UNINSTALLED, bundle)))
 			.isFalse();
 
-		softly.assertThat(BundleEventPredicates.typeInstalled()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeInstalled()
-			.test(new BundleEvent(BundleEvent.UNINSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeLazyActivation()
-			.test(new BundleEvent(BundleEvent.LAZY_ACTIVATION, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeLazyActivation()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeResolved()
-			.test(new BundleEvent(BundleEvent.RESOLVED, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeResolved()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeStarted()
-			.test(new BundleEvent(BundleEvent.STARTED, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeStarted()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeStarting()
-			.test(new BundleEvent(BundleEvent.STARTING, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeStarting()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeStopped()
-			.test(new BundleEvent(BundleEvent.STOPPED, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeStopped()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeStopping()
-			.test(new BundleEvent(BundleEvent.STOPPING, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeStopping()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeUnresolved()
-			.test(new BundleEvent(BundleEvent.UNRESOLVED, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeUnresolved()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeUninstalled()
-			.test(new BundleEvent(BundleEvent.UNINSTALLED, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeUninstalled()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
-		softly.assertThat(BundleEventPredicates.typeUpdated()
-			.test(new BundleEvent(BundleEvent.UPDATED, bundle)))
-			.isTrue();
-
-		softly.assertThat(BundleEventPredicates.typeUpdated()
-			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
-			.isFalse();
-
 		softly.assertThat(BundleEventPredicates.bundleEvent()
 			.test(new BundleEvent(BundleEvent.UPDATED, bundle)))
 			.isTrue();
@@ -149,26 +66,6 @@ public class BundleEventPredicatesTest {
 		assertThat(BundleEventPredicates.bundleEvent()
 			.test("")).isFalse();
 
-	}
-
-	@Test
-	void test_bundleEventAnd() throws Exception {
-
-		AtomicBoolean flag = new AtomicBoolean(false);
-
-		Predicate<BundleEvent> p = new Predicate<BundleEvent>() {
-
-			@Override
-			public boolean test(BundleEvent t) {
-				flag.set(true);
-				return true;
-			}
-		};
-
-		assertThat(BundleEventPredicates.bundleEventAnd(p)
-			.test(new BundleEvent(BundleEvent.UPDATED, bundle))).isTrue();
-
-		assertThat(flag.get()).isTrue();
 	}
 
 }

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventPredicatesTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventPredicatesTest.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.bundleevent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.test.assertj.bundleevent.BundleEventPredicates;
+
+public class BundleEventPredicatesTest {
+
+	Bundle bundle = Mockito.mock(Bundle.class);
+
+	@Test
+	void test_type() throws Exception {
+
+		SoftAssertions softly = new SoftAssertions();
+
+		//
+
+		//
+		softly.assertThat(BundleEventPredicates.type(BundleEvent.INSTALLED)
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.type(BundleEvent.INSTALLED)
+			.test(new BundleEvent(BundleEvent.UNINSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeInstalled()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeInstalled()
+			.test(new BundleEvent(BundleEvent.UNINSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeLazyActivation()
+			.test(new BundleEvent(BundleEvent.LAZY_ACTIVATION, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeLazyActivation()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeResolved()
+			.test(new BundleEvent(BundleEvent.RESOLVED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeResolved()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeStarted()
+			.test(new BundleEvent(BundleEvent.STARTED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeStarted()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeStarting()
+			.test(new BundleEvent(BundleEvent.STARTING, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeStarting()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeStopped()
+			.test(new BundleEvent(BundleEvent.STOPPED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeStopped()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeStopping()
+			.test(new BundleEvent(BundleEvent.STOPPING, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeStopping()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeUnresolved()
+			.test(new BundleEvent(BundleEvent.UNRESOLVED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeUnresolved()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeUninstalled()
+			.test(new BundleEvent(BundleEvent.UNINSTALLED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeUninstalled()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.typeUpdated()
+			.test(new BundleEvent(BundleEvent.UPDATED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.typeUpdated()
+			.test(new BundleEvent(BundleEvent.INSTALLED, bundle)))
+			.isFalse();
+
+		softly.assertThat(BundleEventPredicates.bundleEvent()
+			.test(new BundleEvent(BundleEvent.UPDATED, bundle)))
+			.isTrue();
+
+		softly.assertThat(BundleEventPredicates.bundleEvent()
+			.test(""))
+			.isFalse();
+
+		softly.assertAll();
+	}
+
+	@Test
+	void test_bundleEvent() throws Exception {
+		assertThat(BundleEventPredicates.bundleEvent()
+			.test(new BundleEvent(BundleEvent.UPDATED, bundle))).isTrue();
+
+		assertThat(BundleEventPredicates.bundleEvent()
+			.test("")).isFalse();
+
+	}
+
+	@Test
+	void test_bundleEventAnd() throws Exception {
+
+		AtomicBoolean flag = new AtomicBoolean(false);
+
+		Predicate<BundleEvent> p = new Predicate<BundleEvent>() {
+
+			@Override
+			public boolean test(BundleEvent t) {
+				flag.set(true);
+				return true;
+			}
+		};
+
+		assertThat(BundleEventPredicates.bundleEventAnd(p)
+			.test(new BundleEvent(BundleEvent.UPDATED, bundle))).isTrue();
+
+		assertThat(flag.get()).isTrue();
+	}
+
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventPredicatesTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventPredicatesTest.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.frameworkevent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.test.assertj.frameworkevent.FrameworkEventPredicates;
+
+public class FrameworkEventPredicatesTest {
+
+	Bundle bundle = Mockito.mock(Bundle.class);
+
+	@Test
+	void testPredicateFramework() throws Exception {
+
+		SoftAssertions softly = new SoftAssertions();
+
+		//
+		FrameworkEvent event = new FrameworkEvent(FrameworkEvent.STARTLEVEL_CHANGED, bundle, null);
+
+		//
+		softly.assertThat(FrameworkEventPredicates.type(FrameworkEvent.STARTLEVEL_CHANGED)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.type(FrameworkEvent.STARTED)
+			.test(event))
+			.isFalse();
+
+		softly.assertThat(FrameworkEventPredicates.typeError()
+			.test(new FrameworkEvent(FrameworkEvent.ERROR, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typeError()
+			.test(event))
+			.isFalse();
+
+		//
+		softly.assertThat(FrameworkEventPredicates.typeInfo()
+			.test(new FrameworkEvent(FrameworkEvent.INFO, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typeInfo()
+			.test(event))
+			.isFalse();
+
+		//
+		softly.assertThat(FrameworkEventPredicates.typePackagesRefreshed()
+			.test(new FrameworkEvent(FrameworkEvent.PACKAGES_REFRESHED, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typePackagesRefreshed()
+			.test(event))
+			.isFalse();
+
+		//
+		softly.assertThat(FrameworkEventPredicates.typeStarted()
+			.test(new FrameworkEvent(FrameworkEvent.STARTED, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typeStarted()
+			.test(event))
+			.isFalse();
+
+		//
+		softly.assertThat(FrameworkEventPredicates.typeStartlevelChanged()
+			.test(new FrameworkEvent(FrameworkEvent.STARTLEVEL_CHANGED, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typeStartlevelChanged()
+			.test(new FrameworkEvent(FrameworkEvent.STOPPED, bundle, null)))
+			.isFalse();
+
+		//
+		softly.assertThat(FrameworkEventPredicates.typeStopped()
+			.test(new FrameworkEvent(FrameworkEvent.STOPPED, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typeStopped()
+			.test(event))
+			.isFalse();
+
+		//
+		softly.assertThat(FrameworkEventPredicates.typeStoppedUpdate()
+			.test(new FrameworkEvent(FrameworkEvent.STOPPED_UPDATE, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typeStoppedUpdate()
+			.test(event))
+			.isFalse();
+
+		//
+		softly.assertThat(FrameworkEventPredicates.typeWaitTimeout()
+			.test(new FrameworkEvent(FrameworkEvent.WAIT_TIMEDOUT, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typeWaitTimeout()
+			.test(event))
+			.isFalse();
+
+		//
+		softly.assertThat(FrameworkEventPredicates.typeWarning()
+			.test(new FrameworkEvent(FrameworkEvent.WARNING, bundle, null)))
+			.isTrue();
+
+		softly.assertThat(FrameworkEventPredicates.typeWarning()
+			.test(event))
+			.isFalse();
+
+		softly.assertAll();
+	}
+
+	@Test
+	void test_frameworkEvent() throws Exception {
+		assertThat(FrameworkEventPredicates.frameworkEvent()
+			.test(new FrameworkEvent(FrameworkEvent.WAIT_TIMEDOUT, bundle, null))).isTrue();
+
+		assertThat(FrameworkEventPredicates.frameworkEvent()
+			.test("")).isFalse();
+
+	}
+
+	@Test
+	void test_frameworkEventAnd() throws Exception {
+
+		AtomicBoolean flag = new AtomicBoolean(false);
+
+		Predicate<FrameworkEvent> p = new Predicate<FrameworkEvent>() {
+
+			@Override
+			public boolean test(FrameworkEvent t) {
+				flag.set(true);
+				return true;
+			}
+		};
+
+		assertThat(FrameworkEventPredicates.frameworkEventAnd(p)
+			.test(new FrameworkEvent(FrameworkEvent.WAIT_TIMEDOUT, bundle, null))).isTrue();
+
+		assertThat(flag.get()).isTrue();
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventPredicatesTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventPredicatesTest.java
@@ -20,9 +20,6 @@ package org.osgi.test.assertj.test.frameworkevent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Predicate;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -51,86 +48,6 @@ public class FrameworkEventPredicatesTest {
 			.test(event))
 			.isFalse();
 
-		softly.assertThat(FrameworkEventPredicates.typeError()
-			.test(new FrameworkEvent(FrameworkEvent.ERROR, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typeError()
-			.test(event))
-			.isFalse();
-
-		//
-		softly.assertThat(FrameworkEventPredicates.typeInfo()
-			.test(new FrameworkEvent(FrameworkEvent.INFO, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typeInfo()
-			.test(event))
-			.isFalse();
-
-		//
-		softly.assertThat(FrameworkEventPredicates.typePackagesRefreshed()
-			.test(new FrameworkEvent(FrameworkEvent.PACKAGES_REFRESHED, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typePackagesRefreshed()
-			.test(event))
-			.isFalse();
-
-		//
-		softly.assertThat(FrameworkEventPredicates.typeStarted()
-			.test(new FrameworkEvent(FrameworkEvent.STARTED, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typeStarted()
-			.test(event))
-			.isFalse();
-
-		//
-		softly.assertThat(FrameworkEventPredicates.typeStartlevelChanged()
-			.test(new FrameworkEvent(FrameworkEvent.STARTLEVEL_CHANGED, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typeStartlevelChanged()
-			.test(new FrameworkEvent(FrameworkEvent.STOPPED, bundle, null)))
-			.isFalse();
-
-		//
-		softly.assertThat(FrameworkEventPredicates.typeStopped()
-			.test(new FrameworkEvent(FrameworkEvent.STOPPED, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typeStopped()
-			.test(event))
-			.isFalse();
-
-		//
-		softly.assertThat(FrameworkEventPredicates.typeStoppedUpdate()
-			.test(new FrameworkEvent(FrameworkEvent.STOPPED_UPDATE, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typeStoppedUpdate()
-			.test(event))
-			.isFalse();
-
-		//
-		softly.assertThat(FrameworkEventPredicates.typeWaitTimeout()
-			.test(new FrameworkEvent(FrameworkEvent.WAIT_TIMEDOUT, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typeWaitTimeout()
-			.test(event))
-			.isFalse();
-
-		//
-		softly.assertThat(FrameworkEventPredicates.typeWarning()
-			.test(new FrameworkEvent(FrameworkEvent.WARNING, bundle, null)))
-			.isTrue();
-
-		softly.assertThat(FrameworkEventPredicates.typeWarning()
-			.test(event))
-			.isFalse();
-
 		softly.assertAll();
 	}
 
@@ -144,23 +61,4 @@ public class FrameworkEventPredicatesTest {
 
 	}
 
-	@Test
-	void test_frameworkEventAnd() throws Exception {
-
-		AtomicBoolean flag = new AtomicBoolean(false);
-
-		Predicate<FrameworkEvent> p = new Predicate<FrameworkEvent>() {
-
-			@Override
-			public boolean test(FrameworkEvent t) {
-				flag.set(true);
-				return true;
-			}
-		};
-
-		assertThat(FrameworkEventPredicates.frameworkEventAnd(p)
-			.test(new FrameworkEvent(FrameworkEvent.WAIT_TIMEDOUT, bundle, null))).isTrue();
-
-		assertThat(flag.get()).isTrue();
-	}
 }

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventPredicatesTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventPredicatesTest.java
@@ -22,8 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.Dictionary;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Predicate;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -74,38 +72,6 @@ public class ServiceEventPredicatesTest {
 		softly.assertThat(ServiceEventPredicates.type(ServiceEvent.MODIFIED_ENDMATCH)
 			.test(event))
 			.isFalse();
-		//
-		softly.assertThat(ServiceEventPredicates.typeModified()
-			.test(new ServiceEvent(ServiceEvent.MODIFIED, sr)))
-			.isTrue();
-
-		softly.assertThat(ServiceEventPredicates.typeModified()
-			.test(new ServiceEvent(ServiceEvent.REGISTERED, sr)))
-			.isFalse();
-		//
-		softly.assertThat(ServiceEventPredicates.typeModifiedEndmatch()
-			.test(new ServiceEvent(ServiceEvent.MODIFIED_ENDMATCH, sr)))
-			.isTrue();
-
-		softly.assertThat(ServiceEventPredicates.typeModifiedEndmatch()
-			.test(new ServiceEvent(ServiceEvent.REGISTERED, sr)))
-			.isFalse(); //
-		softly.assertThat(ServiceEventPredicates.typeRegistered()
-			.test(new ServiceEvent(ServiceEvent.REGISTERED, sr)))
-			.isTrue();
-
-		softly.assertThat(ServiceEventPredicates.typeRegistered()
-			.test(new ServiceEvent(ServiceEvent.UNREGISTERING, sr)))
-			.isFalse();
-
-		//
-		softly.assertThat(ServiceEventPredicates.typeUnregistering()
-			.test(new ServiceEvent(ServiceEvent.UNREGISTERING, sr)))
-			.isTrue();
-
-		softly.assertThat(ServiceEventPredicates.typeUnregistering()
-			.test(new ServiceEvent(ServiceEvent.REGISTERED, sr)))
-			.isFalse();
 
 		softly.assertThat(ServiceEventPredicates.containsServiceProperties(dict)
 			.test(event))
@@ -127,17 +93,9 @@ public class ServiceEventPredicatesTest {
 			.test(event))
 			.isFalse();
 
-		softly.assertThat(ServiceEventPredicates.typeRegistered(A.class)
-			.test(event))
-			.isTrue();
-
 		softly.assertThat(ServiceEventPredicates.objectClass(A.class)
 			.test(event))
 			.isTrue();
-
-		softly.assertThat(ServiceEventPredicates.typeModified(A.class)
-			.test(event))
-			.isFalse();
 
 		softly.assertThat(ServiceEventPredicates.matches(ServiceEvent.REGISTERED, A.class, dict)
 			.test(event))
@@ -160,26 +118,6 @@ public class ServiceEventPredicatesTest {
 		assertThat(ServiceEventPredicates.serviceEvent()
 			.test("")).isFalse();
 
-	}
-
-	@Test
-	void test_serviceEventAnd() throws Exception {
-
-		AtomicBoolean flag = new AtomicBoolean(false);
-
-		Predicate<ServiceEvent> p = new Predicate<ServiceEvent>() {
-
-			@Override
-			public boolean test(ServiceEvent t) {
-				flag.set(true);
-				return true;
-			}
-		};
-
-		assertThat(ServiceEventPredicates.serviceEventAnd(p)
-			.test(new ServiceEvent(ServiceEvent.MODIFIED, sr))).isTrue();
-
-		assertThat(flag.get()).isTrue();
 	}
 
 }

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventPredicatesTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventPredicatesTest.java
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.serviceevent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.assertj.serviceevent.ServiceEventPredicates;
+import org.osgi.test.common.dictionary.Dictionaries;
+
+public class ServiceEventPredicatesTest {
+	ServiceReference<?> sr = Mockito.mock(ServiceReference.class);
+
+	@Test
+	void testPredicateService() throws Exception {
+
+		SoftAssertions softly = new SoftAssertions();
+
+		//
+
+		Dictionary<String, Object> dict = Dictionaries.dictionaryOf(Constants.OBJECTCLASS, new String[] {
+			A.class.getName()
+		}, "key1", 1, "key2", 2);
+
+		Mockito.when(sr.getPropertyKeys())
+			.thenReturn(Collections.list(dict.keys())
+				.toArray(new String[3]));
+
+		Mockito.when(sr.getProperty(Mockito.any(String.class)))
+			.then(new Answer<Object>() {
+
+				@Override
+				public Object answer(InvocationOnMock invocation) throws Throwable {
+					String key = invocation.getArgument(0);
+					return dict.get(key);
+				}
+			});
+
+		ServiceEvent event = new ServiceEvent(ServiceEvent.REGISTERED, sr);
+
+		//
+		softly.assertThat(ServiceEventPredicates.type(ServiceEvent.REGISTERED)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.type(ServiceEvent.MODIFIED_ENDMATCH)
+			.test(event))
+			.isFalse();
+		//
+		softly.assertThat(ServiceEventPredicates.typeModified()
+			.test(new ServiceEvent(ServiceEvent.MODIFIED, sr)))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.typeModified()
+			.test(new ServiceEvent(ServiceEvent.REGISTERED, sr)))
+			.isFalse();
+		//
+		softly.assertThat(ServiceEventPredicates.typeModifiedEndmatch()
+			.test(new ServiceEvent(ServiceEvent.MODIFIED_ENDMATCH, sr)))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.typeModifiedEndmatch()
+			.test(new ServiceEvent(ServiceEvent.REGISTERED, sr)))
+			.isFalse(); //
+		softly.assertThat(ServiceEventPredicates.typeRegistered()
+			.test(new ServiceEvent(ServiceEvent.REGISTERED, sr)))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.typeRegistered()
+			.test(new ServiceEvent(ServiceEvent.UNREGISTERING, sr)))
+			.isFalse();
+
+		//
+		softly.assertThat(ServiceEventPredicates.typeUnregistering()
+			.test(new ServiceEvent(ServiceEvent.UNREGISTERING, sr)))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.typeUnregistering()
+			.test(new ServiceEvent(ServiceEvent.REGISTERED, sr)))
+			.isFalse();
+
+		softly.assertThat(ServiceEventPredicates.containsServiceProperties(dict)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.containsServiceProperties(Dictionaries.asMap(dict))
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.containServiceProperty("key1", 1)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.containServiceProperty("key1", 2)
+			.test(event))
+			.isFalse();
+
+		softly.assertThat(ServiceEventPredicates.containServiceProperty("key3", 3)
+			.test(event))
+			.isFalse();
+
+		softly.assertThat(ServiceEventPredicates.typeRegistered(A.class)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.objectClass(A.class)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.typeModified(A.class)
+			.test(event))
+			.isFalse();
+
+		softly.assertThat(ServiceEventPredicates.matches(ServiceEvent.REGISTERED, A.class, dict)
+			.test(event))
+			.isTrue();
+
+		softly.assertThat(ServiceEventPredicates.matches(ServiceEvent.REGISTERED, A.class, Dictionaries.dictionaryOf())
+			.test(event))
+			.isTrue();
+
+		softly.assertAll();
+	}
+
+	interface A {}
+
+	@Test
+	void serviceEvent() throws Exception {
+		assertThat(ServiceEventPredicates.serviceEvent()
+			.test(new ServiceEvent(ServiceEvent.MODIFIED, sr))).isTrue();
+
+		assertThat(ServiceEventPredicates.serviceEvent()
+			.test("")).isFalse();
+
+	}
+
+	@Test
+	void test_serviceEventAnd() throws Exception {
+
+		AtomicBoolean flag = new AtomicBoolean(false);
+
+		Predicate<ServiceEvent> p = new Predicate<ServiceEvent>() {
+
+			@Override
+			public boolean test(ServiceEvent t) {
+				flag.set(true);
+				return true;
+			}
+		};
+
+		assertThat(ServiceEventPredicates.serviceEventAnd(p)
+			.test(new ServiceEvent(ServiceEvent.MODIFIED, sr))).isTrue();
+
+		assertThat(flag.get()).isTrue();
+	}
+
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventPredicatesTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventPredicatesTest.java
@@ -81,17 +81,6 @@ public class ServiceEventPredicatesTest {
 			.test(event))
 			.isTrue();
 
-		softly.assertThat(ServiceEventPredicates.containServiceProperty("key1", 1)
-			.test(event))
-			.isTrue();
-
-		softly.assertThat(ServiceEventPredicates.containServiceProperty("key1", 2)
-			.test(event))
-			.isFalse();
-
-		softly.assertThat(ServiceEventPredicates.containServiceProperty("key3", 3)
-			.test(event))
-			.isFalse();
 
 		softly.assertThat(ServiceEventPredicates.objectClass(A.class)
 			.test(event))


### PR DESCRIPTION
Utilities to Filter Service Bundle and FrameworkEvents. Usefull for further Asserations and in combination with EventRecording.
If this fits to `osgi-test` i will add some docs, otherwise we can close this.