### PR TITLE
build: Set scm tag element to revision

### DIFF
--- a/org.osgi.test.assertj.framework/pom.xml
+++ b/org.osgi.test.assertj.framework/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<dependencies>

--- a/org.osgi.test.assertj.log/pom.xml
+++ b/org.osgi.test.assertj.log/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<dependencies>

--- a/org.osgi.test.assertj.promise/pom.xml
+++ b/org.osgi.test.assertj.promise/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<dependencies>

--- a/org.osgi.test.bom/pom.xml
+++ b/org.osgi.test.bom/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<packaging>pom</packaging>

--- a/org.osgi.test.common/pom.xml
+++ b/org.osgi.test.common/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<dependencies>

--- a/org.osgi.test.junit4/pom.xml
+++ b/org.osgi.test.junit4/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<dependencies>

--- a/org.osgi.test.junit5.cm/pom.xml
+++ b/org.osgi.test.junit5.cm/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<dependencies>

--- a/org.osgi.test.junit5.listeners.log.osgi/pom.xml
+++ b/org.osgi.test.junit5.listeners.log.osgi/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<dependencies>

--- a/org.osgi.test.junit5/pom.xml
+++ b/org.osgi.test.junit5/pom.xml
@@ -36,6 +36,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
-		<tag>HEAD</tag>
+		<tag>${revision}</tag>
 	</scm>
 	<developers>
 		<developer>


### PR DESCRIPTION
When we publish, the revision (version) is also the tag.

