### PR TITLE
[assertj] Add missing soft assertion entry points for framework

### DIFF
--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/version/VersionSoftAssertionsProvider.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/version/VersionSoftAssertionsProvider.java
@@ -16,6 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
-@org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.assertj.version;
+
+import org.assertj.core.api.SoftAssertionsProvider;
+import org.osgi.framework.Version;
+
+public interface VersionSoftAssertionsProvider extends SoftAssertionsProvider {
+	/**
+	 * Create assertion for {@link org.osgi.framework.Version}.
+	 *
+	 * @param actual the actual value.
+	 * @return the created assertion object.
+	 */
+	default VersionAssert assertThat(Version actual) {
+		return proxy(VersionAssert.class, Version.class, actual);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/versionrange/VersionRangeSoftAssertionsProvider.java
+++ b/org.osgi.test.assertj.framework/src/main/java/org/osgi/test/assertj/versionrange/VersionRangeSoftAssertionsProvider.java
@@ -16,6 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
-@org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
-package org.osgi.test.assertj.version;
+package org.osgi.test.assertj.versionrange;
+
+import org.assertj.core.api.SoftAssertionsProvider;
+import org.osgi.framework.VersionRange;
+
+public interface VersionRangeSoftAssertionsProvider extends SoftAssertionsProvider {
+	/**
+	 * Create assertion for {@link org.osgi.framework.VersionRange}.
+	 *
+	 * @param actual the actual value.
+	 * @return the created assertion object.
+	 */
+	default VersionRangeAssert assertThat(VersionRange actual) {
+		return proxy(VersionRangeAssert.class, VersionRange.class, actual);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundle/BundleAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundle/BundleAssertTest.java
@@ -52,12 +52,13 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
 import org.osgi.framework.wiring.BundleRevision;
 import org.osgi.test.assertj.bundle.BundleAssert;
-import org.osgi.test.assertj.test.testutil.AbstractAssertTest;
+import org.osgi.test.assertj.bundle.BundleSoftAssertionsProvider;
+import org.osgi.test.assertj.test.testutil.AbstractAssertAndSAPTest;
 
-public class BundleAssertTest extends AbstractAssertTest<BundleAssert, Bundle> {
+public class BundleAssertTest extends AbstractAssertAndSAPTest<BundleAssert, Bundle, BundleSoftAssertionsProvider> {
 
 	public BundleAssertTest() {
-		super(BundleAssert::assertThat);
+		super(BundleAssert::assertThat, BundleSoftAssertionsProvider.class, Bundle.class, () -> mock(Bundle.class));
 	}
 
 	public static final long	WAIT_TIME	= 2L;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundlecontext/BundleContextAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundlecontext/BundleContextAssertTest.java
@@ -30,12 +30,14 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.test.assertj.bundlecontext.BundleContextAssert;
+import org.osgi.test.assertj.bundlecontext.BundleContextSoftAssertionsProvider;
 import org.osgi.test.assertj.test.bundlereference.AbstractBundleReferenceAssertTest;
 
-class BundleContextAssertTest extends AbstractBundleReferenceAssertTest<BundleContextAssert, BundleContext> {
+class BundleContextAssertTest
+	extends AbstractBundleReferenceAssertTest<BundleContextAssert, BundleContext, BundleContextSoftAssertionsProvider> {
 
 	BundleContextAssertTest() {
-		super(BundleContextAssert::assertThat, BundleContext.class);
+		super(BundleContextAssert::assertThat, BundleContextSoftAssertionsProvider.class, BundleContext.class);
 	}
 
 	@Test

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundleevent/BundleEventAssertTest.java
@@ -45,12 +45,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleEvent;
 import org.osgi.test.assertj.bundleevent.BundleEventAssert;
-import org.osgi.test.assertj.test.testutil.AbstractAssertTest;
+import org.osgi.test.assertj.bundleevent.BundleEventSoftAssertionsProvider;
+import org.osgi.test.assertj.test.testutil.AbstractAssertAndSAPTest;
 
-class BundleEventAssertTest extends AbstractAssertTest<BundleEventAssert, BundleEvent> {
+class BundleEventAssertTest
+	extends AbstractAssertAndSAPTest<BundleEventAssert, BundleEvent, BundleEventSoftAssertionsProvider> {
 
 	BundleEventAssertTest() {
-		super(BundleEventAssert::assertThat);
+		super(BundleEventAssert::assertThat, BundleEventSoftAssertionsProvider.class, BundleEvent.class);
 	}
 
 	Bundle	bundle;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundlereference/AbstractBundleReferenceAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundlereference/AbstractBundleReferenceAssertTest.java
@@ -22,22 +22,22 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.SoftAssertionsProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleReference;
 import org.osgi.test.assertj.bundlereference.AbstractBundleReferenceAssert;
-import org.osgi.test.assertj.test.testutil.AbstractAssertTest;
+import org.osgi.test.assertj.test.testutil.AbstractAssertAndSAPTest;
 
-public abstract class AbstractBundleReferenceAssertTest<ASSERT extends AbstractBundleReferenceAssert<ASSERT, ACTUAL>, ACTUAL extends BundleReference>
-	extends AbstractAssertTest<ASSERT, ACTUAL> {
+public abstract class AbstractBundleReferenceAssertTest<ASSERT extends AbstractBundleReferenceAssert<ASSERT, ACTUAL>, ACTUAL extends BundleReference, SAP extends SoftAssertionsProvider>
+	extends AbstractAssertAndSAPTest<ASSERT, ACTUAL, SAP> {
 
-	protected AbstractBundleReferenceAssertTest(AssertFactory<ACTUAL, ASSERT> factory, Class<ACTUAL> actualClass) {
-		super(factory);
-		this.actualClass = actualClass;
+	protected AbstractBundleReferenceAssertTest(AssertFactory<ACTUAL, ASSERT> factory, Class<SAP> sap,
+		Class<ACTUAL> actualClass) {
+		super(factory, sap, actualClass);
 	}
 
-	final protected Class<ACTUAL>	actualClass;
 	protected Bundle				bundle;
 	protected Bundle				otherBundle;
 

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundlereference/BundleReferenceAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/bundlereference/BundleReferenceAssertTest.java
@@ -20,10 +20,12 @@ package org.osgi.test.assertj.test.bundlereference;
 
 import org.osgi.framework.BundleReference;
 import org.osgi.test.assertj.bundlereference.BundleReferenceAssert;
+import org.osgi.test.assertj.bundlereference.BundleReferenceSoftAssertionsProvider;
 
-class BundleReferenceAssertTest extends AbstractBundleReferenceAssertTest<BundleReferenceAssert, BundleReference> {
+class BundleReferenceAssertTest extends
+	AbstractBundleReferenceAssertTest<BundleReferenceAssert, BundleReference, BundleReferenceSoftAssertionsProvider> {
 
 	BundleReferenceAssertTest() {
-		super(BundleReferenceAssert::assertThat, BundleReference.class);
+		super(BundleReferenceAssert::assertThat, BundleReferenceSoftAssertionsProvider.class, BundleReference.class);
 	}
 }

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/frameworkevent/FrameworkEventAssertTest.java
@@ -45,12 +45,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkEvent;
 import org.osgi.test.assertj.frameworkevent.FrameworkEventAssert;
-import org.osgi.test.assertj.test.testutil.AbstractAssertTest;
+import org.osgi.test.assertj.frameworkevent.FrameworkEventSoftAssertionsProvider;
+import org.osgi.test.assertj.test.testutil.AbstractAssertAndSAPTest;
 
-class FrameworkEventAssertTest extends AbstractAssertTest<FrameworkEventAssert, FrameworkEvent> {
+class FrameworkEventAssertTest
+	extends AbstractAssertAndSAPTest<FrameworkEventAssert, FrameworkEvent, FrameworkEventSoftAssertionsProvider> {
 
 	FrameworkEventAssertTest() {
-		super(FrameworkEventAssert::assertThat);
+		super(FrameworkEventAssert::assertThat, FrameworkEventSoftAssertionsProvider.class, FrameworkEvent.class);
 	}
 
 	Bundle		bundle;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/serviceevent/ServiceEventAssertTest.java
@@ -39,12 +39,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.osgi.framework.ServiceEvent;
 import org.osgi.framework.ServiceReference;
 import org.osgi.test.assertj.serviceevent.ServiceEventAssert;
-import org.osgi.test.assertj.test.testutil.AbstractAssertTest;
+import org.osgi.test.assertj.serviceevent.ServiceEventSoftAssertionsProvider;
+import org.osgi.test.assertj.test.testutil.AbstractAssertAndSAPTest;
 
-class ServiceEventAssertTest extends AbstractAssertTest<ServiceEventAssert, ServiceEvent> {
+class ServiceEventAssertTest
+	extends AbstractAssertAndSAPTest<ServiceEventAssert, ServiceEvent, ServiceEventSoftAssertionsProvider> {
 
 	ServiceEventAssertTest() {
-		super(ServiceEventAssert::assertThat);
+		super(ServiceEventAssert::assertThat, ServiceEventSoftAssertionsProvider.class, ServiceEvent.class);
 	}
 
 	ServiceReference<?>	reference;

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/testutil/AbstractAssertAndSAPTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/testutil/AbstractAssertAndSAPTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.assertj.test.testutil;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.function.Supplier;
+
+import org.assertj.core.api.Assert;
+import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.SoftAssertionsProvider;
+import org.junit.jupiter.api.Test;
+
+// "SAP" = "SoftAssertionsProvider"
+public abstract class AbstractAssertAndSAPTest<SELF extends Assert<SELF, ACTUAL>, ACTUAL, SAP extends SoftAssertionsProvider>
+	extends AbstractAssertTest<SELF, ACTUAL> {
+
+	protected final Class<ACTUAL>		actualClass;
+	protected final Class<SAP> sap;
+	protected final Supplier<ACTUAL>	actualFactory;
+
+	protected AbstractAssertAndSAPTest(AssertFactory<ACTUAL, SELF> assertThat, Class<SAP> sap,
+		Class<ACTUAL> actualClass) {
+		this(assertThat, sap, actualClass, null);
+	}
+
+	protected AbstractAssertAndSAPTest(AssertFactory<ACTUAL, SELF> assertThat, Class<SAP> sap,
+		Class<ACTUAL> actualClass,
+		Supplier<ACTUAL> actualFactory) {
+		super(assertThat);
+		this.sap = sap;
+		this.actualClass = actualClass;
+		this.actualFactory = actualFactory == null ? () -> mock(actualClass) : actualFactory;
+	}
+
+	@Test
+	void softAssertionsProvider() throws Exception {
+		setActual(actualFactory.get());
+		softAssertionsProvider(sap, actualClass);
+	}
+}

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/version/VersionAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/version/VersionAssertTest.java
@@ -18,10 +18,19 @@
 
 package org.osgi.test.assertj.test.version;
 
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Version;
 import org.osgi.test.assertj.version.VersionAssert;
+import org.osgi.test.assertj.version.VersionSoftAssertionsProvider;
 
 public class VersionAssertTest extends AbstractVersionAssertTest<VersionAssert> {
 	public VersionAssertTest() {
 		super(VersionAssert::assertThat);
+	}
+
+	@Test
+	void softAssertionsProvider() throws Exception {
+		setActual(new Version("1.0.0"));
+		softAssertionsProvider(VersionSoftAssertionsProvider.class);
 	}
 }

--- a/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/versionrange/VersionRangeAssertTest.java
+++ b/org.osgi.test.assertj.framework/src/test/java/org/osgi/test/assertj/test/versionrange/VersionRangeAssertTest.java
@@ -30,13 +30,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
-import org.osgi.test.assertj.test.testutil.AbstractAssertTest;
+import org.osgi.test.assertj.test.testutil.AbstractAssertAndSAPTest;
 import org.osgi.test.assertj.versionrange.VersionRangeAssert;
+import org.osgi.test.assertj.versionrange.VersionRangeSoftAssertionsProvider;
 
-public class VersionRangeAssertTest extends AbstractAssertTest<VersionRangeAssert, VersionRange> {
+public class VersionRangeAssertTest
+	extends AbstractAssertAndSAPTest<VersionRangeAssert, VersionRange, VersionRangeSoftAssertionsProvider> {
 
 	public VersionRangeAssertTest() {
-		super(VersionRangeAssert::assertThat);
+		super(VersionRangeAssert::assertThat, VersionRangeSoftAssertionsProvider.class, VersionRange.class,
+			() -> new VersionRange("[1.0,2.0)"));
 	}
 
 	@BeforeEach


### PR DESCRIPTION
Version and VersionRange were missing. Also added comprehensive and generic testing for soft assertion provider implementations.

Signed-off-by: Fr Jeremy Krieg <fr.jkrieg@greekwelfaresa.org.au>