### PR TITLE
annotation: Substitutably import the junit4 annotation package

### DIFF
--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/package-info.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/package-info.java
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
-@Export(attribute = "junit=4", substitution = Substitution.NOIMPORT)
-@Version("1.1.1")
+@Export(attribute = "junit=4")
+@Version("1.1.0")
 package org.osgi.test.common.annotation;
 
 import org.osgi.annotation.bundle.Export;
-import org.osgi.annotation.bundle.Export.Substitution;
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
If both junit4 and junit5 annotation package are available, we want to
allow the junit4 bundle to import the package from the junit 5 bundle.
This allows a single version of the package to be shared for when the
tests are mixed junit4 and junit5 while preferring the junit5
annotation package over the junit4 annotation package.

