### PR TITLE
build: Replace use of osgi.core as a dependency

### DIFF
--- a/org.osgi.test.assertj.framework/pom.xml
+++ b/org.osgi.test.assertj.framework/pom.xml
@@ -55,7 +55,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
+			<artifactId>org.osgi.dto</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.resource</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.framework</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/org.osgi.test.assertj.log/pom.xml
+++ b/org.osgi.test.assertj.log/pom.xml
@@ -55,7 +55,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
+			<artifactId>org.osgi.dto</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.resource</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.framework</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>

--- a/org.osgi.test.assertj.promise/pom.xml
+++ b/org.osgi.test.assertj.promise/pom.xml
@@ -55,7 +55,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
+			<artifactId>org.osgi.dto</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.resource</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.framework</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>

--- a/org.osgi.test.common/pom.xml
+++ b/org.osgi.test.common/pom.xml
@@ -45,7 +45,19 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
+			<artifactId>org.osgi.dto</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.resource</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.framework</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.util.tracker</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/org.osgi.test.junit4/pom.xml
+++ b/org.osgi.test.junit4/pom.xml
@@ -55,7 +55,19 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
+			<artifactId>org.osgi.dto</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.resource</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.framework</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.util.tracker</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/org.osgi.test.junit5.cm/pom.xml
+++ b/org.osgi.test.junit5.cm/pom.xml
@@ -73,7 +73,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
+			<artifactId>org.osgi.dto</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.resource</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.framework</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>

--- a/org.osgi.test.junit5.listeners.log.osgi/pom.xml
+++ b/org.osgi.test.junit5.listeners.log.osgi/pom.xml
@@ -92,7 +92,19 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
+			<artifactId>org.osgi.dto</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.resource</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.framework</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.util.tracker</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/org.osgi.test.junit5/pom.xml
+++ b/org.osgi.test.junit5/pom.xml
@@ -76,7 +76,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
+			<artifactId>org.osgi.dto</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.resource</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.framework</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,10 @@
 		<assertj.version>3.21.0</assertj.version>
 		<awaitility.version>4.1.1</awaitility.version>
 		<osgi.annotation.version>8.0.1</osgi.annotation.version>
-		<osgi.core.version>6.0.0</osgi.core.version>
+		<osgi.dto.version>1.0.0</osgi.dto.version>
+		<osgi.resource.version>1.0.0</osgi.resource.version>
+		<osgi.framework.version>1.8.0</osgi.framework.version>
+		<osgi.tracker.version>1.5.4</osgi.tracker.version>
 		<osgi.log.version>1.4.0</osgi.log.version>
 		<osgi.cm.version>1.6.1</osgi.cm.version>
 		<osgi.function.compile.version>1.0.0</osgi.function.compile.version>
@@ -566,8 +569,26 @@
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
-				<artifactId>osgi.core</artifactId>
-				<version>${osgi.core.version}</version>
+				<artifactId>org.osgi.dto</artifactId>
+				<version>${osgi.dto.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>org.osgi.resource</artifactId>
+				<version>${osgi.resource.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>org.osgi.framework</artifactId>
+				<version>${osgi.framework.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>org.osgi.util.tracker</artifactId>
+				<version>${osgi.tracker.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
We change to use the individual API jars for dependencies.

