### PR TITLE
Log listener build simplify

### DIFF
--- a/org.osgi.test.junit5.listeners.log.osgi/pom.xml
+++ b/org.osgi.test.junit5.listeners.log.osgi/pom.xml
@@ -99,6 +99,10 @@
 			<artifactId>assertj-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 		</dependency>
@@ -137,62 +141,9 @@
 						<configuration>
 							<artifactFragment>false</artifactFragment>
 							<bnd><![CDATA[
-								p = ${project.artifactId}.test
-								Private-Package: ${p}.*
 								Test-Cases: ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE;PUBLIC}
 							]]></bnd>
-							<includeClassesDir>false</includeClassesDir>
 							<testCases>useTestCasesHeader</testCases>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>com.coderplus.maven.plugins</groupId>
-				<artifactId>copy-rename-maven-plugin</artifactId>
-				<version>1.0</version>
-				<executions>
-					<execution>
-						<id>copy-file</id>
-						<phase>package</phase>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<configuration>
-							<sourceFile>${project.build.directory}/${project.artifactId}-${project.version}.jar</sourceFile>
-							<destinationFile>${project.build.testOutputDirectory}/${project.artifactId}.jar</destinationFile>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-jar-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>main-jar</id>
-						<!-- Must run in phase before the copy-rename-maven-plugin so that the artifact
-							 is available when it is needed.
-						-->
-						<phase>pre-package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<configuration>
-							<archive>
-								<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-							</archive>
-						</configuration>
-					</execution>
-					<execution>
-						<id>test-jar</id>
-						<phase>package</phase>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-						<configuration>
-							<archive>
-								<manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-							</archive>
 						</configuration>
 					</execution>
 				</executions>

--- a/org.osgi.test.junit5.listeners.log.osgi/test.bndrun
+++ b/org.osgi.test.junit5.listeners.log.osgi/test.bndrun
@@ -21,6 +21,8 @@
 -runfw: org.eclipse.osgi
 -resolve.effective: active
 -runproperties: \
+	launch.startlevel.default=1,\
+	org.osgi.framework.startlevel.beginning=1,\
 	logback.configurationFile='${fileuri;${.}/logback.xml}',\
 	org.osgi.framework.bootdelegation='sun.misc,sun.reflect',\
 	osgi.console=
@@ -35,9 +37,13 @@
 	org.apache.felix.logback,\
 	slf4j.api
 -runrequires: \
+	bnd.identity;id='${project.artifactId}',\
 	bnd.identity;id='${project.artifactId}-tests',\
 	bnd.identity;id='junit-jupiter-engine',\
 	bnd.identity;id='junit-platform-launcher'
+# Don't start the bundle upon launch. The test case will control this.
+-runbundles+: \
+    ${project.artifactId};startlevel=100
 # This will help us keep -runbundles sorted
 -runstartlevel: \
     order=sortbynameversion,\
@@ -52,6 +58,8 @@
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
 	net.bytebuddy.byte-buddy;version='[1.11.19,1.11.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.11.19,1.11.20)',\
+	org.awaitility;version='[4.1.0,4.1.1)',\
+	org.hamcrest;version='[2.1.0,2.1.1)',\
 	org.mockito.mockito-core;version='[4.0.0,4.0.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
@@ -59,4 +67,5 @@
 	org.osgi.test.assertj.log;version='[1.1.0,1.1.1)',\
 	org.osgi.test.common;version='[1.1.0,1.1.1)',\
 	org.osgi.test.junit5;version='[1.1.0,1.1.1)',\
+	org.osgi.test.junit5.listeners.log.osgi;version='[1.1.0,1.1.1)',\
 	org.osgi.test.junit5.listeners.log.osgi-tests;version='[1.1.0,1.1.1)'

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 		<junit-jupiter.version>5.8.1</junit-jupiter.version>
 		<junit-platform.version>1.8.1</junit-platform.version>
 		<assertj.version>3.21.0</assertj.version>
+		<awaitility.version>4.1.0</awaitility.version>
 		<osgi.annotation.version>8.0.1</osgi.annotation.version>
 		<osgi.core.version>6.0.0</osgi.core.version>
 		<osgi.log.version>1.4.0</osgi.log.version>
@@ -438,21 +439,6 @@
 										</execute>
 									</action>
 								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>com.coderplus.maven.plugins</groupId>
-										<artifactId>copy-rename-maven-plugin</artifactId>
-										<versionRange>[1.0.0,)</versionRange>
-										<goals>
-											<goal>copy</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<execute>
-											<runOnIncremental>true</runOnIncremental>
-										</execute>
-									</action>
-								</pluginExecution>
 							</pluginExecutions>
 						</lifecycleMappingMetadata>
 					</configuration>
@@ -612,6 +598,12 @@
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
 				<version>${assertj.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.awaitility</groupId>
+				<artifactId>awaitility</artifactId>
+				<version>${awaitility.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
There does not appear to be any need to include the jar in the test-jar for the listeners.log.osgi project as far as I can see. None of the other projects which test their jars need to do this. We just need to add the jar to `-runrequires` to make sure it is available during test.

@kriegfrj Am I misunderstanding something here? 