### PR TITLE
Add License-Header

### DIFF
--- a/examples/osgi-test-example-mvn/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/Ball.java
+++ b/examples/osgi-test-example-mvn/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/Ball.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.example.api;
 
 public interface Ball {

--- a/examples/osgi-test-example-mvn/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/Player.java
+++ b/examples/osgi-test-example-mvn/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/Player.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.example.api;
 
 public interface Player {

--- a/examples/osgi-test-example-mvn/org.osgi.test.example.player.impl/src/main/java/org/osgi/test/example/player/impl/PlayerImpl.java
+++ b/examples/osgi-test-example-mvn/org.osgi.test.example.player.impl/src/main/java/org/osgi/test/example/player/impl/PlayerImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.example.player.impl;
 
 import org.osgi.service.component.annotations.Component;

--- a/examples/osgi-test-example-mvn/org.osgi.test.example.player.impl/src/main/java/org/osgi/test/example/player/impl/package-info.java
+++ b/examples/osgi-test-example-mvn/org.osgi.test.example.player.impl/src/main/java/org/osgi/test/example/player/impl/package-info.java
@@ -1,1 +1,17 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.example.player.impl;

--- a/examples/osgi-test-example-mvn/org.osgi.test.example.player.impl/src/test/java/org/osgi/test/example/player/impl/OpenBoxTest.java
+++ b/examples/osgi-test-example-mvn/org.osgi.test.example.player.impl/src/test/java/org/osgi/test/example/player/impl/OpenBoxTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.example.player.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/examples/osgi-test-example-mvn/org.osgi.test.example.player.test/src/test/java/org/osgi/test/example/player/test/PlayerTest.java
+++ b/examples/osgi-test-example-mvn/org.osgi.test.example.player.test/src/test/java/org/osgi/test/example/player/test/PlayerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.example.player.test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundle/BundleAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundle/BundleAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.bundle;
 
 import static org.mockito.ArgumentMatchers.anyString;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundlecontext/BundleContextAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundlecontext/BundleContextAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.bundlecontext;
 
 import static org.mockito.Mockito.mock;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundleevent/BundleEventAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundleevent/BundleEventAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.bundleevent;
 
 import static org.mockito.Mockito.mock;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundlereference/AbstractBundleReferenceAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundlereference/AbstractBundleReferenceAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.bundlereference;
 
 import static org.mockito.Mockito.mock;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundlereference/BundleReferenceAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/bundlereference/BundleReferenceAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.bundlereference;
 
 import org.osgi.framework.BundleReference;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/dictionary/DictionaryAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/dictionary/DictionaryAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.dictionary;
 
 import java.util.Collections;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/filter/FilterConditionTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/filter/FilterConditionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/servicereference/AbstractServiceReferenceAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/servicereference/AbstractServiceReferenceAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.servicereference;
 
 import static org.mockito.Mockito.mock;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/servicereference/ServiceRefSoftAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/servicereference/ServiceRefSoftAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.servicereference;
 
 import static org.mockito.Mockito.mock;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/servicereference/ServiceReferenceAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/servicereference/ServiceReferenceAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.servicereference;
 
 public class ServiceReferenceAssertTest extends AbstractServiceReferenceAssertTest<ServiceReferenceAssert> {

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/testutil/AbstractAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/testutil/AbstractAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.testutil;
 
 import org.assertj.core.api.Assert;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/testutil/AssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/testutil/AssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.testutil;
 
 import java.lang.reflect.Field;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/version/AbstractVersionAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/version/AbstractVersionAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.version;
 
 import static java.lang.String.format;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/version/VersionAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/version/VersionAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.version;
 
 public class VersionAssertTest extends AbstractVersionAssertTest<VersionAssert> {

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/versionrange/VersionBoundAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/versionrange/VersionBoundAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.versionrange;
 
 import org.junit.jupiter.api.DisplayName;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/versionrange/VersionRangeAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/versionrange/VersionRangeAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.versionrange;
 
 import java.util.Arrays;

--- a/org.osgi.test.assertj.promise/src/test/java/org/osgi/test/assertj/promise/PromiseAssertTest.java
+++ b/org.osgi.test.assertj.promise/src/test/java/org/osgi/test/assertj/promise/PromiseAssertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.assertj.promise;
 
 import static org.osgi.test.assertj.promise.PromiseAssert.assertThat;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/config/WithConfigurations.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/config/WithConfigurations.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.annotation.config;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/config/WithFactoryConfigurations.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/config/WithFactoryConfigurations.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.annotation.config;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/context/CloseableServiceObjects.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/context/CloseableServiceObjects.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.context;
 
 import static java.util.stream.Collectors.toMap;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/BiConsumerWithException.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/BiConsumerWithException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import java.util.function.BiConsumer;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/BiFunctionWithException.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/BiFunctionWithException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import static java.util.Objects.requireNonNull;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/BiPredicateWithException.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/BiPredicateWithException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import static java.util.Objects.requireNonNull;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/ConsumerWithException.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/ConsumerWithException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import java.util.function.Consumer;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/Exceptions.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/Exceptions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import static java.util.Objects.requireNonNull;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/FunctionWithException.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/FunctionWithException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import static java.util.Objects.requireNonNull;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/PredicateWithException.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/PredicateWithException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import static java.util.Objects.requireNonNull;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/RunnableWithException.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/RunnableWithException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 /**

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/SupplierWithException.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/SupplierWithException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import static java.util.Objects.requireNonNull;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/inject/TargetType.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/inject/TargetType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.inject;
 
 import java.lang.reflect.Field;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/service/ServiceConfigurationKey.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/service/ServiceConfigurationKey.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.service;
 
 import static java.util.Objects.requireNonNull;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/stream/EntryPipeline.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/stream/EntryPipeline.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.stream;
 
 import static java.util.Objects.requireNonNull;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/stream/MapStream.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/stream/MapStream.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.stream;
 
 import java.util.AbstractMap.SimpleImmutableEntry;

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/context/CloseableBundleContextTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/context/CloseableBundleContextTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.context;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/exceptions/ExceptionsTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/exceptions/ExceptionsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/org.osgi.test.common/src/test/java/org/osgi/test/common/stream/MapStreamTest.java
+++ b/org.osgi.test.common/src/test/java/org/osgi/test/common/stream/MapStreamTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.common.stream;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/org.osgi.test.junit4/src/test/java/org/osgi/test/junit4/ExecutorRule.java
+++ b/org.osgi.test.junit4/src/test/java/org/osgi/test/junit4/ExecutorRule.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit4;
 
 import java.util.concurrent.Callable;

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandler.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.cm;
 
 import java.io.IOException;

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandlerImpl.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandlerImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.cm;
 
 import java.io.IOException;

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationCopy.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationCopy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.cm;
 
 import java.util.Dictionary;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/ExecutorExtension.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/ExecutorExtension.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5;
 
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/ExecutorParameter.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/ExecutorParameter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/AbstractResourceChecker.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/AbstractResourceChecker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import static org.assertj.core.api.Assertions.fail;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextInjectionSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextInjectionSanityCheckingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextInjectionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleContextInjectionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import org.junit.jupiter.api.AfterAll;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleInstallerInjectionSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleInstallerInjectionSanityCheckingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleInstallerInjectionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextExtension_BundleInstallerInjectionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextMultiLevelCleanupTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextMultiLevelCleanupTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import java.util.Map;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextResourceChecker.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/BundleContextResourceChecker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import java.util.Map;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/DynamicNodeGenerator.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/DynamicNodeGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/MultiLevelCleanupTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/MultiLevelCleanupTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import static org.osgi.test.junit5.context.MultiLevelCleanupTest.CallbackPoint.AFTER_AFTER_EACH;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/PreDestroyCallback.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/context/PreDestroyCallback.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.context;
 
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AbstractServiceExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/AbstractServiceExtensionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.service;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtension_SanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/service/ServiceExtension_SanityCheckingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.service;
 
 import static org.osgi.test.junit5.testutils.TestKitUtils.assertThatTest;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/testutils/OSGiSoftAssertions.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/testutils/OSGiSoftAssertions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.testutils;
 
 import org.assertj.core.api.SoftAssertions;

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/testutils/TestKitUtils.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/testutils/TestKitUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) OSGi Alliance (2019, 2021). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.osgi.test.junit5.testutils;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Some Sources and more Tests did not have an License-Header.