### PR TITLE
Update configs only if different

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/config/WithConfiguration.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/config/WithConfiguration.java
@@ -40,7 +40,6 @@ import org.osgi.test.common.annotation.Property;
 @Repeatable(WithConfigurations.class)
 @Retention(RUNTIME)
 @Documented
-
 public @interface WithConfiguration {
 
 	/**
@@ -67,4 +66,10 @@ public @interface WithConfiguration {
 		@Property(key = Property.NOT_SET)
 	};
 
+	/**
+	 * By default a configuration will be updated by using
+	 * {@link org.osgi.service.cm.Configuration#updateIfDifferent}. If set to
+	 * true, {@link org.osgi.service.cm.Configuration#update] will be used.
+	 */
+	boolean forceUpdate() default false;
 }

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/config/WithFactoryConfiguration.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/annotation/config/WithFactoryConfiguration.java
@@ -40,7 +40,6 @@ import org.osgi.test.common.annotation.Property;
 @Repeatable(WithFactoryConfigurations.class)
 @Retention(RUNTIME)
 @Documented
-
 public @interface WithFactoryConfiguration {
 
 	/**
@@ -73,5 +72,12 @@ public @interface WithFactoryConfiguration {
 	Property[] properties() default {
 		@Property(key = Property.NOT_SET)
 	};
+
+	/**
+	 * By default a configuration will be updated by using
+	 * {@link org.osgi.service.cm.Configuration#updateIfDifferent}. If set to
+	 * true, {@link org.osgi.service.cm.Configuration#update] will be used.
+	 */
+	boolean forceUpdate() default false;
 
 }

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandler.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandler.java
@@ -7,7 +7,7 @@ import org.osgi.service.cm.Configuration;
 
 public interface BlockingConfigurationHandler {
 
-	boolean update(Configuration configuration, Dictionary<String, Object> dictionary, long timeout)
+	boolean update(Configuration configuration, Dictionary<String, Object> dictionary, long timeout, boolean ignoreDiff)
 		throws InterruptedException, IOException;
 
 	boolean delete(Configuration configuration, long timeout) throws InterruptedException, IOException;

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandlerImpl.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandlerImpl.java
@@ -18,10 +18,15 @@ public class BlockingConfigurationHandlerImpl implements ConfigurationListener, 
 	private Map<String, CountDownLatch>	deleteMap	= new HashMap<String, CountDownLatch>();
 
 	@Override
-	public boolean update(Configuration configuration, Dictionary<String, Object> dictionary, long timeout)
+	public boolean update(Configuration configuration, Dictionary<String, Object> dictionary, long timeout,
+		boolean ignoredDiff)
 		throws InterruptedException, IOException {
 		CountDownLatch latch = createCountdownLatchUpdate(configuration.getPid());
-		configuration.update(dictionary);
+		if (ignoredDiff) {
+			configuration.update(dictionary);
+		} else {
+			configuration.updateIfDifferent(dictionary);
+		}
 		boolean isOk = latch.await(timeout, TimeUnit.MILLISECONDS);
 		return isOk;
 	}

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandlerImpl.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandlerImpl.java
@@ -22,13 +22,16 @@ public class BlockingConfigurationHandlerImpl implements ConfigurationListener, 
 		boolean ignoredDiff)
 		throws InterruptedException, IOException {
 		CountDownLatch latch = createCountdownLatchUpdate(configuration.getPid());
+		boolean wait = true;
 		if (ignoredDiff) {
 			configuration.update(dictionary);
 		} else {
-			configuration.updateIfDifferent(dictionary);
+			wait = configuration.updateIfDifferent(dictionary);
 		}
-		boolean isOk = latch.await(timeout, TimeUnit.MILLISECONDS);
-		return isOk;
+		if (wait) {
+			return latch.await(timeout, TimeUnit.MILLISECONDS);
+		}
+		return true;
 	}
 
 	@Override

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigUtil.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigUtil.java
@@ -107,7 +107,7 @@ public class ConfigUtil {
 					.anyMatch((copy) -> {
 						if (Objects.equals(conf.getPid(), copy.getPid())) {
 							try {
-								timeoutListener.update(conf, copy.getProperties(), 3000);
+								timeoutListener.update(conf, copy.getProperties(), 3000, false);
 							} catch (IOException e) {
 								throw new UncheckedIOException(e);
 							} catch (InterruptedException e) {
@@ -145,7 +145,7 @@ public class ConfigUtil {
 					}
 
 					try {
-						timeoutListener.update(conf, copy.getProperties(), 3000);
+						timeoutListener.update(conf, copy.getProperties(), 3000, true);
 
 					} catch (IOException e) {
 						throw new UncheckedIOException(e);

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationExtension.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationExtension.java
@@ -131,7 +131,7 @@ public class ConfigurationExtension
 			}
 
 			updateConfigurationRespectNew(configuration, PropertiesConverter.of(configAnnotation.properties()),
-				configBefore == null);
+				configBefore == null || configAnnotation.forceUpdate());
 
 			return configuration;
 
@@ -158,7 +158,7 @@ public class ConfigurationExtension
 			}
 
 			updateConfigurationRespectNew(configuration, PropertiesConverter.of(configAnnotation.properties()),
-				configBefore == null);
+				configBefore == null || configAnnotation.forceUpdate());
 
 			return configuration;
 
@@ -367,17 +367,17 @@ public class ConfigurationExtension
 	}
 
 	public void updateConfigurationRespectNew(Configuration configurationToBeUpdated,
-		Dictionary<String, Object> newConfigurationProperties, boolean isNewConfiguration)
+		Dictionary<String, Object> newConfigurationProperties, boolean forceUpdate)
 		throws InterruptedException, IOException {
 		if (configurationToBeUpdated != null) {
 			if (newConfigurationProperties != null
 				&& !ConfigUtil.isDictionaryWithNotSetMarker(newConfigurationProperties)) {
 				// has relevant Properties to update
-				blockingConfigHandler.update(configurationToBeUpdated, newConfigurationProperties, 1000, false);
-			} else if (isNewConfiguration) {
+				blockingConfigHandler.update(configurationToBeUpdated, newConfigurationProperties, 1000, forceUpdate);
+			} else if (forceUpdate) {
 				// is new created Configuration. must be updated
 				blockingConfigHandler.update(configurationToBeUpdated, Dictionaries.dictionaryOf(), 1000,
-					true);
+					forceUpdate);
 			}
 		}
 	}

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationExtension.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationExtension.java
@@ -373,10 +373,11 @@ public class ConfigurationExtension
 			if (newConfigurationProperties != null
 				&& !ConfigUtil.isDictionaryWithNotSetMarker(newConfigurationProperties)) {
 				// has relevant Properties to update
-				blockingConfigHandler.update(configurationToBeUpdated, newConfigurationProperties, 1000);
+				blockingConfigHandler.update(configurationToBeUpdated, newConfigurationProperties, 1000, false);
 			} else if (isNewConfiguration) {
 				// is new created Configuration. must be updated
-				blockingConfigHandler.update(configurationToBeUpdated, Dictionaries.dictionaryOf(), 1000);
+				blockingConfigHandler.update(configurationToBeUpdated, Dictionaries.dictionaryOf(), 1000,
+					true);
 			}
 		}
 	}


### PR DESCRIPTION
Configurations are updated to liberal, when trying to reset the state before the test. Using the `updateIfDifferent` method seems a low hanging fruit. 
Signed-off-by: Jürgen Albert <j.albert@data-in-motion.biz>