### PR TITLE
Add the dynamic ServiceAware functionality to injected Lists

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/list/ListSupplierDelegate.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/list/ListSupplierDelegate.java
@@ -1,0 +1,215 @@
+package org.osgi.test.common.list;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+public class ListSupplierDelegate<E> implements List<E> {
+
+	private final Supplier<? extends List<E>> supplier;
+
+	public ListSupplierDelegate(Supplier<? extends List<E>> supplier) {
+		this.supplier = Objects.requireNonNull(supplier);
+	}
+
+	@Override
+	public boolean add(E e) {
+		return supplier.get()
+			.add(e);
+	}
+
+	@Override
+	public void add(int index, E element) {
+		supplier.get()
+			.add(index, element);
+	}
+
+	@Override
+	public boolean addAll(Collection<? extends E> c) {
+		return supplier.get()
+			.addAll(c);
+	}
+
+	@Override
+	public boolean addAll(int index, Collection<? extends E> c) {
+		return supplier.get()
+			.addAll(index, c);
+	}
+
+	@Override
+	public void clear() {
+		supplier.get()
+			.clear();
+	}
+
+	@Override
+	public boolean contains(Object o) {
+		return supplier.get()
+			.contains(o);
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		return supplier.get()
+			.containsAll(c);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return supplier.get()
+			.equals(o);
+	}
+
+	@Override
+	public void forEach(Consumer<? super E> action) {
+		supplier.get()
+			.forEach(action);
+	}
+
+	@Override
+	public E get(int index) {
+		return supplier.get()
+			.get(index);
+	}
+
+	@Override
+	public int hashCode() {
+		return supplier.get()
+			.hashCode();
+	}
+
+	@Override
+	public int indexOf(Object o) {
+		return supplier.get()
+			.indexOf(o);
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return supplier.get()
+			.isEmpty();
+	}
+
+	@Override
+	public Iterator<E> iterator() {
+		return supplier.get()
+			.iterator();
+	}
+
+	@Override
+	public int lastIndexOf(Object o) {
+		return supplier.get()
+			.lastIndexOf(o);
+	}
+
+	@Override
+	public ListIterator<E> listIterator() {
+		return supplier.get()
+			.listIterator();
+	}
+
+	@Override
+	public ListIterator<E> listIterator(int index) {
+		return supplier.get()
+			.listIterator(index);
+	}
+
+	@Override
+	public Stream<E> parallelStream() {
+		return supplier.get()
+			.parallelStream();
+	}
+
+	@Override
+	public E remove(int index) {
+		return supplier.get()
+			.remove(index);
+	}
+
+	@Override
+	public boolean remove(Object o) {
+		return supplier.get()
+			.remove(o);
+	}
+
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		return supplier.get()
+			.removeAll(c);
+	}
+
+	@Override
+	public boolean removeIf(Predicate<? super E> filter) {
+		return supplier.get()
+			.removeIf(filter);
+	}
+
+	@Override
+	public void replaceAll(UnaryOperator<E> operator) {
+		supplier.get()
+			.replaceAll(operator);
+	}
+
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		return supplier.get()
+			.retainAll(c);
+	}
+
+	@Override
+	public E set(int index, E element) {
+		return supplier.get()
+			.set(index, element);
+	}
+
+	@Override
+	public int size() {
+		return supplier.get()
+			.size();
+	}
+
+	@Override
+	public void sort(Comparator<? super E> c) {
+		supplier.get()
+			.sort(c);
+	}
+
+	@Override
+	public Spliterator<E> spliterator() {
+		return supplier.get()
+			.spliterator();
+	}
+
+	@Override
+	public Stream<E> stream() {
+		return supplier.get()
+			.stream();
+	}
+
+	@Override
+	public List<E> subList(int fromIndex, int toIndex) {
+		return supplier.get()
+			.subList(fromIndex, toIndex);
+	}
+
+	@Override
+	public Object[] toArray() {
+		return supplier.get()
+			.toArray();
+	}
+
+	@Override
+	public <T> T[] toArray(T[] a) {
+		return supplier.get()
+			.toArray(a);
+	}
+}

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/list/package-info.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/list/package-info.java
@@ -15,7 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
+@Export
+@Version("1.0.0")
+package org.osgi.test.common.list;
 
-@org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.1")
-package org.osgi.test.junit5.service;
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceExtension.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.common.inject.TargetType;
+import org.osgi.test.common.list.ListSupplierDelegate;
 import org.osgi.test.common.service.ServiceAware;
 import org.osgi.test.common.service.ServiceConfiguration;
 import org.osgi.test.common.service.ServiceConfigurationKey;
