### PR TITLE
build: Move flatten config out of execution

### DIFF
--- a/examples/osgi-test-example-mvn/pom.xml
+++ b/examples/osgi-test-example-mvn/pom.xml
@@ -269,6 +269,9 @@
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>flatten-maven-plugin</artifactId>
 					<version>1.2.7</version>
+					<configuration>
+						<flattenMode>oss</flattenMode>
+					</configuration>
 					<executions>
 						<execution>
 							<id>flatten</id>
@@ -276,9 +279,6 @@
 							<goals>
 								<goal>flatten</goal>
 							</goals>
-							<configuration>
-								<flattenMode>oss</flattenMode>
-							</configuration>
 						</execution>
 						<execution>
 							<id>flatten-clean</id>

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,9 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>flatten-maven-plugin</artifactId>
 					<version>1.2.7</version>
+					<configuration>
+						<flattenMode>oss</flattenMode>
+					</configuration>
 					<executions>
 						<execution>
 							<id>flatten</id>
@@ -350,9 +353,6 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 							<goals>
 								<goal>flatten</goal>
 							</goals>
-							<configuration>
-								<flattenMode>oss</flattenMode>
-							</configuration>
 						</execution>
 						<execution>
 							<id>flatten-clean</id>


### PR DESCRIPTION
This caused issues with install/deploy the unflattened pom. So
the bom for 1.2.0 is unusable.

