### PR TITLE
junit5: Add cardinality element to ServiceSource

### DIFF
--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/InjectService.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/InjectService.java
@@ -77,7 +77,7 @@ public @interface InjectService {
 
 	/**
 	 * Indicate the number of services that are required to arrive within the
-	 * specified by {@link #timeout()} before starting the test.
+	 * specified {@link #timeout()} before starting the test.
 	 *
 	 * @return The cardinality.
 	 */

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceSource.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/ServiceSource.java
@@ -58,4 +58,14 @@ public @interface ServiceSource {
 	 * @return The timeout.
 	 */
 	long timeout() default DEFAULT_TIMEOUT;
+
+	/**
+	 * Indicate the number of services that are required to arrive within the
+	 * specified {@link #timeout()} before starting the test.
+	 * The default value is 1.
+	 *
+	 * @return The cardinality.
+	 * @since 1.2
+	 */
+	int cardinality() default 1;
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/package-info.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/service/package-info.java
@@ -17,5 +17,5 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.2.0")
 package org.osgi.test.junit5.service;


### PR DESCRIPTION
This allows the user to specify the desired cardinality (like InjectService). The default cardinality is now 1. It was previously 0 but that seems wrong.

If the cardinality is not met, a ParameterResolutionException is thrown with an error message.