### PR TITLE
spliterator: Update Spliterator implementations

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/stream/DropWhile.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/stream/DropWhile.java
@@ -37,6 +37,20 @@ public final class DropWhile<T> extends AbstractWhile<T> {
 	}
 
 	@Override
+	public void forEachRemaining(Consumer<? super T> action) {
+		if (drop) {
+			drop = false;
+			while (spliterator.tryAdvance(this)) {
+				if (!predicate.test(item)) {
+					action.accept(item);
+					break;
+				}
+			}
+		}
+		spliterator.forEachRemaining(action);
+	}
+
+	@Override
 	public boolean tryAdvance(Consumer<? super T> action) {
 		if (drop) {
 			drop = false;

--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/stream/TakeWhile.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/stream/TakeWhile.java
@@ -37,6 +37,16 @@ public final class TakeWhile<T> extends AbstractWhile<T> {
 	}
 
 	@Override
+	public void forEachRemaining(Consumer<? super T> action) {
+		if (take) {
+			while (spliterator.tryAdvance(this) && predicate.test(item)) {
+				action.accept(item);
+			}
+			take = false;
+		}
+	}
+
+	@Override
 	public boolean tryAdvance(Consumer<? super T> action) {
 		if (take) {
 			if (spliterator.tryAdvance(this) && predicate.test(item)) {


### PR DESCRIPTION
We make sure forEachRemaining is implemented as this is often used
for non-short-circuited stream operations.

