### PR TITLE
[log.osgi] Make maven build work in m2e

### DIFF
--- a/org.osgi.test.junit5.listeners.log.osgi/pom.xml
+++ b/org.osgi.test.junit5.listeners.log.osgi/pom.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) Contributors to the Eclipse Foundation Licensed under 
-	the Apache License, Version 2.0 (the "License"); you may not use this file 
-	except in compliance with the License. You may obtain a copy of the License 
-	at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable 
-	law or agreed to in writing, software distributed under the License is distributed 
-	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-	express or implied. See the License for the specific language governing permissions 
-	and limitations under the License. SPDX-License-Identifier: Apache-2.0 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<!--
+    Copyright (c) Contributors to the Eclipse Foundation
+   
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+   
+        http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+   
+    SPDX-License-Identifier: Apache-2.0
+ -->
+ <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -138,27 +147,20 @@
 					</execution>
 				</executions>
 			</plugin>
- 			<plugin>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.2.0</version>
+			<plugin>
+				<groupId>com.coderplus.maven.plugins</groupId>
+				<artifactId>copy-rename-maven-plugin</artifactId>
+				<version>1.0</version>
 				<executions>
 					<execution>
-						<id>copy</id>
+						<id>copy-file</id>
 						<phase>package</phase>
 						<goals>
 							<goal>copy</goal>
 						</goals>
 						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>${project.groupId}</groupId>
-									<artifactId>${project.artifactId}</artifactId>
-									<version>${project.version}</version>
-									<overWrite>true</overWrite>
-									<outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
-								</artifactItem>
-							</artifactItems>
-							<stripVersion>true</stripVersion>
+							<sourceFile>${project.build.directory}/${project.artifactId}-${project.version}.jar</sourceFile>
+							<destinationFile>${project.build.testOutputDirectory}/${project.artifactId}.jar</destinationFile>
 						</configuration>
 					</execution>
 				</executions>
@@ -166,6 +168,21 @@
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<executions>
+					<execution>
+						<id>main-jar</id>
+						<!-- Must run in phase before the copy-rename-maven-plugin so that the artifact
+							 is available when it is needed.
+						-->
+						<phase>pre-package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+							</archive>
+						</configuration>
+					</execution>
 					<execution>
 						<id>test-jar</id>
 						<phase>package</phase>
@@ -176,9 +193,6 @@
 							<archive>
 								<manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 							</archive>
-							<excludes>
-								<exclude>**/test/tb*/**</exclude>
-							</excludes>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) Contributors to the Eclipse Foundation
-
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
-
-	SPDX-License-Identifier: Apache-2.0
--->
+    Copyright (c) Contributors to the Eclipse Foundation
+   
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+   
+        http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+   
+    SPDX-License-Identifier: Apache-2.0
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -405,30 +405,9 @@
 								<goal>report-integration</goal>
 							</goals>
 						</execution>
-						<!-- <execution>
-							<id>default-check</id>
-							<goals>
-							<goal>check</goal>
-							</goals>
-							<configuration>
-							<rules>
-							<rule>
-							<element>BUNDLE</element>
-							<limits>
-							<limit>
-							<counter>COMPLEXITY</counter>
-							<value>COVEREDRATIO</value>
-							<minimum>0.60</minimum>
-							</limit>
-							</limits>
-							</rule>
-							</rules>
-							</configuration>
-							</execution>
-						-->
 					</executions>
 				</plugin>
-				<!--This plugin's configuration is used to store Eclipse m2e settings
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -450,6 +429,21 @@
 										<ignore>
 											<message></message>
 										</ignore>
+									</action>
+								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>com.coderplus.maven.plugins</groupId>
+										<artifactId>copy-rename-maven-plugin</artifactId>
+										<versionRange>[1.0.0,)</versionRange>
+										<goals>
+											<goal>copy</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<execute>
+											<runOnIncremental>true</runOnIncremental>
+										</execute>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>


### PR DESCRIPTION
Previous PR #401 worked with raw Maven but not within m2e/Eclipse.

This update uses an m2e-friendly `copy-rename-maven-plugin` to copy the artifact to the test-classes directory before `maven-jar-plugin:test-jar` goal but after `maven-jar-plugin:jar`.