### PR TITLE
Annotations with location NOT_SET should use null locations

### DIFF
--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationExtension.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationExtension.java
@@ -168,7 +168,7 @@ public class ConfigurationExtension extends InjectingExtension<InjectConfigurati
 
 			Configuration configuration;
 			if (Property.NOT_SET.equals(configAnnotation.location())) {
-				configuration = configurationAdmin.getConfiguration(configAnnotation.pid());
+				configuration = configurationAdmin.getConfiguration(configAnnotation.pid(), null);
 			} else {
 				configuration = configurationAdmin.getConfiguration(configAnnotation.pid(),
 					configAnnotation.location());
@@ -197,7 +197,7 @@ public class ConfigurationExtension extends InjectingExtension<InjectConfigurati
 			Configuration configuration;
 			if (Property.NOT_SET.equals(configAnnotation.location())) {
 				configuration = configurationAdmin.getFactoryConfiguration(configAnnotation.factoryPid(),
-					configAnnotation.name());
+					configAnnotation.name(), null);
 			} else {
 				configuration = configurationAdmin.getFactoryConfiguration(configAnnotation.factoryPid(),
 					configAnnotation.name(), configAnnotation.location());

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
@@ -19,6 +19,7 @@ package org.osgi.test.junit5.cm.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -151,4 +152,101 @@ public class ConfigAnnotationTest {
 
 	}
 
+	@Nested
+	class LocationTests {
+
+		private static final String TEST = "test";
+
+		@Test
+		@WithConfiguration(pid = PARAM_PID, properties = {
+			@Property(key = "bar", value = "foo")
+		})
+		public void testMethodLevelNoLocation(@InjectService
+		ConfigurationAdmin ca) throws Exception {
+
+			Configuration cs = ConfigUtil.getConfigsByServicePid(ca, PARAM_PID);
+			assertThat(cs).isNotNull();
+			assertThat(cs.getBundleLocation()).isNull();
+		}
+
+		@Test
+		public void testInjectedNoLocation(
+			@InjectConfiguration(withConfig = @WithConfiguration(pid = PARAM_PID, properties = {
+			@Property(key = "bar", value = "foo")
+		}))
+		Configuration cs) throws Exception {
+
+			assertThat(cs).isNotNull();
+			assertThat(cs.getBundleLocation()).isNull();
+		}
+
+		@Test
+		@WithConfiguration(pid = PARAM_PID, location = "?", properties = {
+			@Property(key = "bar", value = "foo")
+		})
+		public void testMethodLevelWithLocation(@InjectService
+		ConfigurationAdmin ca) throws Exception {
+
+			Configuration cs = ConfigUtil.getConfigsByServicePid(ca, PARAM_PID);
+			assertThat(cs).isNotNull();
+			assertThat(cs.getBundleLocation()).isEqualTo("?");
+		}
+
+		@Test
+		public void testInjectedWithLocation(
+			@InjectConfiguration(withConfig = @WithConfiguration(pid = PARAM_PID, location = "?", properties = {
+				@Property(key = "bar", value = "foo")
+			}))
+			Configuration cs) throws Exception {
+
+			assertThat(cs).isNotNull();
+			assertThat(cs.getBundleLocation()).isEqualTo("?");
+		}
+
+		@Test
+		@WithFactoryConfiguration(factoryPid = PARAM_PID, name = TEST, properties = {
+			@Property(key = "bar", value = "foo")
+		})
+		public void testMethodLevelFactoryNoLocation(@InjectService
+		ConfigurationAdmin ca) throws Exception {
+
+			Configuration cs = ConfigUtil.getConfigsByServicePid(ca, PARAM_PID + "~" + TEST);
+			assertThat(cs).isNotNull();
+			assertThat(cs.getBundleLocation()).isNull();
+		}
+
+		@Test
+		public void testInjectedFactoryNoLocation(
+			@InjectConfiguration(withFactoryConfig = @WithFactoryConfiguration(factoryPid = PARAM_PID, name = TEST, properties = {
+				@Property(key = "bar", value = "foo")
+			}))
+			Configuration cs) throws Exception {
+
+			assertThat(cs).isNotNull();
+			assertThat(cs.getBundleLocation()).isNull();
+		}
+
+		@Test
+		@WithFactoryConfiguration(factoryPid = PARAM_PID, name=TEST, location = "?", properties = {
+			@Property(key = "bar", value = "foo")
+		})
+		public void testMethodLevelFactoryWithLocation(@InjectService
+		ConfigurationAdmin ca) throws Exception {
+
+			Configuration cs = ConfigUtil.getConfigsByServicePid(ca, PARAM_PID + "~" + TEST);
+			assertThat(cs).isNotNull();
+			assertThat(cs.getBundleLocation()).isEqualTo("?");
+		}
+
+		@Test
+		public void testInjectedFactoryWithLocation(
+			@InjectConfiguration(withFactoryConfig = @WithFactoryConfiguration(factoryPid = PARAM_PID, name = TEST, location = "?", properties = {
+				@Property(key = "bar", value = "foo")
+			}))
+			Configuration cs) throws Exception {
+
+			assertThat(cs).isNotNull();
+			assertThat(cs.getBundleLocation()).isEqualTo("?");
+		}
+	}
 }


### PR DESCRIPTION
When processing annotations a NOT_SET location was resulting in the configuration location being set to the tester bundle - this is clearly incorrect and should explicitly unset as per the ConfigurationAdmin API.

Fixes #615