### PR TITLE
Revert "build: Bump ch.qos.logback:logback-classic from 1.3.4 to 1.4.14 in /examples/osgi-test-example-gradle"

### DIFF
--- a/examples/osgi-test-example-gradle/org.osgi.test.example.player.test/build.gradle
+++ b/examples/osgi-test-example-gradle/org.osgi.test.example.player.test/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	runtimeOnly(project(":org.osgi.test.example.player.impl"))
 	runtimeOnly("org.junit.platform:junit-platform-launcher")
 	runtimeOnly("org.apache.felix:org.apache.felix.scr:2.2.10")
-	runtimeOnly("ch.qos.logback:logback-classic:1.4.14")
+	runtimeOnly("ch.qos.logback:logback-classic:1.3.4")
 	runtimeOnly("org.apache.felix:org.apache.felix.logback:1.0.6")
 	runtimeOnly("org.eclipse.platform:org.eclipse.osgi:3.18.600")
 	runtimeOnly("org.osgi:org.osgi.service.component:1.5.1")


### PR DESCRIPTION
Reverts osgi/osgi-test#760

Logback 1.4 is for Jakarta EE and requires Java 11.