### PR TITLE
Junit5 Extension to start an OSGi-Connect-Framework as part of the test

### DIFF
--- a/examples/osgi-test-example-mvn-connect/README.md
+++ b/examples/osgi-test-example-mvn-connect/README.md
@@ -1,0 +1,3 @@
+# osgi-test-example-mvn-connect
+An example project demonstrating OSGi testing capabilities using osgi/osgi-test support libraries in a maven environment 
+with an embedded Framework.

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.api/pom.xml
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.api/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) Contributors to the Eclipse Foundation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache-2.0
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.osgi.test.example</groupId>
+		<artifactId>org.osgi.test.example.connect.parent</artifactId>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.osgi.test.example.api</artifactId>
+	<description>OSGi Testing Example API</description>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<url>https://www.osgi.org</url>
+	<scm>
+		<url>https://github.com/rotty3000/osgi-test-example-mvn</url>
+		<connection>scm:git:https://github.com/rotty3000/osgi-test-example-mvn.git</connection>
+		<developerConnection>scm:git:git@github.com:rotty3000/osgi-test-example-mvn.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-baseline-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>baseline</id>
+						<goals>
+							<goal>baseline</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/Ball.java
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/Ball.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.api;
+
+public interface Ball {
+
+	void inflate();
+
+	void kick();
+	
+}

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/Player.java
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/Player.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.api;
+
+public interface Player {
+
+	Ball getBall();
+
+	void kickBall();
+}

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/package-info.java
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.api/src/main/java/org/osgi/test/example/api/package-info.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package org.osgi.test.example.api;

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/pom.xml
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) Contributors to the Eclipse Foundation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache-2.0
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.osgi.test.example</groupId>
+		<artifactId>org.osgi.test.example.connect.parent</artifactId>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.osgi.test.example.player.impl</artifactId>
+	<description>OSGi Testing Example Player Implementation</description>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<url>https://www.osgi.org</url>
+	<scm>
+		<url>https://github.com/rotty3000/osgi-test-example-mvn</url>
+		<connection>scm:git:https://github.com/rotty3000/osgi-test-example-mvn.git</connection>
+		<developerConnection>scm:git:git@github.com:rotty3000/osgi-test-example-mvn.git</developerConnection>
+	</scm>
+	<properties>
+		<equinoxVersion>3.18.0</equinoxVersion>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.service.component.annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi.test.example</groupId>
+			<artifactId>org.osgi.test.example.api</artifactId>
+			<version>${revision}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.osgi</groupId>
+		    <artifactId>org.osgi.framework</artifactId>
+		    <version>1.10.0</version>
+		    <scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.scr</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.test.junit5</artifactId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.test.assertj.framework</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.osgi</artifactId>
+			<version>${equinoxVersion}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/src/main/java/org/osgi/test/example/player/impl/PlayerImpl.java
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/src/main/java/org/osgi/test/example/player/impl/PlayerImpl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.player.impl;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.test.example.api.Ball;
+import org.osgi.test.example.api.Player;
+
+@Component
+public class PlayerImpl implements Player {
+
+	@Reference
+	Ball ball;
+
+	@Override
+	public void kickBall() {
+		ball.kick();
+	}
+
+	@Override
+	public Ball getBall() {
+		return ball;
+	}
+}

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/src/main/java/org/osgi/test/example/player/impl/package-info.java
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/src/main/java/org/osgi/test/example/player/impl/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.player.impl;

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/src/test/java/org/osgi/test/example/player/impl/OpenBoxTest.java
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/src/test/java/org/osgi/test/example/player/impl/OpenBoxTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.player.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.osgi.test.example.api.Ball;
+
+public class OpenBoxTest {
+
+	@Test
+	void myTest() {
+		PlayerImpl p = new PlayerImpl();
+		p.ball = mock(Ball.class);
+		assertThat(p.getBall()).isNotNull();
+		verifyNoInteractions(p.getBall());
+		p.kickBall();
+		verify(p.getBall()).kick();
+	}
+
+}

--- a/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/src/test/java/org/osgi/test/example/player/impl/PlayerTest.java
+++ b/examples/osgi-test-example-mvn-connect/org.osgi.test.example.player.impl/src/test/java/org/osgi/test/example/player/impl/PlayerTest.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.example.player.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Dictionary;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.osgi.framework.BundleContext;
+import org.osgi.test.assertj.dictionary.DictionaryAssert;
+import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.dictionary.Dictionaries;
+import org.osgi.test.common.service.ServiceAware;
+import org.osgi.test.example.api.Ball;
+import org.osgi.test.example.api.Player;
+import org.osgi.test.junit5.context.BundleContextExtension;
+import org.osgi.test.junit5.framework.FrameworkExtension;
+import org.osgi.test.junit5.service.ServiceExtension;
+
+@ExtendWith(BundleContextExtension.class)
+@ExtendWith(ServiceExtension.class)
+public class PlayerTest {
+
+	@RegisterExtension
+	static FrameworkExtension	framework	= FrameworkExtension.builder()
+		.withServiceComponentRuntime()
+		.withBundle("org.osgi.test.example.api")
+		.withBundle("org.osgi.test.example.player.impl", true)
+		.build();
+
+	static Ball b;
+
+	@InjectBundleContext
+	BundleContext bc;
+
+	@BeforeAll
+	static void beforeAll(@InjectBundleContext BundleContext staticBC) {
+		framework.printBundles(System.out::println);
+		b = mock(Ball.class);
+		Dictionary<String, Object> props = Dictionaries.dictionaryOf("test", "testball");
+		staticBC.registerService(Ball.class, b, props);
+		framework.printComponents(System.out::println);
+	}
+
+	@InjectService
+	Player p;
+
+	@Test
+	void myTest() {
+		assertThat(p).isNotNull();
+		assertThat(p.getBall()).isSameAs(b);
+		verifyNoInteractions(b);
+		p.kickBall();
+		verify(b).kick();
+	}
+
+	static class DummyBall implements Ball {
+
+		@Override
+		public void inflate() {
+		}
+
+		@Override
+		public void kick() {
+		}
+	}
+
+	@Test
+	void myServiceAwareTest(@InjectService(cardinality = 0) ServiceAware<Ball> ball) {
+		assertThat(ball.getServices()).hasSize(1);
+		DictionaryAssert.assertThat(ball.getServiceReference()
+			.getProperties())
+			.containsEntry("test", "testball");
+		bc.registerService(Ball.class, new DummyBall(), null);
+		assertThat(ball.getServices()).hasSize(2);
+		bc.registerService(Ball.class, new DummyBall(), null);
+		assertThat(ball.getServices()).hasSize(3);
+	}
+
+	@Nested
+	@TestInstance(Lifecycle.PER_CLASS)
+	class TwoBalls {
+		Ball b2;
+
+		@BeforeAll
+		void beforeAll(@InjectBundleContext BundleContext bc) {
+			b2 = mock(Ball.class);
+			bc.registerService(Ball.class, b2, null);
+		}
+
+		@Test
+		void twoBallTest(@InjectService(cardinality = 2) List<Ball> services) {
+			assertThat(services)
+				.containsExactlyInAnyOrder(b, b2);
+		}
+	}
+
+}