@@ -189,7 +190,7 @@ public class ServiceExtension implements BeforeAllCallback, BeforeEachCallback, 
 			injectService.filterArguments(), injectService.cardinality(), injectService.timeout(), extensionContext);
 
 		if (targetType.matches(List.class) && targetType.hasParameterizedTypes()) {
-			return configuration.getServices();
+			return new ListSupplierDelegate<>(configuration::getServices);
 		} else if (targetType.matches(ServiceAware.class) && targetType.hasParameterizedTypes()) {
 			return configuration;
 		}

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/service/ServiceExtensionTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/service/ServiceExtensionTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.osgi.test.common.annotation.InjectService.DEFAULT_TIMEOUT;
 import static org.osgi.test.junit5.test.testutils.TestKitUtils.assertThatTest;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -147,14 +148,17 @@ public class ServiceExtensionTest extends AbstractServiceExtensionTest {
 		@InjectService(cardinality = 2)
 		List<Foo> foos;
 
+		List<Foo>	foosCopy	= new ArrayList<>();
 		@Override
 		List<Foo> getServices() {
-			return foos;
+			return foosCopy;
 		}
 
 		@Override
 		@Test
-		void test() throws Exception {}
+		void test() throws Exception {
+			foos.forEach(e -> foosCopy.add(e));
+		}
 	}
 
 	@Test

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/service/ServiceListTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/service/ServiceListTest.java
@@ -22,17 +22,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.log.LogService;
+import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.service.ServiceAware;
+import org.osgi.test.junit5.context.BundleContextExtension;
 import org.osgi.test.junit5.service.ServiceExtension;
 
+@ExtendWith(BundleContextExtension.class)
 @ExtendWith(ServiceExtension.class)
 public class ServiceListTest {
 
+	@InjectBundleContext
+	BundleContext										bc;
 	@InjectService
-	List<LogService>				logServices;
+	List<LogService>									logServices;
+
+	@InjectService(cardinality = 0)
+	List<TestServiceWithMultipleCardinality>			testServices;
+
+	@InjectService(cardinality = 0)
+	ServiceAware<TestServiceWithMultipleCardinality>	testServicesAware;
 
 	@Test
 	public void testField() throws Exception {
@@ -41,9 +56,51 @@ public class ServiceListTest {
 	}
 
 	@Test
-	public void testParam(@InjectService List<LogService> logServices) throws Exception {
+	public void testParam(@InjectService
+	List<LogService> logServices) throws Exception {
 		assertThat(logServices).size()
 			.isEqualTo(1);
+	}
+
+	@Test
+	public void servicesWithMultipleCardinalityCanAlsoBeInjected() throws InterruptedException {
+
+		Assertions.assertEquals(0, this.testServicesAware.getCardinality(),
+			"getCardinality() delivers the initial Cardinality (e.g. set via @InjectService(cardinality = 0)");
+
+		Assertions.assertEquals(0, this.testServices.size(), "Initially no test service should be found");
+		Assertions.assertEquals(0, this.testServicesAware.getCardinality(),
+			"The ServiceAware should reflect the same situation");
+		// register service through bundle context
+		final ServiceRegistration<TestServiceWithMultipleCardinality> reg = bc.registerService(
+			TestServiceWithMultipleCardinality.class, new TestServiceWithMultipleCardinalityImpl(), null);
+
+		assertThat(testServicesAware.waitForService(1000l)).isNotNull();
+		Assertions.assertEquals(0, this.testServicesAware.getCardinality(), "and the cardinality will not change");
+
+		Assertions.assertEquals(1, this.testServices.size(), "After registration, there should be 1 service");
+		Assertions.assertEquals(1, this.testServicesAware.getServices()
+			.size(), "The ServiceAware should reflect the same situation");
+
+		Assertions.assertEquals(1, this.testServicesAware.getTrackingCount(),
+			"changes happened could be tracked via getTrackingCount");
+
+		reg.unregister();
+		Assertions.assertEquals(0, this.testServices.size(), "After unregister, no test service should be found");
+		Assertions.assertEquals(0, this.testServicesAware.getCardinality(),
+			"The ServiceAware should reflect the same situation");
+
+		Assertions.assertEquals(2, this.testServicesAware.getTrackingCount(),
+			"changes happened could be tracked via getTrackingCount");
+
+	}
+
+	interface TestServiceWithMultipleCardinality {
+
+	}
+
+	class TestServiceWithMultipleCardinalityImpl implements TestServiceWithMultipleCardinality {
+
 	}
 
 }


### PR DESCRIPTION
from `osgi-test` mailing list

```
I was expecting that if I would have an injected List<S> with S a certain type of service, and I would register a service using the BundleContext in the test, the List<S> would reflect the newly registered service. A ServiceAware<S> also does not seem to reflect the new situation.

Are my expectations wrong?
```

This PR could solve this Problem but will break an other existing test.

@bjhargrave what do you think about?