### PR TITLE
Revert "build: Bump org.osgi.util.promise from 1.0.0 to 1.3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<osgi.log.version>1.4.0</osgi.log.version>
 		<osgi.cm.version>1.6.1</osgi.cm.version>
 		<osgi.function.compile.version>1.0.0</osgi.function.compile.version>
-		<osgi.promise.compile.version>1.3.0</osgi.promise.compile.version>
+		<osgi.promise.compile.version>1.0.0</osgi.promise.compile.version>
 		<osgi.function.version>1.2.0</osgi.function.version>
 		<osgi.promise.version>1.3.0</osgi.promise.version>
 	</properties>


### PR DESCRIPTION
Reverts osgi/osgi-test#630

The compile version must be low. We need to support 1.0 of the Promise API.