--- a/examples/osgi-test-example-mvn-connect/pom.xml
+++ b/examples/osgi-test-example-mvn-connect/pom.xml
@@ -1,35 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) Contributors to the Eclipse Foundation
+	Copyright (c) Contributors to the Eclipse Foundation
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 
-    SPDX-License-Identifier: Apache-2.0
- -->
+	SPDX-License-Identifier: Apache-2.0
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.osgi</groupId>
-	<artifactId>org.osgi.test.parent</artifactId>
-	<description>OSGi Testing Support Parent</description>
+	<groupId>org.osgi.test.example</groupId>
+	<artifactId>org.osgi.test.example.connect.parent</artifactId>
+	<description>OSGi Testing Example Parent</description>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>pom</packaging>
 	<version>${revision}</version>
 
 	<properties>
-		<revision>1.2.0-SNAPSHOT</revision>
+		<revision>0.1.0-SNAPSHOT</revision>
 		<project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
@@ -37,42 +38,21 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<bnd.version>6.2.0</bnd.version>
-		<junit-jupiter.compile.version>5.6.0</junit-jupiter.compile.version>
-		<junit-platform.compile.version>1.6.0</junit-platform.compile.version>
 		<junit-jupiter.version>5.8.2</junit-jupiter.version>
-		<junit-platform.version>1.8.2</junit-platform.version>
 		<assertj.version>3.22.0</assertj.version>
 		<mockito.version>4.4.0</mockito.version>
-		<awaitility.version>4.2.0</awaitility.version>
-		<osgi.annotation.version>8.1.0</osgi.annotation.version>
-		<osgi.dto.version>1.0.0</osgi.dto.version>
-		<osgi.resource.version>1.0.0</osgi.resource.version>
-		<osgi.framework.version>1.10.0</osgi.framework.version>
-		<osgi.tracker.version>1.5.4</osgi.tracker.version>
-		<osgi.log.version>1.4.0</osgi.log.version>
-		<osgi.cm.version>1.6.1</osgi.cm.version>
-		<osgi.function.compile.version>1.0.0</osgi.function.compile.version>
-		<osgi.promise.compile.version>1.0.0</osgi.promise.compile.version>
-		<osgi.function.version>1.2.0</osgi.function.version>
-		<osgi.promise.version>1.2.0</osgi.promise.version>
+		<osgi-test.version>1.1.0</osgi-test.version>
 	</properties>
 
 	<modules>
-		<module>org.osgi.test.common</module>
-		<module>org.osgi.test.assertj.framework</module>
-		<module>org.osgi.test.assertj.log</module>
-		<module>org.osgi.test.assertj.promise</module>
-		<module>org.osgi.test.junit4</module>
-		<module>org.osgi.test.junit5</module>
-		<module>org.osgi.test.junit5.cm</module>
-		<module>org.osgi.test.junit5.listeners.log.osgi</module>
-		<module>org.osgi.test.bom</module>
+		<module>org.osgi.test.example.api</module>
+		<module>org.osgi.test.example.player.impl</module>
 	</modules>
 
 	<url>https://www.osgi.org</url>
 	<organization>
-		<name>Eclipse Foundation</name>
-		<url>https://www.eclipse.org</url>
+		<name>OSGi Working Group</name>
+		<url>https://www.osgi.org</url>
 	</organization>
 	<licenses>
 		<license>
@@ -86,7 +66,6 @@
 		<url>https://github.com/osgi/osgi-test</url>
 		<connection>scm:git:https://github.com/osgi/osgi-test.git</connection>
 		<developerConnection>scm:git:git@github.com:osgi/osgi-test.git</developerConnection>
-		<tag>${revision}</tag>
 	</scm>
 	<developers>
 		<developer>
@@ -122,15 +101,8 @@
 	</developers>
 	<issueManagement>
 		<system>GitHub Issues</system>
-		<url>https://github.com/osgi/osgi-test/issues</url>
+		<url>https://github.com/osgi/osgi-test</url>
 	</issueManagement>
-	<mailingLists>
-		<mailingList>
-			<name>OSGi Users List</name>
-			<post>osgi-users@eclipse.org</post>
-			<archive>http://www.eclipse.org/lists/osgi-users</archive>
-		</mailingList>
-	</mailingLists>
 
 	<build>
 		<pluginManagement>
@@ -148,82 +120,10 @@
 							</goals>
 							<configuration>
 								<bnd><![CDATA[
-SPDX-License-Identifier: ${project.licenses[0].name}
--includeresource.legal:\
- "META-INF/=${project.parent.basedir}/LICENSE",\
- "META-INF/=${project.parent.basedir}/NOTICE"
-]]></bnd>
-							</configuration>
-						</execution>
-						<!-- Integration Test Configuration -->
-						<execution>
-							<id>test-jar</id>
-							<goals>
-								<goal>test-jar</goal>
-							</goals>
-							<configuration>
-								<artifactFragment>false</artifactFragment>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>biz.aQute.bnd</groupId>
-					<artifactId>bnd-resolver-maven-plugin</artifactId>
-					<version>${bnd.version}</version>
-					<executions>
-						<!-- Integration Test Configuration -->
-						<execution>
-							<id>resolve-test</id>
-							<phase>pre-integration-test</phase>
-							<goals>
-								<goal>resolve</goal>
-							</goals>
-							<configuration>
-								<bndruns>
-									<include>test*.bndrun</include>
-								</bndruns>
-								<bundles>
-									<bundle>${project.build.directory}/${project.build.finalName}-tests.jar</bundle>
-								</bundles>
-								<failOnChanges>false</failOnChanges>
-								<includeDependencyManagement>true</includeDependencyManagement>
-								<reportOptional>false</reportOptional>
-								<scopes>
-									<scope>compile</scope>
-									<scope>runtime</scope>
-									<scope>test</scope>
-								</scopes>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>biz.aQute.bnd</groupId>
-					<artifactId>bnd-testing-maven-plugin</artifactId>
-					<version>${bnd.version}</version>
-					<executions>
-						<!-- OSGi integration tests execution -->
-						<execution>
-							<id>testing</id>
-							<goals>
-								<goal>testing</goal>
-							</goals>
-							<configuration>
-								<bndruns>
-									<include>test*.bndrun</include>
-								</bndruns>
-								<bundles>
-									<bundle>${project.build.directory}/${project.build.finalName}-tests.jar</bundle>
-								</bundles>
-								<failOnChanges>false</failOnChanges>
-								<includeDependencyManagement>true</includeDependencyManagement>
-								<resolve>false</resolve>
-								<scopes>
-									<scope>compile</scope>
-									<scope>runtime</scope>
-									<scope>test</scope>
-								</scopes>
+								-noextraheaders: true
+								-noimportjava: true
+								-fixupmessages: The JAR is empty:
+								]]></bnd>
 							</configuration>
 						</execution>
 					</executions>
