### PR TITLE
build: Update OSGi dependencies

### DIFF
--- a/examples/osgi-test-example-bndworkspace/cnf/ext/central.mvn
+++ b/examples/osgi-test-example-bndworkspace/cnf/ext/central.mvn
@@ -1,4 +1,4 @@
-org.osgi:osgi.annotation:8.0.0
+org.osgi:osgi.annotation:8.0.1
 org.osgi:osgi.core:8.0.0
 org.osgi:org.osgi.namespace.service:1.0.0
 org.osgi:org.osgi.service.component.annotations:1.4.0
@@ -24,5 +24,5 @@ ch.qos.logback:logback-classic:1.2.0
 ch.qos.logback:logback-core:1.2.0
 org.slf4j:slf4j-api:1.7.22
 org.eclipse.platform:org.eclipse.osgi:3.17.0
-org.osgi:org.osgi.util.function:1.1.0
-org.osgi:org.osgi.util.promise:1.1.0
+org.osgi:org.osgi.util.function:1.2.0
+org.osgi:org.osgi.util.promise:1.2.0

--- a/examples/osgi-test-example-bndworkspace/org.osgi.test.example.api/bnd.bnd
+++ b/examples/osgi-test-example-bndworkspace/org.osgi.test.example.api/bnd.bnd
@@ -2,3 +2,5 @@
 -include: ${workspace}/cnf/includes/jdt.bnd
 
 Bundle-Description: OSGi Testing Example API
+
+-buildpath.annotation: osgi.annotation;version=latest;maven-scope=compile

--- a/examples/osgi-test-example-gradle/buildSrc/src/main/groovy/org.osgi.test.example.java-conventions.gradle
+++ b/examples/osgi-test-example-gradle/buildSrc/src/main/groovy/org.osgi.test.example.java-conventions.gradle
@@ -8,7 +8,8 @@ repositories {
 }
 
 dependencies {
-	compileOnly("org.osgi:osgi.annotation:8.0.0")
+	def configurationName = pluginManager.hasPlugin("java-library") ? "api" : "compileOnly"
+	add(configurationName, "org.osgi:osgi.annotation:8.0.1")
 }
 
 group = "org.osgi.test.example"

--- a/examples/osgi-test-example-gradle/org.osgi.test.example.api/build.gradle
+++ b/examples/osgi-test-example-gradle/org.osgi.test.example.api/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id("java-library")
 	id("org.osgi.test.example.java-conventions")
 }
 

--- a/examples/osgi-test-example-gradle/org.osgi.test.example.player.test/build.gradle
+++ b/examples/osgi-test-example-gradle/org.osgi.test.example.player.test/build.gradle
@@ -22,8 +22,8 @@ dependencies {
 	runtimeOnly("org.apache.felix:org.apache.felix.scr:2.1.28")
 	runtimeOnly("org.apache.felix:org.apache.felix.logback:1.0.2")
 	runtimeOnly("org.eclipse.platform:org.eclipse.osgi:3.17.0")
-	runtimeOnly("org.osgi:org.osgi.util.function:1.1.0")
-	runtimeOnly("org.osgi:org.osgi.util.promise:1.1.0")
+	runtimeOnly("org.osgi:org.osgi.util.function:1.2.0")
+	runtimeOnly("org.osgi:org.osgi.util.promise:1.2.0")
 }
 
 description = "OSGi Testing Example Player Test"

--- a/examples/osgi-test-example-mvn/org.osgi.test.example.api/pom.xml
+++ b/examples/osgi-test-example-mvn/org.osgi.test.example.api/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) Contributors to the Eclipse Foundation
-   
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-   
+
         http://www.apache.org/licenses/LICENSE-2.0
-   
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-   
+
     SPDX-License-Identifier: Apache-2.0
  -->
 
@@ -39,6 +39,13 @@
 		<developerConnection>scm:git:git@github.com:rotty3000/osgi-test-example-mvn.git</developerConnection>
 	</scm>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
 	<build>
 		<plugins>
 			<plugin>

