### PR TITLE
[build] Re-instate baselining

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,9 +517,7 @@
 						<goals>
 							<goal>baseline</goal>
 						</goals>
-						<!-- Disable baseline validation until we are at version > 1.0.0.
-							Then change inherited to false. -->
-						<inherited>true</inherited>
+						<inherited>false</inherited>
 						<configuration>
 							<skip>true</skip>
 						</configuration>


### PR DESCRIPTION
Now that we have a 1.0.0 release, we need to re-instate baselining to guard against incompatible changes.