### PR TITLE
Injection refactor

### DIFF
--- a/org.osgi.test.common/src/main/java/org/osgi/test/common/inject/package-info.java
+++ b/org.osgi.test.common/src/main/java/org/osgi/test/common/inject/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.osgi.test.common.inject;

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/InjectService.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/InjectService.java
@@ -93,11 +93,11 @@ public @interface InjectService {
 	/**
 	 * Indicate to take the serviceClass from not from the parameter. Use
 	 * `org.osgi.test.common.annotation.InjectService.AnyService` and the
-	 * ParameterType or FieldType`java.lang.Object` for any Service.
+	 * ParameterType or FieldType `java.lang.Object` for any Service.
 	 *
 	 * @return The service class.
 	 */
-	Class<?> service() default Object.class;
+	Class<?> service() default InjectService.class;
 
 	public static final class AnyService {
 		private AnyService() {}

--- a/org.osgi.test.junit4/src/test/java/org/osgi/test/junit4/test/service/OwnServiceTest.java
+++ b/org.osgi.test.junit4/src/test/java/org/osgi/test/junit4/test/service/OwnServiceTest.java
@@ -39,7 +39,7 @@ public class OwnServiceTest {
 
 	@InjectBundleContext
 	BundleContext				bundleContext;
-	@InjectService(cardinality = 0)
+	@InjectService(cardinality = 0, service = Foo.class)
 	ServiceAware<Foo>	fooServiceAware;
 
 	@Test

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/package-info.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/package-info.java
@@ -17,7 +17,7 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 
 @org.osgi.service.cm.annotations.RequireConfigurationAdmin
 package org.osgi.test.junit5.cm;

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/InjectService.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/InjectService.java
@@ -97,11 +97,11 @@ public @interface InjectService {
 	/**
 	 * Indicate to take the serviceClass from not from the parameter. Use
 	 * `org.osgi.test.common.annotation.InjectService.AnyService` and the
-	 * ParameterType or FieldType`java.lang.Object` for any Service.
+	 * ParameterType or FieldType `java.lang.Object` for any Service.
 	 *
 	 * @return The service class.
 	 */
-	Class<?> service() default Object.class;
+	Class<?> service() default InjectService.class;
 
 	public static final class AnyService {
 		private AnyService() {}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
@@ -18,20 +18,14 @@
 
 package org.osgi.test.junit5.context;
 
-import static org.osgi.test.common.inject.FieldInjector.assertFieldIsOfType;
-import static org.osgi.test.common.inject.FieldInjector.assertParameterIsOfType;
-
 import java.lang.reflect.Field;
-import java.lang.reflect.Parameter;
 
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.test.common.annotation.InjectBundleContext;
@@ -75,7 +69,7 @@ public class BundleContextExtension extends InjectingExtension<InjectBundleConte
 	public static final String	INSTALL_BUNDLE_KEY	= BundleInstallerExtension.INSTALL_BUNDLE_KEY;
 
 	public BundleContextExtension() {
-		super(InjectBundleContext.class);
+		super(InjectBundleContext.class, BundleContext.class);
 	}
 
 	public static BundleContext getBundleContext(ExtensionContext extensionContext) {
@@ -135,17 +129,12 @@ public class BundleContextExtension extends InjectingExtension<InjectBundleConte
 	}
 
 	@Override
-	protected Object fieldValue(Field field, ExtensionContext extensionContext) {
-		assertFieldIsOfType(field, BundleContext.class, supported, ExtensionConfigurationException::new);
+	protected Object resolveField(Field field, ExtensionContext extensionContext) {
 		return getBundleContext(extensionContext);
 	}
 
 	@Override
-	protected Object parameterValue(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		final Parameter parameter = parameterContext.getParameter();
-
-		Class<?> parameterType = parameter.getType();
-		assertParameterIsOfType(parameterType, BundleContext.class, supported, ParameterResolutionException::new);
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
 		return getBundleContext(extensionContext);
 	}
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleContextExtension.java
@@ -18,18 +18,17 @@
 
 package org.osgi.test.junit5.context;
 
-import java.lang.reflect.Field;
-
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
-import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.common.context.CloseableBundleContext;
+import org.osgi.test.common.inject.TargetType;
 import org.osgi.test.common.install.BundleInstaller;
 import org.osgi.test.junit5.inject.InjectingExtension;
 
@@ -129,12 +128,8 @@ public class BundleContextExtension extends InjectingExtension<InjectBundleConte
 	}
 
 	@Override
-	protected Object resolveField(Field field, ExtensionContext extensionContext) {
-		return getBundleContext(extensionContext);
-	}
-
-	@Override
-	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+	protected Object resolveValue(TargetType targetType, InjectBundleContext injection,
+		ExtensionContext extensionContext) throws ParameterResolutionException {
 		return getBundleContext(extensionContext);
 	}
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleInstallerExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleInstallerExtension.java
@@ -18,18 +18,12 @@
 
 package org.osgi.test.junit5.context;
 
-import static org.osgi.test.common.inject.FieldInjector.assertFieldIsOfType;
-import static org.osgi.test.common.inject.FieldInjector.assertParameterIsOfType;
-
 import java.lang.reflect.Field;
-import java.lang.reflect.Parameter;
 
-import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.osgi.framework.BundleContext;
 import org.osgi.test.common.annotation.InjectBundleInstaller;
 import org.osgi.test.common.install.BundleInstaller;
@@ -65,7 +59,7 @@ public class BundleInstallerExtension extends InjectingExtension<InjectBundleIns
 	public static final String	INSTALL_BUNDLE_KEY	= "bundle.installer";
 
 	public BundleInstallerExtension() {
-		super(InjectBundleInstaller.class);
+		super(InjectBundleInstaller.class, BundleInstaller.class);
 	}
 
 	public static BundleInstaller getBundleInstaller(ExtensionContext extensionContext) {
@@ -80,17 +74,12 @@ public class BundleInstallerExtension extends InjectingExtension<InjectBundleIns
 	}
 
 	@Override
-	protected Object fieldValue(Field field, ExtensionContext extensionContext) {
-		assertFieldIsOfType(field, BundleInstaller.class, supported, ExtensionConfigurationException::new);
+	protected Object resolveField(Field field, ExtensionContext extensionContext) {
 		return getBundleInstaller(extensionContext);
 	}
 
 	@Override
-	protected Object parameterValue(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		final Parameter parameter = parameterContext.getParameter();
-
-		Class<?> parameterType = parameter.getType();
-		assertParameterIsOfType(parameterType, BundleInstaller.class, supported, ParameterResolutionException::new);
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
 		return getBundleInstaller(extensionContext);
 	}
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleInstallerExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/context/BundleInstallerExtension.java
@@ -18,14 +18,13 @@
 
 package org.osgi.test.junit5.context;
 
-import java.lang.reflect.Field;
-
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
-import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.osgi.framework.BundleContext;
 import org.osgi.test.common.annotation.InjectBundleInstaller;
+import org.osgi.test.common.inject.TargetType;
 import org.osgi.test.common.install.BundleInstaller;
 import org.osgi.test.junit5.inject.InjectingExtension;
 
@@ -74,12 +73,8 @@ public class BundleInstallerExtension extends InjectingExtension<InjectBundleIns
 	}
 
 	@Override
-	protected Object resolveField(Field field, ExtensionContext extensionContext) {
-		return getBundleInstaller(extensionContext);
-	}
-
-	@Override
-	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+	protected Object resolveValue(TargetType targetType, InjectBundleInstaller injection,
+		ExtensionContext extensionContext) throws ParameterResolutionException {
 		return getBundleInstaller(extensionContext);
 	}
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/inject/InjectingExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/inject/InjectingExtension.java
@@ -18,6 +18,8 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
@@ -29,7 +31,7 @@ import org.junit.jupiter.api.extension.TestInstances;
 import org.osgi.test.common.inject.TargetType;
 
 public abstract class InjectingExtension<A extends Annotation>
-	implements BeforeEachCallback, BeforeAllCallback, ParameterResolver {
+	implements BeforeEachCallback, BeforeAllCallback, ParameterResolver, AfterAllCallback, AfterEachCallback {
 
 	private final Class<A>			annotation;
 	private final List<Class<?>>	targetTypes;
@@ -125,12 +127,19 @@ public abstract class InjectingExtension<A extends Annotation>
 	}
 
 	@Override
+	public void afterAll(ExtensionContext extensionContext) throws Exception {}
+
+
+	@Override
 	public void beforeEach(ExtensionContext extensionContext) throws Exception {
 		if (!isPerClass(extensionContext)) {
 			injectNonStaticFields(extensionContext, extensionContext.getRequiredTestInstance());
 		}
 		injectNonStaticFields(extensionContext);
 	}
+
+	@Override
+	public void afterEach(ExtensionContext extensionContext) throws Exception {}
 
 	private void injectNonStaticFields(ExtensionContext extensionContext) {
 		if (!extensionContext.getTestInstances()

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/inject/InjectingExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/inject/InjectingExtension.java
@@ -120,7 +120,7 @@ public abstract class InjectingExtension<A extends Annotation>
 		fields.stream()
 			.filter(field -> supportsField(field, extensionContext))
 			.forEach(field -> setField(field, null, resolveField(field, extensionContext)));
-		if (isPerClass(extensionContext)) {
+		if (isLifecyclePerClass(extensionContext)) {
 			injectNonStaticFields(extensionContext, extensionContext.getRequiredTestInstance());
 		}
 		injectNonStaticFields(extensionContext);
@@ -132,7 +132,7 @@ public abstract class InjectingExtension<A extends Annotation>
 
 	@Override
 	public void beforeEach(ExtensionContext extensionContext) throws Exception {
-		if (!isPerClass(extensionContext)) {
+		if (!isLifecyclePerClass(extensionContext)) {
 			injectNonStaticFields(extensionContext, extensionContext.getRequiredTestInstance());
 		}
 		injectNonStaticFields(extensionContext);
@@ -154,7 +154,7 @@ public abstract class InjectingExtension<A extends Annotation>
 				continue;
 			}
 			final Class<?> testClass = instance.getClass();
-			boolean perInstance = !isAnnotatedPerClass(testClass);
+			boolean perInstance = !isLifecyclePerClass(testClass);
 			if (perInstance) {
 				injectNonStaticFields(extensionContext, instance);
 			}
@@ -170,13 +170,13 @@ public abstract class InjectingExtension<A extends Annotation>
 			.forEach(field -> setField(field, instance, resolveField(field, extensionContext)));
 	}
 
-	private static boolean isPerClass(ExtensionContext context) {
+	protected boolean isLifecyclePerClass(ExtensionContext context) {
 		return context.getTestInstanceLifecycle()
 			.filter(Lifecycle.PER_CLASS::equals)
 			.isPresent();
 	}
 
-	private static boolean isAnnotatedPerClass(Class<?> testClass) {
+	protected boolean isLifecyclePerClass(Class<?> testClass) {
 		return findAnnotation(testClass, TestInstance.class).map(TestInstance::value)
 			.filter(Lifecycle.PER_CLASS::equals)
 			.isPresent();

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/inject/InjectingExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/inject/InjectingExtension.java
@@ -1,6 +1,9 @@
 package org.osgi.test.junit5.inject;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
 import static org.osgi.test.common.inject.FieldInjector.findAnnotatedFields;
 import static org.osgi.test.common.inject.FieldInjector.findAnnotatedNonStaticFields;
 import static org.osgi.test.common.inject.FieldInjector.setField;
@@ -9,7 +12,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
+import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -18,19 +23,116 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestInstances;
+import org.osgi.test.common.inject.TargetType;
 
 public abstract class InjectingExtension<A extends Annotation>
 	implements BeforeEachCallback, BeforeAllCallback, ParameterResolver {
 
-	protected final Class<A> supported;
+	private final Class<A>			annotation;
+	private final List<Class<?>>	targetTypes;
 
-	protected InjectingExtension(Class<A> annotation) {
-		supported = annotation;
+	protected InjectingExtension(Class<A> annotation, Class<?>... targetTypes) {
+		this.annotation = requireNonNull(annotation);
+		this.targetTypes = Arrays.asList(targetTypes);
 	}
 
-	void injectNonStaticFields(ExtensionContext extensionContext) {
+	protected Class<A> annotation() {
+		return annotation;
+	}
+
+	protected List<Class<?>> targetTypes() {
+		return targetTypes;
+	}
+
+	/**
+	 * Determine if this extender supports resolution for the specified
+	 * {@link TargetType} for the specified {@link ExtensionContext}.
+	 */
+	protected boolean supportsType(TargetType targetType, Function<String, ? extends RuntimeException> exception,
+		ExtensionContext extensionContext) {
+		if (!targetTypes().isEmpty()) {
+			Class<?> type = targetType.getType();
+			if (targetTypes().stream()
+				.noneMatch(type::isAssignableFrom)) {
+				throw exception.apply(
+					String.format("Element %s has an unsupported type %s for annotation @%s. Supported types are: %s.",
+						targetType.getName(), type.getName(), annotation().getSimpleName(), targetTypes().stream()
+							.map(Class::getName)
+							.collect(joining())));
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Determine if this extender supports resolution for the specified
+	 * {@link Field} for the specified {@link ExtensionContext}.
+	 */
+	protected boolean supportsField(Field field, ExtensionContext extensionContext) {
+		if (!isAnnotated(field, annotation())) {
+			return false;
+		}
+		if (!supportsType(TargetType.of(field), ExtensionConfigurationException::new, extensionContext)) {
+			return false;
+		}
+		if (Modifier.isFinal(field.getModifiers()) || Modifier.isPrivate(field.getModifiers())) {
+			throw new ExtensionConfigurationException(
+				String.format("Field %s must not be private or final for annotation @%s.", field.getName(),
+					annotation().getSimpleName()));
+		}
+		return true;
+	}
+
+	/**
+	 * Resolve the value for the specified {@link Field} for the specified
+	 * {@link ExtensionContext}.
+	 */
+	protected abstract Object resolveField(Field field, ExtensionContext extensionContext);
+
+	/**
+	 * Determine if this resolver supports resolution of an argument for the
+	 * {@link Parameter} in the specified {@link ParameterContext} for the
+	 * specified {@link ExtensionContext}.
+	 */
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+		throws ParameterResolutionException {
+		if (!parameterContext.isAnnotated(annotation())) {
+			return false;
+		}
+		if (!supportsType(TargetType.of(parameterContext.getParameter()), ParameterResolutionException::new,
+			extensionContext)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public void beforeAll(ExtensionContext extensionContext) throws Exception {
+		List<Field> fields = findAnnotatedFields(extensionContext.getRequiredTestClass(), annotation(),
+			m -> Modifier.isStatic(m.getModifiers()));
+
+		fields.stream()
+			.filter(field -> supportsField(field, extensionContext))
+			.forEach(field -> setField(field, null, resolveField(field, extensionContext)));
+		if (isPerClass(extensionContext)) {
+			injectNonStaticFields(extensionContext, extensionContext.getRequiredTestInstance());
+		}
+		injectNonStaticFields(extensionContext);
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext extensionContext) throws Exception {
+		if (!isPerClass(extensionContext)) {
+			injectNonStaticFields(extensionContext, extensionContext.getRequiredTestInstance());
+		}
+		injectNonStaticFields(extensionContext);
+	}
+
+	private void injectNonStaticFields(ExtensionContext extensionContext) {
 		if (!extensionContext.getTestInstances()
 			.isPresent()) {
 			return;
@@ -50,69 +152,24 @@ public abstract class InjectingExtension<A extends Annotation>
 		}
 	}
 
-	static boolean isPerClass(ExtensionContext context) {
+	private void injectNonStaticFields(ExtensionContext extensionContext, Object instance) {
+		final Class<?> testClass = instance.getClass();
+		List<Field> fields = findAnnotatedNonStaticFields(testClass, annotation());
+
+		fields.stream()
+			.filter(field -> supportsField(field, extensionContext))
+			.forEach(field -> setField(field, instance, resolveField(field, extensionContext)));
+	}
+
+	private static boolean isPerClass(ExtensionContext context) {
 		return context.getTestInstanceLifecycle()
 			.filter(Lifecycle.PER_CLASS::equals)
 			.isPresent();
 	}
 
-	static boolean isAnnotatedPerClass(Class<?> testClass) {
+	private static boolean isAnnotatedPerClass(Class<?> testClass) {
 		return findAnnotation(testClass, TestInstance.class).map(TestInstance::value)
 			.filter(Lifecycle.PER_CLASS::equals)
 			.isPresent();
-	}
-
-	void injectNonStaticFields(ExtensionContext extensionContext, Object instance) {
-		final Class<?> testClass = instance.getClass();
-		List<Field> fields = findAnnotatedNonStaticFields(testClass, supported);
-
-		fields.forEach(field -> setField(field, instance, fieldValue(field, extensionContext)));
-	}
-
-	/**
-	 * Resolve annotated {@link Parameter} with
-	 * {@link #parameterValue(ParameterContext, ExtensionContext)} result.
-	 */
-	@Override
-	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		if (parameterContext.isAnnotated(supported)) {
-			return parameterValue(parameterContext, extensionContext);
-		}
-
-		throw new ExtensionConfigurationException(
-			"No parameter types known to " + getClass().getSimpleName() + " were found");
-	}
-
-	/**
-	 * Determine if the {@link Parameter} in the supplied
-	 * {@link ParameterContext} is annotated with supported annotation.
-	 */
-	@Override
-	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		return parameterContext.isAnnotated(supported);
-	}
-
-	protected abstract Object fieldValue(Field field, ExtensionContext extensionContext);
-
-	protected abstract Object parameterValue(ParameterContext parameterContext, ExtensionContext extensionContext);
-
-	@Override
-	public void beforeAll(ExtensionContext extensionContext) throws Exception {
-		List<Field> fields = findAnnotatedFields(extensionContext.getRequiredTestClass(), supported,
-			m -> Modifier.isStatic(m.getModifiers()));
-
-		fields.forEach(field -> setField(field, null, fieldValue(field, extensionContext)));
-		if (isPerClass(extensionContext)) {
-			injectNonStaticFields(extensionContext, extensionContext.getRequiredTestInstance());
-		}
-		injectNonStaticFields(extensionContext);
-	}
-
-	@Override
-	public void beforeEach(ExtensionContext extensionContext) throws Exception {
-		if (!isPerClass(extensionContext)) {
-			injectNonStaticFields(extensionContext, extensionContext.getRequiredTestInstance());
-		}
-		injectNonStaticFields(extensionContext);
 	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleContextExtension_BundleContextInjectionSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleContextExtension_BundleContextInjectionSanityCheckingTest.java
@@ -42,8 +42,7 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedParameter_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectParameterType.class).isInstanceOf(ParameterResolutionException.class)
-			.hasMessageEndingWith(
-				"Can only resolve @InjectBundleContext parameter of type org.osgi.framework.BundleContext but was: java.lang.String");
+			.hasMessageContainingAll("java.lang.String", "@InjectBundleContext", "org.osgi.framework.BundleContext");
 	}
 
 	static class IncorrectFieldType extends TestBase {
@@ -59,8 +58,8 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"[myField] Can only resolve @InjectBundleContext field of type org.osgi.framework.BundleContext but was: java.lang.String");
+			.hasMessageContainingAll("myField", "java.lang.String", "@InjectBundleContext",
+				"org.osgi.framework.BundleContext");
 	}
 
 	static class IncorrectStaticFieldType extends TestBase {
@@ -76,8 +75,8 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectStaticFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"[myStaticField] Can only resolve @InjectBundleContext field of type org.osgi.framework.BundleContext but was: java.lang.String");
+			.hasMessageContainingAll("myStaticField", "java.lang.String", "@InjectBundleContext",
+				"org.osgi.framework.BundleContext");
 	}
 
 	static class FinalStaticField extends TestBase {
@@ -92,7 +91,7 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsFinal_throwsException() {
 		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*final.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleContext");
 	}
 
 	static class FinalField extends TestBase {
@@ -107,7 +106,7 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*final.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleContext");
 	}
 
 	static class PrivateField extends TestBase {
@@ -122,7 +121,7 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*private.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleContext");
 	}
 
 	static class StaticPrivateField extends TestBase {
@@ -137,6 +136,6 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsPrivate_throwsException() {
 		assertThatTest(StaticPrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectBundleContext field \\[bc\\] must not be .*private.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleContext");
 	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleContextExtension_BundleContextInjectionSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleContextExtension_BundleContextInjectionSanityCheckingTest.java
@@ -91,7 +91,7 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsFinal_throwsException() {
 		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleContext");
+			.hasMessageContainingAll("bc", "must not be final", "@InjectBundleContext");
 	}
 
 	static class FinalField extends TestBase {
@@ -106,7 +106,7 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleContext");
+			.hasMessageContainingAll("bc", "must not be final", "@InjectBundleContext");
 	}
 
 	static class PrivateField extends TestBase {
@@ -121,7 +121,7 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleContext");
+			.hasMessageContainingAll("bc", "must not be private", "@InjectBundleContext");
 	}
 
 	static class StaticPrivateField extends TestBase {
@@ -136,6 +136,6 @@ public class BundleContextExtension_BundleContextInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsPrivate_throwsException() {
 		assertThatTest(StaticPrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleContext");
+			.hasMessageContainingAll("bc", "must not be private", "@InjectBundleContext");
 	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleContextExtension_BundleInstallerInjectionSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleContextExtension_BundleInstallerInjectionSanityCheckingTest.java
@@ -42,8 +42,8 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedParameter_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectParameterType.class).isInstanceOf(ParameterResolutionException.class)
-			.hasMessageEndingWith(
-				"Can only resolve @InjectBundleInstaller parameter of type org.osgi.test.common.install.BundleInstaller but was: java.lang.String");
+			.hasMessageContainingAll("java.lang.String", "@InjectBundleInstaller",
+				"org.osgi.test.common.install.BundleInstaller");
 	}
 
 	static class IncorrectFieldType extends TestBase {
@@ -59,8 +59,8 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"[myField] Can only resolve @InjectBundleInstaller field of type org.osgi.test.common.install.BundleInstaller but was: java.lang.String");
+			.hasMessageContainingAll("myField", "java.lang.String", "@InjectBundleInstaller",
+				"org.osgi.test.common.install.BundleInstaller");
 	}
 
 	static class IncorrectStaticFieldType extends TestBase {
@@ -76,8 +76,8 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectStaticFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"[myStaticField] Can only resolve @InjectBundleInstaller field of type org.osgi.test.common.install.BundleInstaller but was: java.lang.String");
+			.hasMessageContainingAll("myStaticField", "java.lang.String", "@InjectBundleInstaller",
+				"org.osgi.test.common.install.BundleInstaller");
 	}
 
 	static class FinalStaticField extends TestBase {
@@ -92,7 +92,7 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsFinal_throwsException() {
 		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectBundleInstaller field \\[bc\\] must not be .*final.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleInstaller");
 	}
 
 	static class FinalField extends TestBase {
@@ -107,7 +107,7 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectBundleInstaller field \\[bc\\] must not be .*final.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleInstaller");
 	}
 
 	static class PrivateStaticField extends TestBase {
@@ -122,7 +122,7 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectBundleInstaller field \\[bc\\] must not be .*private.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleInstaller");
 	}
 
 	static class PrivateField extends TestBase {
@@ -137,6 +137,6 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectBundleInstaller field \\[bc\\] must not be .*private.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleInstaller");
 	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleContextExtension_BundleInstallerInjectionSanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleContextExtension_BundleInstallerInjectionSanityCheckingTest.java
@@ -92,7 +92,7 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsFinal_throwsException() {
 		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleInstaller");
+			.hasMessageContainingAll("bc", "must not be final", "@InjectBundleInstaller");
 	}
 
 	static class FinalField extends TestBase {
@@ -107,7 +107,7 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleInstaller");
+			.hasMessageContainingAll("bc", "must not be final", "@InjectBundleInstaller");
 	}
 
 	static class PrivateStaticField extends TestBase {
@@ -122,7 +122,7 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleInstaller");
+			.hasMessageContainingAll("bc", "must not be private", "@InjectBundleInstaller");
 	}
 
 	static class PrivateField extends TestBase {
@@ -137,6 +137,6 @@ public class BundleContextExtension_BundleInstallerInjectionSanityCheckingTest {
 	@Test
 	void annotatedField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectBundleInstaller");
+			.hasMessageContainingAll("bc", "must not be private", "@InjectBundleInstaller");
 	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleInjection_SanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleInjection_SanityCheckingTest.java
@@ -42,8 +42,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedParameter_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectParameterType.class).isInstanceOf(ParameterResolutionException.class)
-			.hasMessageEndingWith(
-				"Can only resolve @InjectInstalledBundle parameter of type org.osgi.framework.Bundle but was: java.lang.String");
+			.hasMessageContainingAll("java.lang.String", "@InjectInstalledBundle", "org.osgi.framework.Bundle");
 	}
 
 	static class IncorrectFieldType {
@@ -58,8 +57,8 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedField_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"[myField] Can only resolve @InjectInstalledBundle field of type org.osgi.framework.Bundle but was: java.lang.String");
+			.hasMessageContainingAll("myField", "java.lang.String", "@InjectInstalledBundle",
+				"org.osgi.framework.Bundle");
 	}
 
 	static class IncorrectStaticFieldType {
@@ -74,8 +73,8 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedStaticField_withIncorrectType_throwsException() {
 		assertThatTest(IncorrectStaticFieldType.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessage(
-				"[myStaticField] Can only resolve @InjectInstalledBundle field of type org.osgi.framework.Bundle but was: java.lang.String");
+			.hasMessageContainingAll("myStaticField", "java.lang.String", "@InjectInstalledBundle",
+				"org.osgi.framework.Bundle");
 	}
 
 	static class FinalStaticField {
@@ -89,7 +88,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsFinal_throwsException() {
 		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectInstalledBundle field \\[bundle\\] must not be .*final.*");
+			.hasMessageContainingAll("bundle", "must not be private or final", "@InjectInstalledBundle");
 	}
 
 	static class FinalField {
@@ -103,7 +102,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectInstalledBundle field \\[bundle\\] must not be .*final.*");
+			.hasMessageContainingAll("bundle", "must not be private or final", "@InjectInstalledBundle");
 	}
 
 	static class PrivateStaticField {
@@ -117,7 +116,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectInstalledBundle field \\[bundle\\] must not be .*private.*");
+			.hasMessageContainingAll("bundle", "must not be private or final", "@InjectInstalledBundle");
 	}
 
 	static class PrivateField {
@@ -131,7 +130,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectInstalledBundle field \\[bundle\\] must not be .*private.*");
+			.hasMessageContainingAll("bundle", "must not be private or final", "@InjectInstalledBundle");
 	}
 
 	static class MissingBundle {

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleInjection_SanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/context/BundleInjection_SanityCheckingTest.java
@@ -88,7 +88,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsFinal_throwsException() {
 		assertThatTest(FinalStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bundle", "must not be private or final", "@InjectInstalledBundle");
+			.hasMessageContainingAll("bundle", "must not be final", "@InjectInstalledBundle");
 	}
 
 	static class FinalField {
@@ -102,7 +102,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bundle", "must not be private or final", "@InjectInstalledBundle");
+			.hasMessageContainingAll("bundle", "must not be final", "@InjectInstalledBundle");
 	}
 
 	static class PrivateStaticField {
@@ -116,7 +116,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedStaticField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateStaticField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bundle", "must not be private or final", "@InjectInstalledBundle");
+			.hasMessageContainingAll("bundle", "must not be private", "@InjectInstalledBundle");
 	}
 
 	static class PrivateField {
@@ -130,7 +130,7 @@ public class BundleInjection_SanityCheckingTest {
 	@Test
 	void annotatedField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bundle", "must not be private or final", "@InjectInstalledBundle");
+			.hasMessageContainingAll("bundle", "must not be private", "@InjectInstalledBundle");
 	}
 
 	static class MissingBundle {

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/service/ServiceExtension_SanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/service/ServiceExtension_SanityCheckingTest.java
@@ -80,7 +80,7 @@ public class ServiceExtension_SanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectService");
+			.hasMessageContainingAll("bc", "must not be final", "@InjectService");
 	}
 
 	static class PrivateField extends TestBase {
@@ -95,6 +95,6 @@ public class ServiceExtension_SanityCheckingTest {
 	@Test
 	void annotatedField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageContainingAll("bc", "must not be private or final", "@InjectService");
+			.hasMessageContainingAll("bc", "must not be private", "@InjectService");
 	}
 }

--- a/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/service/ServiceExtension_SanityCheckingTest.java
+++ b/org.osgi.test.junit5/src/test/java/org/osgi/test/junit5/test/service/ServiceExtension_SanityCheckingTest.java
@@ -65,9 +65,7 @@ public class ServiceExtension_SanityCheckingTest {
 	})
 	void annotatedParameter_withNonRawType_throwsException(Class<?> test) {
 		assertThatTest(test).isInstanceOf(ParameterResolutionException.class)
-			.hasMessageEndingWith(
-				"Can only resolve @InjectService parameter for services with non-generic types, service type was: "
-					+ AtomicReference.class.getName() + "<?>");
+			.hasMessageContainingAll("non-generic type", "@InjectService", AtomicReference.class.getName());
 	}
 
 	static class FinalField extends TestBase {
@@ -82,7 +80,7 @@ public class ServiceExtension_SanityCheckingTest {
 	@Test
 	void annotatedField_thatIsFinal_throwsException() {
 		assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectService field \\[bc\\] must not be.*final.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectService");
 	}
 
 	static class PrivateField extends TestBase {
@@ -97,6 +95,6 @@ public class ServiceExtension_SanityCheckingTest {
 	@Test
 	void annotatedField_thatIsPrivate_throwsException() {
 		assertThatTest(PrivateField.class).isInstanceOf(ExtensionConfigurationException.class)
-			.hasMessageMatching("@InjectService field \\[bc\\] must not be.*private.*");
+			.hasMessageContainingAll("bc", "must not be private or final", "@InjectService");
 	}
 }


### PR DESCRIPTION
Refactor InjectingExtension to handle basic type validation.

For most uses, the base InjectingExtension class can validate the
target injection site type and remove that burden from subclasses.

So we allow subclasses to supply target types which will be used to
validate the injection site is compatible with at least one target
type.