--- a/examples/osgi-test-example-mvn/org.osgi.test.example.player.test/test.bndrun
+++ b/examples/osgi-test-example-mvn/org.osgi.test.example.player.test/test.bndrun
@@ -49,5 +49,5 @@
 	org.osgi.test.example.player.impl;version='[0.1.0,0.1.1)',\
 	org.osgi.test.example.player.test-tests;version='[0.1.0,0.1.1)',\
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/examples/osgi-test-example-mvn/pom.xml
+++ b/examples/osgi-test-example-mvn/pom.xml
@@ -412,7 +412,7 @@
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>osgi.annotation</artifactId>
-				<version>8.0.0</version>
+				<version>8.0.1</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -436,13 +436,13 @@
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.util.function</artifactId>
-				<version>1.1.0</version>
+				<version>1.2.0</version>
 				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.util.promise</artifactId>
-				<version>1.1.1</version>
+				<version>1.2.0</version>
 				<scope>compile</scope>
 			</dependency>
 			<dependency>

--- a/org.osgi.test.assertj.promise/pom.xml
+++ b/org.osgi.test.assertj.promise/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) Contributors to the Eclipse Foundation
-   
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-   
+
         http://www.apache.org/licenses/LICENSE-2.0
-   
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-   
+
     SPDX-License-Identifier: Apache-2.0
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -56,6 +56,26 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>osgi.core</artifactId>
+		</dependency>
+		<dependency>
+			<!-- Maven hack!
+				We add '.' after the groupId to specify a different version of the dependency for test.
+				This must be specified before the compile scope dependency.
+			-->
+			<groupId>org.osgi.</groupId>
+			<artifactId>org.osgi.util.function</artifactId>
+			<version>${osgi.function.test.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<!-- Maven hack!
+				We add '.' after the groupId to specify a different version of the dependency for test.
+				This must be specified before the compile scope dependency.
+			-->
+			<groupId>org.osgi.</groupId>
+			<artifactId>org.osgi.util.promise</artifactId>
+			<version>${osgi.promise.test.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>

--- a/org.osgi.test.assertj.promise/test.bndrun
+++ b/org.osgi.test.assertj.promise/test.bndrun
@@ -59,5 +59,5 @@
 	org.osgi.test.assertj.promise;version='[1.1.0,1.1.1)',\
 	org.osgi.test.assertj.promise-tests;version='[1.1.0,1.1.1)',\
 	org.osgi.test.common;version='[1.1.0,1.1.1)',\
-	org.osgi.util.function;version='[1.0.0,1.0.1)',\
-	org.osgi.util.promise;version='[1.0.0,1.0.1)'
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,14 @@
 		<junit-jupiter.version>5.8.1</junit-jupiter.version>
 		<junit-platform.version>1.8.1</junit-platform.version>
 		<assertj.version>3.21.0</assertj.version>
+		<osgi.annotation.version>8.0.1</osgi.annotation.version>
+		<osgi.core.version>6.0.0</osgi.core.version>
+		<osgi.log.version>1.4.0</osgi.log.version>
+		<osgi.cm.version>1.6.0</osgi.cm.version>
+		<osgi.function.version>1.0.0</osgi.function.version>
+		<osgi.promise.version>1.0.0</osgi.promise.version>
+		<osgi.function.test.version>1.2.0</osgi.function.test.version>
+		<osgi.promise.test.version>1.2.0</osgi.promise.test.version>
 	</properties>
 
 	<modules>
@@ -557,37 +565,37 @@
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>osgi.annotation</artifactId>
-				<version>8.0.0</version>
+				<version>${osgi.annotation.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.service.log</artifactId>
-				<version>1.4.0</version>
+				<version>${osgi.log.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>osgi.core</artifactId>
-				<version>6.0.0</version>
+				<version>${osgi.core.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.service.cm</artifactId>
-				<version>1.6.0</version>
+				<version>${osgi.cm.version}</version>
 				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.util.function</artifactId>
-				<version>1.0.0</version>
+				<version>${osgi.function.version}</version>
 				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.util.promise</artifactId>
-				<version>1.0.0</version>
+				<version>${osgi.promise.version}</version>
 				<scope>compile</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
For promise, we still compile against the 1.0.0 version of promise,
but we now test against the latest version of promise.

