### PR TITLE
example: No longer need to explicitly mention test jar

### DIFF
--- a/examples/osgi-test-example-mvn/pom.xml
+++ b/examples/osgi-test-example-mvn/pom.xml
@@ -145,9 +145,6 @@
 								<bndruns>
 									<bndrun>test.bndrun</bndrun>
 								</bndruns>
-								<bundles>
-									<bundle>${project.build.directory}/${project.build.finalName}-tests.jar</bundle>
-								</bundles>
 								<failOnChanges>false</failOnChanges>
 								<includeDependencyManagement>true</includeDependencyManagement>
 								<reportOptional>false</reportOptional>
@@ -175,9 +172,6 @@
 								<bndruns>
 									<bndrun>test.bndrun</bndrun>
 								</bndruns>
-								<bundles>
-									<bundle>${project.build.directory}/${project.build.finalName}-tests.jar</bundle>
-								</bundles>
 								<failOnChanges>false</failOnChanges>
 								<includeDependencyManagement>true</includeDependencyManagement>
 								<resolve>false</resolve>


### PR DESCRIPTION
The Bnd maven plugins now include the attached artifacts, so we don't
need to be explicit.
