### PR TITLE
perf: Replace uses of StringWriter with CharArrayWriter

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/Exceptions.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/exceptions/Exceptions.java
@@ -21,7 +21,7 @@ package org.osgi.test.common.exceptions;
 import static java.util.Objects.requireNonNull;
 
 import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.CharArrayWriter;
 import java.util.StringJoiner;
 import java.util.concurrent.Callable;
 
@@ -55,7 +55,7 @@ public class Exceptions {
 	}
 
 	public static String toString(Throwable t) {
-		StringWriter sw = new StringWriter();
+		CharArrayWriter sw = new CharArrayWriter();
 		t.printStackTrace(new PrintWriter(sw));
 		return sw.toString();
 	}


### PR DESCRIPTION
StringWriter uses the older StringBuffer internally with synchronization
we don't generally need.

