### PR TITLE
[assertj] Improved code coverage of PromiseAssert

### DIFF
--- a/org.osgi.test.assertj.promise/src/test/java/org/osgi/test/assertj/testutils/TestUtil.java
+++ b/org.osgi.test.assertj.promise/src/test/java/org/osgi/test/assertj/testutils/TestUtil.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.testutils;
+
+import org.assertj.core.api.StandardSoftAssertionsProvider;
+import org.osgi.test.common.exceptions.Exceptions;
+
+public class TestUtil {
+	private TestUtil() {}
+
+	static final long TIMEOUT_MS = 10000;
+
+	public static void waitForThreadToWait(Thread thread, StandardSoftAssertionsProvider softly) {
+		final long waitTime = TIMEOUT_MS;
+		final long endTime = System.currentTimeMillis() + waitTime;
+		int waitCount = 0;
+		try {
+			OUTER: while (true) {
+				Thread.sleep(100);
+				final Thread.State state = thread.getState();
+				// System.err.println("Thread: " + thread + ", state: " +
+				// state);
+				switch (state) {
+					case TERMINATED :
+					case TIMED_WAITING :
+					case WAITING :
+					case BLOCKED :
+						if (waitCount++ > 5) {
+							break OUTER;
+						}
+						break;
+					default :
+						waitCount = 0;
+						break;
+				}
+				if (System.currentTimeMillis() > endTime) {
+					throw new InterruptedException("Thread still hasn't entered wait state after " + waitTime + "ms");
+				}
+			}
+		} catch (InterruptedException e) {
+			throw Exceptions.duck(e);
+		}
+		// Check that it hasn't terminated.
+		softly.assertThat(thread.getState())
+			.as("thread:" + thread.getName())
+			.isIn(Thread.State.WAITING, Thread.State.TIMED_WAITING, Thread.State.BLOCKED);
+	}
+
+}

--- a/org.osgi.test.assertj.promise/test.bndrun
+++ b/org.osgi.test.assertj.promise/test.bndrun
@@ -49,6 +49,10 @@
 	junit-platform-commons;version='[1.7.2,1.7.3)',\
 	junit-platform-engine;version='[1.7.2,1.7.3)',\
 	junit-platform-launcher;version='[1.7.2,1.7.3)',\
+	net.bytebuddy.byte-buddy;version='[1.11.1,1.11.2)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.11.1,1.11.2)',\
+	org.mockito.mockito-core;version='[3.11.0,3.11.1)',\
+	org.objenesis;version='[3.2.0,3.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.test.assertj.promise;version='[1.1.0,1.1.1)',\
 	org.osgi.test.assertj.promise-tests;version='[1.1.0,1.1.1)',\


### PR DESCRIPTION
There were some critical code paths in PromiseAssert that were not covered at all by our tests.

In particular, all of the tests dealt with assertions that either remained unresolved before, during and after the assertion, or else were resolved before, during and after the assertion. None of them tested the case where the resolved state changed while the assertion was waiting for the countdown latch to be decremented via the `onResolve()` callback. Current PR adds these checks.

Also adds a check for the case where (in violation of the Promise API contract) a Promise signals "isDone()" with no failure, but then `getValue()` throws an `InvocationTargetException`. 