@@ -270,10 +170,6 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.22.2</version>
-					<!-- We let bnd-testing-maven-plugin do all the testing -->
-					<configuration>
-						<skipTests>true</skipTests>
-					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -310,33 +206,7 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 					<configuration>
 						<detectJavaApiLink>false</detectJavaApiLink>
 						<doclint>none</doclint>
-						<links>
-							<link>https://docs.osgi.org/javadoc/osgi.annotation/${osgi.annotation.version}</link>
-						</links>
-						<additionalJOptions>
-							<additionalJOption>-J-Dhttp.agent=maven-javadoc-plugin</additionalJOption>
-						</additionalJOptions>
 					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-gpg-plugin</artifactId>
-					<version>3.0.1</version>
-					<executions>
-						<execution>
-							<id>sign-artifacts</id>
-							<phase>verify</phase>
-							<goals>
-								<goal>sign</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.sonatype.plugins</groupId>
-					<artifactId>nexus-staging-maven-plugin</artifactId>
-					<version>1.6.12</version>
-					<extensions>true</extensions>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -413,26 +283,7 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<execute>
-											<runOnConfiguration>true</runOnConfiguration>
-											<runOnIncremental>true</runOnIncremental>
-										</execute>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>biz.aQute.bnd</groupId>
-										<artifactId>bnd-baseline-maven-plugin</artifactId>
-										<versionRange>[1,)</versionRange>
-										<goals>
-											<goal>baseline</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<execute>
-											<runOnConfiguration>true</runOnConfiguration>
-											<runOnIncremental>true</runOnIncremental>
-										</execute>
+										<ignore></ignore>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>
@@ -445,55 +296,6 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 			<plugin>
 				<groupId>biz.aQute.bnd</groupId>
 				<artifactId>bnd-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>biz.aQute.bnd</groupId>
-				<artifactId>bnd-resolver-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>resolve-test</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>resolve</goal>
-						</goals>
-						<inherited>false</inherited>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>biz.aQute.bnd</groupId>
-				<artifactId>bnd-testing-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>testing</id>
-						<goals>
-							<goal>testing</goal>
-						</goals>
-						<inherited>false</inherited>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>biz.aQute.bnd</groupId>
-				<artifactId>bnd-baseline-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>baseline</id>
-						<goals>
-							<goal>baseline</goal>
-						</goals>
-						<inherited>false</inherited>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -527,44 +329,14 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>osgi.annotation</artifactId>
-				<version>${osgi.annotation.version}</version>
+				<version>8.1.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
-				<artifactId>org.osgi.service.log</artifactId>
-				<version>${osgi.log.version}</version>
+				<artifactId>osgi.core</artifactId>
+				<version>8.0.0</version>
 				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.osgi</groupId>
