### PR TITLE
Add an example that could be used inside PDE

### DIFF
--- a/examples/osgi-test-example-pde/README.md
+++ b/examples/osgi-test-example-pde/README.md
@@ -1,0 +1,8 @@
+# osgi-test-example-pde
+An example project demonstrating OSGi testing capabilities using [Eclipse PDE](https://www.eclipse.org/pde/).
+
+To execute it do the following:
+
+- make sure you are using a recent Eclipse for RCP/RAP Developers edition (minimum 2022-03)
+- open the 'example.target' and set it as your active target
+- import the projects, right click on PlayerTest.java and choose `Run As` > `Junit Plugin Test`

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/.classpath
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/.project
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>example.api</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/META-INF/MANIFEST.MF
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: API
+Bundle-SymbolicName: org.osgi.test.example.api
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: org.osgi.test.example.api
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Export-Package: org.osgi.test.example.api;version="1.0.0"

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/build.properties
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/src/org/osgi/test/example/api/Ball.java
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/src/org/osgi/test/example/api/Ball.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.api;
+
+public interface Ball {
+
+	void inflate();
+
+	void kick();
+	
+}

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/src/org/osgi/test/example/api/Player.java
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.api/src/org/osgi/test/example/api/Player.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.api;
+
+public interface Player {
+
+	Ball getBall();
+
+	void kickBall();
+}

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/.classpath
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src_test"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/.project
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>example.player.impl</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,8 @@
+classpath=true
+dsVersion=V1_3
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/META-INF/MANIFEST.MF
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/META-INF/MANIFEST.MF
@@ -1,0 +1,20 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Player Impl
+Bundle-SymbolicName: org.osgi.test.example.player.impl
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: org.osgi.test.example.player.impl
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Import-Package: org.osgi.framework;version="1.10.0",
+ org.osgi.service.component.annotations;version="1.3.0",
+ org.osgi.test.example.api;version="[1.0.0,1.1.0)"
+Bundle-ActivationPolicy: lazy
+Require-Bundle: org.junit,
+ org.osgi.test.common;resolution:=optional,
+ assertj-core;resolution:=optional,
+ org.osgi.test.assertj.framework;resolution:=optional,
+ org.mockito.mockito-core;resolution:=optional,
+ org.osgi.test.junit5;bundle-version="1.1.0";resolution:=optional,
+ org.junit.jupiter.api;bundle-version="5.8.1";resolution:=optional
+Export-Package: org.osgi.test.example.player.test
+Service-Component: OSGI-INF/org.osgi.test.example.player.impl.PlayerImpl.xml

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/OSGI-INF/org.osgi.test.example.player.impl.PlayerImpl.xml
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/OSGI-INF/org.osgi.test.example.player.impl.PlayerImpl.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="org.osgi.test.example.player.impl.PlayerImpl">
+   <service>
+      <provide interface="org.osgi.test.example.api.Player"/>
+   </service>
+   <reference cardinality="1..1" field="ball" interface="org.osgi.test.example.api.Ball" name="ball"/>
+   <implementation class="org.osgi.test.example.player.impl.PlayerImpl"/>
+</scr:component>

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/build.properties
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/org.osgi.test.example.player.impl.PlayerImpl.xml

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/src/org/osgi/test/example/player/impl/PlayerImpl.java
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/src/org/osgi/test/example/player/impl/PlayerImpl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.player.impl;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.test.example.api.Ball;
+import org.osgi.test.example.api.Player;
+
+@Component
+public class PlayerImpl implements Player {
+
+	@Reference
+	Ball ball;
+
+	@Override
+	public void kickBall() {
+		ball.kick();
+	}
+
+	@Override
+	public Ball getBall() {
+		return ball;
+	}
+}

--- a/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/src_test/org/osgi/test/example/player/test/PlayerTest.java
+++ b/examples/osgi-test-example-pde/bundles/org.osgi.test.example.player.impl/src_test/org/osgi/test/example/player/test/PlayerTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.player.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Dictionary;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.BundleContext;
+import org.osgi.test.assertj.dictionary.DictionaryAssert;
+import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.dictionary.Dictionaries;
+import org.osgi.test.common.service.ServiceAware;
+import org.osgi.test.example.api.Ball;
+import org.osgi.test.example.api.Player;
+import org.osgi.test.junit5.context.BundleContextExtension;
+import org.osgi.test.junit5.service.ServiceExtension;
+
+@ExtendWith(BundleContextExtension.class)
+@ExtendWith(ServiceExtension.class)
+public class PlayerTest {
+
+	static Ball b;
+
+	@InjectBundleContext
+	BundleContext bc;
+
+	public PlayerTest() {
+		System.out.println();
+	}
+
+	@BeforeAll
+	static void beforeAll(@InjectBundleContext BundleContext staticBC) {
+		b = mock(Ball.class);
+		Dictionary<String, Object> props = Dictionaries.dictionaryOf("test", "testball");
+		staticBC.registerService(Ball.class, b, props);
+
+	}
+
+	@InjectService
+	Player p;
+
+	@Test
+	void myTest() {
+		assertThat(p).isNotNull();
+		assertThat(p.getBall()).isSameAs(b);
+		verifyNoInteractions(b);
+		p.kickBall();
+		verify(b).kick();
+	}
+
+	static class DummyBall implements Ball {
+
+		@Override
+		public void inflate() {
+		}
+
+		@Override
+		public void kick() {
+		}
+	}
+
+	@Test
+	void myServiceAwareTest(@InjectService(cardinality = 0) ServiceAware<Ball> ball) {
+		assertThat(ball.getServices()).hasSize(1);
+		DictionaryAssert.assertThat(ball.getServiceReference().getProperties()).containsEntry("test", "testball");
+		bc.registerService(Ball.class, new DummyBall(), null);
+		assertThat(ball.getServices()).hasSize(2);
+		bc.registerService(Ball.class, new DummyBall(), null);
+		assertThat(ball.getServices()).hasSize(3);
+	}
+
+	@Nested
+	@TestInstance(Lifecycle.PER_CLASS)
+	class TwoBalls {
+		Ball b2;
+
+		@BeforeAll
+		void beforeAll(@InjectBundleContext BundleContext bc) {
+			b2 = mock(Ball.class);
+			bc.registerService(Ball.class, b2, null);
+		}
+
+		@Test
+		void twoBallTest(@InjectService(cardinality = 2) List<Ball> services) {
+			assertThat(services).containsExactlyInAnyOrder(b, b2);
+		}
+	}
+
+	// This test should fail - proves that the second ball registered
+	// in the nested test gets cleaned up.
+//	@Test
+//	void myDoubleTest(@InjectService(cardinality = 2) List<Ball> balls) {
+//	}
+}

--- a/examples/osgi-test-example-pde/example.target
+++ b/examples/osgi-test-example-pde/example.target
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="example">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2022-03/"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+		</location>
+		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="ignore" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-core</artifactId>
+					<version>3.8.0</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+		<location includeDependencyDepth="infinite" includeDependencyScopes="compile,test" includeSource="true" label="osgi-test" missingManifest="error" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.test.assertj.framework</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.test.assertj.log</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.test.assertj.promise</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.test.common</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.test.junit5.cm</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.test.junit5.listeners.log.osgi</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.test.junit5</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+	</locations>
+</target>


### PR DESCRIPTION
This is an example where one can run osgi-test from inside [Eclipse PDE](https://www.eclipse.org/pde/)

To execute it do the following:

- make sure you are using a recent Eclipse for RCP/RAP Developers edition (minimum 2022-03)
- open the 'example.target' and set it as your active target
- import the projects, right click on PlayerTest.java and choose `Run As` > `Junit Plugin Test`