### PR TITLE
[junit5.cm] handle just configurations from annotations

### DIFF
--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandler.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandler.java
@@ -1,4 +1,5 @@
 /*******************************************************************************
+
  * Copyright (c) Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandlerImpl.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/BlockingConfigurationHandlerImpl.java
@@ -31,15 +31,18 @@ import org.osgi.service.cm.ConfigurationListener;
 
 public class BlockingConfigurationHandlerImpl implements ConfigurationListener, BlockingConfigurationHandler {
 
-
 	private Map<String, CountDownLatch>	updateMap	= new HashMap<String, CountDownLatch>();
 	private Map<String, CountDownLatch>	deleteMap	= new HashMap<String, CountDownLatch>();
 
 	@Override
 	public boolean update(Configuration configuration, Dictionary<String, Object> dictionary, long timeout)
 		throws InterruptedException, IOException {
+
 		CountDownLatch latch = createCountdownLatchUpdate(configuration.getPid());
-		configuration.update(dictionary);
+		boolean updatedBecauseDifferent = configuration.updateIfDifferent(dictionary);
+		if (!updatedBecauseDifferent) {
+			return true;
+		}
 		boolean isOk = latch.await(timeout, TimeUnit.MILLISECONDS);
 		return isOk;
 	}

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigCloseableResource.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigCloseableResource.java
@@ -1,0 +1,95 @@
+package org.osgi.test.junit5.cm;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+public class ConfigCloseableResource implements CloseableResource {
+	private ExtensionContext				extensionContext;
+	private BlockingConfigurationHandler	timeoutListener;
+	private List<ConfigurationHolder>		holders	= new ArrayList<ConfigurationHolder>();
+
+	public ConfigCloseableResource(ExtensionContext extensionContext, BlockingConfigurationHandler timeoutListener) {
+		this.extensionContext = extensionContext;
+		this.timeoutListener = timeoutListener;
+	}
+
+	@Override
+	public void close() throws Throwable {
+		ConfigurationAdmin ca = ConfigurationExtension.configurationAdmin(extensionContext);
+		holders.stream()
+			.forEach(holder -> {
+
+				if (holder == null) {
+					return;
+				}
+
+				if (holder.getConfiguration() == null) {
+					return;
+				}
+
+				ConfigurationCopy configuration = holder.getConfiguration();
+				Optional<ConfigurationCopy> configurationCopyBefore = holder.getBeforeConfiguration();
+
+				try {
+					if (configurationCopyBefore.isPresent()) {
+
+						ConfigurationCopy copy = configurationCopyBefore.get();
+						Configuration conf = null;
+						if (copy.getFactoryPid() != null) {
+							String name = copy.getPid()
+								.substring(copy.getFactoryPid()
+									.length() + 1);
+							conf = ca.getFactoryConfiguration(copy.getFactoryPid(), name, copy.getBundleLocation());
+						} else {
+							conf = ca.getConfiguration(copy.getPid(), copy.getBundleLocation());
+						}
+						timeoutListener.update(conf, copy.getProperties(), 3000);
+					} else {
+
+						String pid = configuration.getPid();
+
+						Configuration configurationToDelete = ConfigUtil.getConfigsByServicePid(ca, pid, 1000);
+						if (configurationToDelete != null) {
+							timeoutListener.delete(configurationToDelete, 3000);
+						}
+					}
+				} catch (IOException e) {
+					throw new UncheckedIOException(e);
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+			});
+	}
+
+	public void addAll(List<ConfigurationHolder> holders) {
+		holders.forEach(this::add);
+	}
+
+	public void add(ConfigurationHolder holder) {
+
+		// We may know the state of the Configuration.
+		ConfigurationCopy compateConfig = holder.getConfiguration();
+		Optional<ConfigurationHolder> preStoresConfig = holders.stream()
+			.filter(c -> {
+				return c.getConfiguration()
+					.getPid()
+					.endsWith(compateConfig.getPid());
+			})
+			.findAny();
+
+		// if we habe a state, we can ignore later ons
+		if (!preStoresConfig.isPresent()) {
+			holders.add(holder);
+		}
+
+	}
+
+}

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationHolder.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationHolder.java
@@ -1,0 +1,24 @@
+package org.osgi.test.junit5.cm;
+
+import java.util.Optional;
+
+public class ConfigurationHolder {
+
+	public ConfigurationHolder(ConfigurationCopy configuration, Optional<ConfigurationCopy> beforeConfiguration) {
+		super();
+		this.configuration = configuration;
+		this.beforeConfiguration = beforeConfiguration;
+	}
+
+	public ConfigurationCopy getConfiguration() {
+		return configuration;
+	}
+
+	public Optional<ConfigurationCopy> getBeforeConfiguration() {
+		return beforeConfiguration;
+	}
+
+	private ConfigurationCopy			configuration;
+	private Optional<ConfigurationCopy>	beforeConfiguration;
+
+}

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/package-info.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/package-info.java
@@ -17,7 +17,7 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.2.0")
 
 @org.osgi.service.cm.annotations.RequireConfigurationAdmin
 package org.osgi.test.junit5.cm;

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
@@ -39,8 +39,6 @@ public class ConfigAnnotationTest {
 	@InjectService
 	ConfigurationAdmin			ca;
 
-
-
 	// START TESTS
 	@InjectConfiguration(NONSTATIC_CONFIGURATION_PID)
 	Configuration nonStaticConfiguration;


### PR DESCRIPTION
Fix: handle just configurations from annotations

@timothyjward the pom structure has one version for all bundles. should we switch to independent bundleversions. defind in parent-poms properties?