-				<artifactId>org.osgi.dto</artifactId>
-				<version>${osgi.dto.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.osgi</groupId>
-				<artifactId>org.osgi.resource</artifactId>
-				<version>${osgi.resource.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.osgi</groupId>
-				<artifactId>org.osgi.framework</artifactId>
-				<version>${osgi.framework.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.osgi</groupId>
-				<artifactId>org.osgi.util.tracker</artifactId>
-				<version>${osgi.tracker.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.osgi</groupId>
-				<artifactId>org.osgi.service.cm</artifactId>
-				<version>${osgi.cm.version}</version>
-				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
@@ -574,15 +346,21 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
+				<artifactId>org.osgi.service.component.annotations</artifactId>
+				<version>1.5.0</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.util.function</artifactId>
-				<version>${osgi.function.version}</version>
-				<scope>test</scope>
+				<version>1.2.0</version>
+				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.util.promise</artifactId>
-				<version>${osgi.promise.version}</version>
-				<scope>test</scope>
+				<version>1.2.0</version>
+				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>
@@ -591,58 +369,11 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.awaitility</groupId>
-				<artifactId>awaitility</artifactId>
-				<version>${awaitility.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-api</artifactId>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
 				<version>${junit-jupiter.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.platform</groupId>
-				<artifactId>junit-platform-commons</artifactId>
-				<version>${junit-platform.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-params</artifactId>
-				<version>${junit-jupiter.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-engine</artifactId>
-				<version>${junit-jupiter.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.vintage</groupId>
-				<artifactId>junit-vintage-engine</artifactId>
-				<version>${junit-jupiter.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.platform</groupId>
-				<artifactId>junit-platform-engine</artifactId>
-				<version>${junit-platform.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.platform</groupId>
-				<artifactId>junit-platform-launcher</artifactId>
-				<version>${junit-platform.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.platform</groupId>
-				<artifactId>junit-platform-testkit</artifactId>
-				<version>${junit-platform.version}</version>
-				<scope>test</scope>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>
@@ -657,6 +388,13 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>org.osgi.test.bom</artifactId>
+				<version>${osgi-test.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.eclipse.platform</groupId>
 				<artifactId>org.eclipse.osgi</artifactId>
 				<version>3.17.200</version>
@@ -664,8 +402,8 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 			</dependency>
 			<dependency>
 				<groupId>org.apache.felix</groupId>
-				<artifactId>org.apache.felix.configadmin</artifactId>
-				<version>1.9.22</version>
+				<artifactId>org.apache.felix.scr</artifactId>
+				<version>2.2.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -682,6 +420,13 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+		</dependency>
+	</dependencies>
 
 	<profiles>
 		<profile>
@@ -745,38 +490,6 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 					</plugin>
 				</plugins>
 			</build>
-		</profile>
-		<profile>
-			<id>ossrh</id>
-			<properties>
-				<skipTests>true</skipTests>
-				<maven.test.skip>true</maven.test.skip>
-				<bnd.baseline.skip>true</bnd.baseline.skip>
-				<bnd.resolve.skip>true</bnd.resolve.skip>
-				<jacoco.skip>true</jacoco.skip>
-			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-					</plugin>
-					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-			<distributionManagement>
-				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-				</snapshotRepository>
-			</distributionManagement>
 		</profile>
 	</profiles>
 

--- a/org.osgi.test.junit5/.settings/org.eclipse.core.resources.prefs
+++ b/org.osgi.test.junit5/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,5 @@
 eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
 encoding//src/test/java=UTF-8
 encoding/<project>=UTF-8

--- a/org.osgi.test.junit5/README.md
+++ b/org.osgi.test.junit5/README.md
@@ -2,6 +2,107 @@
 
 This artifact provides support classes for OSGi testing with [JUnit 5](https://junit.org/junit5/) including JUnit 5 Extensions.
 
+## Setup an embedded Testframework with `FrameworkExtension`
+
+`org.osgi.test` itself assumes running inside an OSGI Framework and you can setup one 
+using [BND](https://github.com/bndtools/bnd), [Tycho](https://github.com/eclipse/tycho/), [Pax Exam](https://github.com/ops4j/org.ops4j.pax.exam2) or other techniques but this often requires carefull setup 
+and often mean all your tests run in the same setup or you spread them over different 
+test-artifacts.
+
+With the `FrameworkExtension` it is possible to start a so called [Connect-Framework](http://docs.osgi.org/specification/osgi.core/8.0.0/framework.connect.html) 
+that is directly feed from the classpath of your test, this makes it suitable for test-cases 
+where you have a small set of bundles (even though the number is not limited in any 
+way), want to run different configurations or run directly from your current module 
+(e.g. the usual maven setup where the test-code is next to your code and executed by 
+maven-surefire as part of that build).
+
+First you need to consider some things:
+
+- you are responsible for setting up what makes your Framework, the good news is that 
+you often do not need setup all bundles, just those required for your test
+- all bundles must be on the classpath of your test, either as a jar or as a folder
+- even though your test will see a full Framework and thus can register services, use 
+declarative services and so on, all bundles share the same classloader. This has advantages 
+(e.g. your test can easily interact with all code in the framework) but also limit 
+the usage of some OSGi feature, e.g. you can't use the same bundle in different versions
+- because of this, lazy activation of bundles do not work and they will always be activated 
+beforehands
+
+### Configure the framework
+
+The framework is confugured using a builder, lets assume you only need your test and 
+will setup everything else using `org.osgi.test` (e.g. installing other bundles, register 
+services, see below) then you can use this and you are done.
+
+```java
+@RegisterExtension
+static FrameworkExtension framework = FrameworkExtension.builder()
+		.build();
+```
+
+### adding a bundle from the classpath
+
+Often one wants additional stuff, so you can load it from the classpath of your test 
+(e.g. adding it as a maven dependency):
+
+```java
+static FrameworkExtension framework = FrameworkExtension.builder()
+		.withBundle("org.xerial.sqlite-jdbc")
+		.build();
+```
+
+you simply pass the bundle name of the bundle and you are done.
+
+If you like, you can even mark your bundle as beeing started:
+```java
+static FrameworkExtension framework = FrameworkExtension.builder()
+		.withBundle("org.xerial.sqlite-jdbc", true)
+		.build();
+```
+
+### Inspect the state of the framework
+
+The extension provides some usefull methods to give you insights into the state
+of your framework:
+
+- `framework.printBundles(System.out::println)` will print an overview of all installed 
+bundles and their state
+- `framework.printServices(System.out::println)` will print an overview of all installed 
+services
+- `framework.printComponents(System.out::println)` will print an overview of all declarative 
+  services components and their state
+- `framework.printFrameworkState(System.out::println)` will print bundes, services 
+and components
+-  `framework.getFrameworkEvents` return the `FrameworkEvents` for this framework that 
+could be used to inspect any `FrameworkEvent`s that occuring while starting or running 
+the embedded framework.
+
+### Export additional packages
+
+In most cases your bundles under test will require additional packages (e.g. from APIs) 
+and you can of course simply provide the API bundle as well to fullfill this requirements:
+
+```java
+static FrameworkExtension framework = FrameworkExtension.builder()
+		.withBundle("org.xerial.sqlite-jdbc", true)
+		.withBundle("org.osgi.service.jdbc")
+		.build();
+```
+depending how good you shape your system (and how good shaped the libraries are you 
+are using), this can become a headache as those bundles might require additional packages 
+or capabilities.
+As an alternative you can export arbitrary packages from your test-probe, this could 
+also be used to make some things aviable from within your test-probe even though it 
+is not a bundle at all:
+
+```java
+static FrameworkExtension framework = FrameworkExtension.builder()
+		.withBundle("org.xerial.sqlite-jdbc", true)
+		.exportPackage("org.osgi.service.jdbc", "1.0.0")
+		.build();
+```
+ 
+
 ## Testing with `BundleContext`
 
 There are a number of operations that can be performed with or on the OSGi `BundleContext`. However, this is a 

--- a/org.osgi.test.junit5/pom.xml
+++ b/org.osgi.test.junit5/pom.xml
@@ -45,6 +45,12 @@
 			<artifactId>osgi.annotation</artifactId>
 		</dependency>
 		<dependency>
+		    <groupId>org.osgi</groupId>
+		    <artifactId>org.osgi.service.component</artifactId>
+		    <version>1.5.0</version>
+		    <scope>compile</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.test.common</artifactId>
 			<version>${revision}</version>

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/FileConnectEntry.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/FileConnectEntry.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.osgi.framework.connect.ConnectContent.ConnectEntry;
+
+class FileConnectEntry implements ConnectEntry {
+
+	private File file;
+
+	FileConnectEntry(File file) {
+		this.file = file;
+	}
+
+	@Override
+	public String getName() {
+		return file.getName();
+	}
+
+	@Override
+	public long getContentLength() {
+		return file.length();
+	}
+
+	@Override
+	public long getLastModified() {
+		return file.lastModified();
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return new FileInputStream(file);
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/FrameworkEvents.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/FrameworkEvents.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+
+/**
+ * This class can be used as a way to listen to framework events and inspect
+ * them later.
+ */
+public class FrameworkEvents implements FrameworkListener {
+
+	private Map<FrameworkEvent, Long>	timeStamps	= new ConcurrentHashMap<>();
+	private Set<FrameworkEvent> events = ConcurrentHashMap.newKeySet();
+
+	@Override
+	public void frameworkEvent(FrameworkEvent event) {
+
+		if (events.add(event)) {
+			timeStamps.put(event, System.currentTimeMillis());
+		}
+	}
+
+	/**
+	 * clear all recorded events
+	 */
+	public void clear() {
+		events.clear();
+	}
+
+	/**
+	 * @return a stream of events in the order they where recorded
+	 */
+	public Stream<FrameworkEvent> events() {
+		return events.stream()
+			.sorted(Comparator.comparingLong(event -> timeStamps.getOrDefault(event, Long.MAX_VALUE / 2)));
+	}
+
+	/**
+	 * @return a stream of events in the order they where recorded and of the
+	 *         given type
+	 */
+	public Stream<FrameworkEvent> events(int type) {
+		return events().filter(event -> event.getType() == type);
+	}
+
+	/**
+	 * asserts that the current recorded events do not contain any error
+	 */
+	public void assertErrorsFree() {
+		events(FrameworkEvent.ERROR).findFirst()
+			.ifPresent(event -> {
+				throw new AssertionError(event.getBundle()
+					.getSymbolicName(), event.getThrowable());
+			});
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/FrameworkExtension.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/FrameworkExtension.java
@@ -1,0 +1,277 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.platform.commons.PreconditionViolationException;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentConfigurationDTO;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.service.component.runtime.dto.UnsatisfiedReferenceDTO;
+
+public class FrameworkExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+
+	private FrameworkExtensionBuilder	builder;
+	private JUnit5ConnectFramework		connect;
+
+	FrameworkExtension(FrameworkExtensionBuilder builder) {
+		this.builder = builder;
+	}
+
+	public static FrameworkExtensionBuilder builder() {
+		return new FrameworkExtensionBuilder();
+	}
+
+	public static final class FrameworkExtensionBuilder {
+
+		FrameworkExtensionBuilder() {}
+
+		Set<String>	bundles			= new LinkedHashSet<>();
+		Set<String>	autostartBundle	= new HashSet<>();
+		Collection<String>	additionalPackages	= new ArrayList<>();
+
+		public FrameworkExtension build() {
+			return new FrameworkExtension(this);
+		}
+
+		public FrameworkExtensionBuilder withBundle(String bsn) {
+			return withBundle(bsn, false);
+		}
+
+		public FrameworkExtensionBuilder withBundle(String bsn, boolean start) {
+			bundles.add(bsn);
+			if (start) {
+				autostartBundle.add(bsn);
+			} else {
+				autostartBundle.remove(bsn);
+			}
+			return this;
+		}
+
+		public FrameworkExtensionBuilder exportPackage(String pkg) {
+			return exportPackage(pkg, null);
+		}
+
+		public FrameworkExtensionBuilder exportPackage(String pkg, String version) {
+			if (version == null || version.isEmpty()) {
+				additionalPackages.add(pkg);
+				return this;
+			}
+			// make sure this is a valid version
+			Version parsedVersion = Version.parseVersion(version);
+			if (parsedVersion.equals(Version.emptyVersion)) {
+				additionalPackages.add(pkg);
+				return this;
+			}
+			additionalPackages
+				.add(String.format("%s;%s=\"%s\"", pkg, Constants.VERSION_ATTRIBUTE, parsedVersion.toString()));
+			return this;
+		}
+
+		public FrameworkExtensionBuilder withServiceComponentRuntime() {
+			return withBundle("org.apache.felix.scr", true).withBundle("org.osgi.util.promise")
+				.withBundle("org.osgi.util.function");
+		}
+	}
+
+	@Override
+	public void beforeAll(ExtensionContext context) throws Exception {
+		this.connect = getConnectFramework(context);
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		JUnit5FrameworkUtilHelper.threadHelper.set(connect);
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		JUnit5FrameworkUtilHelper.threadHelper.set(null);
+	}
+
+	private JUnit5ConnectFramework getConnectFramework(ExtensionContext context) {
+		Namespace namespace = Namespace.create(FrameworkExtension.class, context.getUniqueId());
+		Store store = context.getStore(namespace);
+		return store.getOrComputeIfAbsent("JUnit5ConnectFramework", key -> {
+			try {
+				return new JUnit5ConnectFramework(context.getRequiredTestClass(), context.getUniqueId(), builder);
+			} catch (Exception e) {
+				throw new PreconditionViolationException("problem starting framework: " + e, e);
+			}
+		}, JUnit5ConnectFramework.class);
+	}
+
+	public FrameworkEvents getFrameworkEvents() {
+		return connect.frameworkEvents;
+	}
+
+	/**
+	 * Prints the current Framework bundles and their state to the given log
+	 * consumer
+	 *
+	 * @param log for each line, this consumer will receive a string
+	 */
+	public void printBundles(Consumer<String> log) {
+		Bundle[] bundles = connect.getBundles();
+		log.accept("============ Framework Bundles ==================");
+		Comparator<Bundle> bySymbolicName = Comparator.comparing(Bundle::getSymbolicName,
+			String.CASE_INSENSITIVE_ORDER);
+		Comparator<Bundle> byState = Comparator.comparingInt(Bundle::getState);
+		Arrays.stream(bundles)
+			.sorted(byState.thenComparing(bySymbolicName))
+			.forEachOrdered(bundle -> {
+				log.accept(toBundleState(bundle.getState()) + " | " + bundle.getSymbolicName() + " ("
+					+ bundle.getVersion() + ")");
+			});
+	}
+
+	/**
+	 * Prints the current Framework bundles, registered services and components
+	 * to the given log consumer
+	 *
+	 * @param log for each line, this consumer will receive a string
+	 */
+	public void printFrameworkState(Consumer<String> log) {
+		printBundles(log);
+		printComponents(log);
+		printServices(log);
+	}
+
+	/**
+	 * Prints the current Framework registered services to the given log
+	 * consumer
+	 *
+	 * @param log for each line, this consumer will receive a string
+	 */
+	public void printServices(Consumer<String> log) {
+		log.accept("============ Registered Services ==================");
+		Arrays.stream(connect.getBundles())
+			.map(bundle -> bundle.getRegisteredServices())
+			.filter(Objects::nonNull)
+			.flatMap(Arrays::stream)
+			.forEach(reference -> {
+				Object service = reference.getProperty(Constants.OBJECTCLASS);
+				if (service instanceof Object[]) {
+					Object[] objects = (Object[]) service;
+					if (objects.length == 1) {
+						service = objects[0];
+					} else {
+						service = Arrays.toString(objects);
+					}
+				}
+				log.accept(service + " registered by " + reference.getBundle()
+					.getSymbolicName() + " | " + reference.getProperties());
+			});
+	}
+
+	/**
+	 * Prints the current Framework bundles and their state to the given log
+	 * consumer
+	 *
+	 * @param log for each line, this consumer will receive a string
+	 */
+	public void printComponents(Consumer<String> log) {
+		BundleContext bc = connect.framework.getBundleContext();
+		ServiceReference<ServiceComponentRuntime> reference = bc.getServiceReference(ServiceComponentRuntime.class);
+		ServiceComponentRuntime componentRuntime;
+		if (reference != null) {
+			componentRuntime = bc.getService(reference);
+		} else {
+			componentRuntime = null;
+		}
+		if (componentRuntime != null) {
+			log.accept("============ Framework Components ==================");
+			Collection<ComponentDescriptionDTO> descriptionDTOs = componentRuntime.getComponentDescriptionDTOs();
+			Comparator<ComponentConfigurationDTO> byComponentName = Comparator.comparing(dto -> dto.description.name,
+				String.CASE_INSENSITIVE_ORDER);
+			Comparator<ComponentConfigurationDTO> byComponentState = Comparator.comparingInt(dto -> dto.state);
+			descriptionDTOs.stream()
+				.flatMap(dto -> componentRuntime.getComponentConfigurationDTOs(dto)
+					.stream())
+				.sorted(byComponentState.thenComparing(byComponentName))
+				.forEachOrdered(dto -> {
+					if (dto.state == ComponentConfigurationDTO.FAILED_ACTIVATION) {
+						log.accept(toComponentState(dto.state) + " | " + dto.description.name + " | " + dto.failure);
+					} else {
+						log.accept(toComponentState(dto.state) + " | " + dto.description.name);
+					}
+					for (int i = 0; i < dto.unsatisfiedReferences.length; i++) {
+						UnsatisfiedReferenceDTO ref = dto.unsatisfiedReferences[i];
+						log.accept("\t" + ref.name + " is missing");
+					}
+				});
+			bc.ungetService(reference);
+		} else {
+			log.accept("No service component runtime installed (or started) in this framework!");
+		}
+	}
+
+	private static String toComponentState(int state) {
+		switch (state) {
+			case ComponentConfigurationDTO.ACTIVE :
+				return "ACTIVE ";
+			case ComponentConfigurationDTO.FAILED_ACTIVATION :
+				return "FAILED ";
+			case ComponentConfigurationDTO.SATISFIED :
+				return "SATISFIED ";
+			case ComponentConfigurationDTO.UNSATISFIED_CONFIGURATION :
+			case ComponentConfigurationDTO.UNSATISFIED_REFERENCE :
+				return "UNSATISFIED";
+			default :
+				return String.valueOf(state);
+		}
+	}
+
+	private static String toBundleState(int state) {
+		switch (state) {
+			case Bundle.ACTIVE :
+				return "ACTIVE   ";
+			case Bundle.INSTALLED :
+				return "INSTALLED";
+			case Bundle.RESOLVED :
+				return "RESOLVED ";
+			case Bundle.STARTING :
+				return "STARTING ";
+			case Bundle.STOPPING :
+				return "STOPPING ";
+			default :
+				return String.valueOf(state);
+		}
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/JUnit5ConnectFramework.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/JUnit5ConnectFramework.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.platform.commons.PreconditionViolationException;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
+import org.osgi.framework.connect.ConnectFrameworkFactory;
+import org.osgi.framework.connect.FrameworkUtilHelper;
+import org.osgi.framework.launch.Framework;
+import org.osgi.test.junit5.framework.FrameworkExtension.FrameworkExtensionBuilder;
+
+class JUnit5ConnectFramework implements CloseableResource, FrameworkUtilHelper {
+
+	private static final String			FILE_SCHEME		= "file";
+	private static final String			JAR_SCHEME		= "jar";
+
+	final Framework						framework;
+	final FrameworkEvents				frameworkEvents	= new FrameworkEvents();
+	private Class<?>					testClass;
+
+	private final JUnit5ModuleConnector	connector		= new JUnit5ModuleConnector();
+
+	public JUnit5ConnectFramework(Class<?> testClass, String uniqueId, FrameworkExtensionBuilder builder)
+		throws IOException, BundleException {
+		this.testClass = testClass;
+		List<JUnit5Module> modules = new ArrayList<>();
+		ClassLoader classLoader = testClass.getClassLoader();
+		TestProbeModule probeModule = new TestProbeModule("test-probe-" + uniqueId, classLoader,
+			builder.additionalPackages);
+		modules.add(probeModule);
+		Enumeration<URL> resources = classLoader.getResources(JarFile.MANIFEST_NAME);
+		Set<String> missingBundles = new HashSet<>(builder.autostartBundle);
+		while (resources.hasMoreElements()) {
+			URL url = resources.nextElement();
+			JUnit5Module module = getModule(url, classLoader);
+			if (module != null && builder.bundles.contains(module.getName())) {
+				missingBundles.remove(module.getName());
+				modules.add(module);
+			}
+		}
+		if (!missingBundles.isEmpty()) {
+			throw new PreconditionViolationException(
+				"The follwoing bundles that where requested could not be found: " + missingBundles);
+		}
+		Map<String, String> p = new HashMap<>();
+		p.put("osgi.framework.useSystemProperties", "false");
+		p.put("osgi.parentClassloader", "fwk");
+		p.put(Constants.FRAMEWORK_STORAGE,
+			System.getProperty("java.io.tmpdir") + File.separator + "osgi-test-" + uniqueId);
+		p.put(Constants.FRAMEWORK_BEGINNING_STARTLEVEL, "6");
+		ServiceLoader<ConnectFrameworkFactory> sl = ServiceLoader.load(ConnectFrameworkFactory.class,
+			getClass().getClassLoader());
+		ConnectFrameworkFactory factory = sl.iterator()
+			.next();
+
+		framework = factory.newFramework(p, connector);
+		JUnit5FrameworkUtilHelper.additionalHelpers.add(this);
+		framework.init(frameworkEvents);
+		framework.getBundleContext()
+			.addFrameworkListener(frameworkEvents);
+		connector.install(modules, framework.getBundleContext());
+		JUnit5FrameworkUtilHelper.testProbeMap.put(testClass, connector.getBundle(probeModule));
+		framework.start();
+		for (JUnit5Module module : modules) {
+			if (builder.autostartBundle.contains(module.getName())) {
+				framework.getBundleContext()
+					.getBundle(module.getName())
+					.start();
+			}
+		}
+		framework.getBundleContext()
+			.getBundle(probeModule.getName())
+			.start();
+	}
+
+	Bundle[] getBundles() {
+		return framework.getBundleContext()
+			.getBundles();
+	}
+
+	@Override
+	public void close() throws Throwable {
+		framework.getBundleContext()
+			.removeFrameworkListener(frameworkEvents);
+		framework.stop();
+		framework.waitForStop(TimeUnit.SECONDS.toMillis(30));
+		JUnit5FrameworkUtilHelper.additionalHelpers.remove(this);
+		JUnit5FrameworkUtilHelper.testProbeMap.remove(testClass);
+	}
+
+	private static final JUnit5Module getModule(URL url, ClassLoader classLoader) {
+		try {
+			Manifest manifest;
+			try (InputStream stream = url.openStream()) {
+				manifest = new Manifest(stream);
+			}
+			Attributes attributes = manifest.getMainAttributes();
+			String value = attributes.getValue(Constants.BUNDLE_SYMBOLICNAME);
+			if (value != null) {
+				Map<String, String> headers = new LinkedHashMap<String, String>();
+				for (Entry<Object, Object> entry : attributes.entrySet()) {
+					headers.put(entry.getKey()
+						.toString(),
+						entry.getValue()
+							.toString());
+				}
+				return new JUnit5Module(value.split(";")[0].trim(), Collections.unmodifiableMap(headers), classLoader,
+					getFileLocation(url.toURI()));
+			}
+			return null;
+		} catch (IOException e) {
+			return null;
+		} catch (URISyntaxException e) {
+			return null;
+		}
+	}
+
+	private static File getFileLocation(URI uri) {
+		if (JAR_SCHEME.equalsIgnoreCase(uri.getScheme())) {
+			String remainingPart = uri.toASCIIString()
+				.substring(JAR_SCHEME.length() + 1)
+				.split("!")[0];
+			if (remainingPart.toLowerCase()
+				.startsWith(FILE_SCHEME + ":")) {
+				return getFileLocation(URI.create(remainingPart));
+			}
+		} else if (FILE_SCHEME.equalsIgnoreCase(uri.getScheme())) {
+			File file = new File(uri);
+			if (file.exists()) {
+				if (file.getName()
+					.equals("MANIFEST.MF")) {
+					return file.getParentFile()
+						.getParentFile();
+				}
+				return file;
+			}
+		}
+		return null;
+	}
+
+	private static File getFileLocation(URL url) {
+		if (url != null) {
+			try {
+				return getFileLocation(url.toURI());
+			} catch (URISyntaxException e) {}
+		}
+		return null;
+	}
+
+	@Override
+	public Optional<Bundle> getBundle(Class<?> classFromBundle) {
+		ClassLoader classLoader = classFromBundle.getClassLoader();
+		if (classLoader == null) {
+			return Optional.empty();
+		}
+		ProtectionDomain protectionDomain = classFromBundle.getProtectionDomain();
+		if (protectionDomain == null) {
+			return Optional.empty();
+		}
+		CodeSource codeSource = protectionDomain.getCodeSource();
+		if (codeSource == null) {
+			return Optional.empty();
+		}
+		File location = getFileLocation(codeSource.getLocation());
+		if (location == null) {
+			return Optional.empty();
+		}
+		return connector.getBundle(location);
+	}
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/JUnit5FrameworkUtilHelper.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/JUnit5FrameworkUtilHelper.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.connect.FrameworkUtilHelper;
+
+public class JUnit5FrameworkUtilHelper implements FrameworkUtilHelper {
+
+	static Map<Class<?>, Bundle>			testProbeMap		= new ConcurrentHashMap<>();
+	static Set<FrameworkUtilHelper>			additionalHelpers	= ConcurrentHashMap.newKeySet();
+	static ThreadLocal<FrameworkUtilHelper>	threadHelper		= new ThreadLocal<>();
+
+	@Override
+	public Optional<Bundle> getBundle(Class<?> classFromBundle) {
+		// for the test probe we always know the bundle
+		Bundle probeBundle = testProbeMap.get(classFromBundle);
+		if (probeBundle != null) {
+			return Optional.of(probeBundle);
+		}
+		// the check if we have a thread attached helper
+		FrameworkUtilHelper threadHelper = JUnit5FrameworkUtilHelper.threadHelper.get();
+		if (threadHelper != null) {
+			return threadHelper.getBundle(classFromBundle);
+		}
+		// last resort (might return false positives when using multiple
+		// frameworks that have overlapping classpathes!)
+		for (FrameworkUtilHelper helper : additionalHelpers) {
+			Optional<Bundle> bundle = helper.getBundle(classFromBundle);
+			if (bundle.isPresent()) {
+				return bundle;
+			}
+		}
+		return Optional.empty();
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/JUnit5Module.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/JUnit5Module.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+
+import org.osgi.framework.connect.ConnectContent;
+import org.osgi.framework.connect.ConnectModule;
+
+public class JUnit5Module implements ConnectContent, ConnectModule {
+
+	private Map<String, String>	headers;
+	private ClassLoader			classLoader;
+	private File				location;
+	private JarFile				jarFile;
+	private String				name;
+
+	public JUnit5Module(String name, Map<String, String> headers, ClassLoader classLoader, File location) {
+		this.name = name;
+		this.headers = headers;
+		this.classLoader = classLoader;
+		this.location = location;
+	}
+
+	@Override
+	public ConnectContent getContent() throws IOException {
+		return this;
+	}
+
+	@Override
+	public Optional<Map<String, String>> getHeaders() {
+		return Optional.of(headers);
+	}
+
+	@Override
+	public Iterable<String> getEntries() throws IOException {
+		if (jarFile != null) {
+			return jarFile.stream()
+				.map(JarEntry::getName)
+				.collect(Collectors.toList());
+		}
+		if (location != null && location.isDirectory()) {
+			Stream<String> stream = Files.walk(location.toPath())
+				.map(p -> p.toString());
+			List<String> collect = stream
+				.collect(Collectors.toList());
+			stream.close();
+			return collect;
+		}
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Optional<ConnectEntry> getEntry(String path) {
+		if (jarFile != null) {
+			final ZipEntry entry = jarFile.getEntry(path);
+			if (entry == null) {
+				return Optional.empty();
+			}
+			return Optional.of(new ZipConnectEntry(jarFile, entry));
+		}
+		if (location != null && location.isDirectory()) {
+			File file = new File(location, path);
+			if (file.isFile()) {
+				return Optional.of(new FileConnectEntry(file));
+			}
+		}
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<ClassLoader> getClassLoader() {
+		return Optional.of(classLoader);
+	}
+
+	@Override
+	public void open() throws IOException {
+		if (location != null && jarFile == null && location.isFile()) {
+			jarFile = new JarFile(location);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (jarFile != null) {
+			jarFile.close();
+		}
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public File getLocation() {
+		return location;
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/JUnit5ModuleConnector.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/JUnit5ModuleConnector.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.connect.ConnectModule;
+import org.osgi.framework.connect.ModuleConnector;
+
+class JUnit5ModuleConnector implements ModuleConnector {
+
+	private Map<String, JUnit5Module> moduleMap = new HashMap<>();
+	private Map<JUnit5Module, Bundle>	bundleMap	= new HashMap<>();
+
+	@Override
+	public void initialize(File storage, Map<String, String> configuration) {
+
+	}
+
+	@Override
+	public Optional<ConnectModule> connect(String location) throws BundleException {
+		return Optional.ofNullable(moduleMap.get(location));
+	}
+
+	@Override
+	public Optional<BundleActivator> newBundleActivator() {
+		return Optional.empty();
+	}
+
+	public void install(List<JUnit5Module> modules, BundleContext bundleContext) throws BundleException {
+		for (JUnit5Module module : modules) {
+			moduleMap.put(module.getName(), module);
+			bundleMap.put(module, bundleContext.installBundle(module.getName()));
+		}
+	}
+
+	Bundle getBundle(JUnit5Module module) {
+		return bundleMap.get(module);
+	}
+
+	public Optional<Bundle> getBundle(File location) {
+		return bundleMap.entrySet()
+			.stream()
+			.filter(entry -> location.equals(entry.getKey()
+				.getLocation()))
+			.findAny()
+			.map(entry -> entry.getValue());
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/TestProbeModule.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/TestProbeModule.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.osgi.framework.Constants;
+
+public class TestProbeModule extends JUnit5Module {
+
+	public TestProbeModule(String name, ClassLoader classLoader, Collection<String> additionalPackages) {
+		super(name, generateManifest(name, additionalPackages), classLoader, null);
+	}
+
+	private static Map<String, String> generateManifest(String name, Collection<String> additionalPackages) {
+		LinkedHashMap<String, String> headers = new LinkedHashMap<>();
+		headers.put("Manifest-Version", "1.0");
+		headers.put(Constants.BUNDLE_MANIFESTVERSION, "2");
+		headers.put(Constants.BUNDLE_SYMBOLICNAME, name);
+		headers.put(Constants.BUNDLE_VERSION, "1.0.0");
+		if (!additionalPackages.isEmpty()) {
+			headers.put(Constants.EXPORT_PACKAGE, additionalPackages.stream()
+				.collect(Collectors.joining(",")));
+		}
+		return headers;
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/ZipConnectEntry.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/framework/ZipConnectEntry.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.framework;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+import org.osgi.framework.connect.ConnectContent.ConnectEntry;
+
+final class ZipConnectEntry implements ConnectEntry {
+
+	private ZipEntry	entry;
+	private JarFile		jarFile;
+
+	public ZipConnectEntry(JarFile jarFile, ZipEntry entry) {
+		this.jarFile = jarFile;
+		this.entry = entry;
+	}
+
+	@Override
+	public String getName() {
+		return entry.getName();
+	}
+
+	@Override
+	public long getContentLength() {
+		return entry.getSize();
+	}
+
+	@Override
+	public long getLastModified() {
+		return entry.getTime();
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return jarFile.getInputStream(entry);
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/resources/META-INF/services/org.osgi.framework.connect.FrameworkUtilHelper
+++ b/org.osgi.test.junit5/src/main/resources/META-INF/services/org.osgi.framework.connect.FrameworkUtilHelper
@@ -1,0 +1,1 @@
+org.osgi.test.junit5.framework.JUnit5FrameworkUtilHelper

--- a/org.osgi.test.junit5/test.bndrun
+++ b/org.osgi.test.junit5/test.bndrun
@@ -40,7 +40,8 @@
 -runrequires: \
 	bnd.identity;id='${project.artifactId}-tests',\
 	bnd.identity;id='junit-jupiter-engine',\
-	bnd.identity;id='junit-platform-launcher'
+	bnd.identity;id='junit-platform-launcher',\
+	bnd.identity;id='org.osgi.service.component'
 # This will help us keep -runbundles sorted
 -runstartlevel: \
     order=sortbynameversion,\
@@ -59,7 +60,10 @@
 	org.mockito.mockito-core;version='[4.4.0,4.4.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.test.assertj.framework;version='[1.2.0,1.2.1)',\
 	org.osgi.test.common;version='[1.2.0,1.2.1)',\
 	org.osgi.test.junit5;version='[1.2.0,1.2.1)',\
-	org.osgi.test.junit5-tests;version='[1.2.0,1.2.1)'
+	org.osgi.test.junit5-tests;version='[1.2.0,1.2.1)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'


### PR DESCRIPTION
The current setup is rather complex and hard to understand for anyone not familiar with OSGi+BND tooling.

This adds a JUnit5 Extension on top of the OSGi Framework connect that drastically reduces the complexity but still enables usage of osgi-test in a unit test environment.

Fixes https://github.com/osgi/osgi-test/issues/541