### PR TITLE
dictionaryassert: Proper handling of null actual

### DIFF
--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/DictionaryAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/DictionaryAssert.java
@@ -36,7 +36,7 @@ public class DictionaryAssert<KEY, VALUE>
 	extends AbstractDictionaryAssert<DictionaryAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> {
 
 	public DictionaryAssert(Dictionary<KEY, VALUE> actual) {
-		this(Dictionaries.asMap(actual));
+		this((actual != null) ? Dictionaries.asMap(actual) : null);
 	}
 
 	protected DictionaryAssert(Map<KEY, VALUE> actual) {

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/ProxyableDictionaryAssert.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/dictionary/ProxyableDictionaryAssert.java
@@ -31,7 +31,7 @@ public class ProxyableDictionaryAssert<KEY, VALUE>
 	extends AbstractDictionaryAssert<ProxyableDictionaryAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> {
 
 	public ProxyableDictionaryAssert(Dictionary<KEY, VALUE> actual) {
-		this(Dictionaries.asMap(actual));
+		this((actual != null) ? Dictionaries.asMap(actual) : null);
 	}
 
 	protected ProxyableDictionaryAssert(Map<KEY, VALUE> actual) {

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/dictionary/DictionaryAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/dictionary/DictionaryAssertTest.java
@@ -221,6 +221,24 @@ public class DictionaryAssertTest {
 			.isInstanceOf(AssertionError.class);
 	}
 
+	@Test
+	public void null_actual(DictionarySoftAssertions softly) throws Exception {
+		final Dictionary<?, ?> nullDictionary = null;
+		softly.assertThatCode(() -> {
+			DictionaryAssert.assertThat(nullDictionary)
+				.isNull();
+		})
+			.doesNotThrowAnyException();
+		softly.assertThatCode(() -> {
+			DictionaryAssert.assertThat(nullDictionary)
+				.isNotNull();
+		})
+			.isInstanceOf(AssertionError.class);
+
+		softly.assertThat(nullDictionary)
+			.isNull();
+	}
+
 	public static class TestDictionary<K, V> extends Dictionary<K, V> {
 		private final Map<K, V> map;
 


### PR DESCRIPTION
Null actual must be supported so that is it meaningful to call isNull()
or isNonNull() on the assertion.
