### PR TITLE
Add support for system properties in configuration annotations

### DIFF
--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
@@ -17,10 +17,13 @@
  *******************************************************************************/
 package org.osgi.test.common.annotation;
 
+import static org.osgi.test.common.annotation.Property.NOT_SET;
+
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.Properties;
 
 import org.osgi.test.common.annotation.Property.Scalar;
 import org.osgi.test.common.annotation.Property.Type;
@@ -39,9 +42,24 @@ public class PropertiesConverter {
 
 		boolean primitive = entry.type()
 			.equals(Type.PrimitiveArray);
-		Object result = createArray(entry.scalar(), primitive, entry.value().length);
+		String[] value;
+		if (NOT_SET.equals(entry.systemProperty())) {
+			value = entry.value();
+		} else {
+			Properties sysProps = System.getProperties();
+			if (sysProps.containsKey(entry.systemProperty())) {
+				String prop = sysProps.getProperty(entry.systemProperty());
+				value = entry.type() == Type.Scalar ? new String[] {
+					prop
+				} : prop.split(",");
+			} else {
+				value = entry.value();
+			}
+		}
+
+		Object result = createArray(entry.scalar(), primitive, value.length);
 		int i = 0;
-		for (String v : entry.value()) {
+		for (String v : value) {
 			Object val = null;
 
 			if (v != null) {

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
@@ -21,8 +21,8 @@ import java.util.Dictionary;
 
 /**
  * The generic PropertiesConverter is unable to support all forms of property
- * conversion and should not be used. Use the JUnit version specific alternative
- * instead.
+ * conversion and should not be used. Use the JUnit 4 specific
+ * {@link org.osgi.test.junit4.properties.PropertiesConverter} instead.
  */
 @Deprecated
 public class PropertiesConverter {

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -55,6 +55,26 @@ public @interface Property {
 		PrimitiveArray
 	}
 
+	public enum ValueSource {
+		/** Use the {@link Property#value()} directly */
+		Value,
+		/**
+		 * Use the first {@link Property#value()} as a key in the System
+		 * Properties
+		 */
+		SystemProperty,
+		/**
+		 * Use the first {@link Property#value()} as a key in the Environment
+		 */
+		EnvironmentVariable,
+		/** Use the name of the test class */
+		TestClass,
+		/** Use the name of the test method */
+		TestMethod,
+		/** Use the test unique identifier */
+		TestUniqueId
+	}
+
 	String key();
 
 	String[] value() default "";
@@ -63,6 +83,9 @@ public @interface Property {
 
 	Type type() default Type.Scalar;
 
-	String systemProperty() default NOT_SET;
+	/**
+	 * @return the source that should be used to obtain the value
+	 */
+	ValueSource source() default ValueSource.Value;
 
 }

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -63,4 +63,6 @@ public @interface Property {
 
 	Type type() default Type.Scalar;
 
+	String systemProperty() default NOT_SET;
+
 }

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -65,11 +65,22 @@ public @interface Property {
 		Value,
 		/**
 		 * Use the first {@link Property#value()} as a key in the System
-		 * Properties
+		 * Properties. If the key does not exist then either:
+		 * <ul>
+		 * <li>Use the second {@link Property#value()} as the value</li>
+		 * <li>Throw an exception indicating that there is no property for the
+		 * supplied key</li>
+		 * </ul>
 		 */
 		SystemProperty,
 		/**
-		 * Use the first {@link Property#value()} as a key in the Environment
+		 * Use the first {@link Property#value()} as a key in the Environment If
+		 * the key does not exist then either:
+		 * <ul>
+		 * <li>Use the second {@link Property#value()} as the value</li>
+		 * <li>Throw an exception indicating that there is no property for the
+		 * supplied variable name</li>
+		 * </ul>
 		 */
 		EnvironmentVariable,
 		/** Use the name of the test class */

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -55,6 +55,11 @@ public @interface Property {
 		PrimitiveArray
 	}
 
+	/**
+	 * Indicates the source of the configuration value
+	 *
+	 * @since 1.2
+	 */
 	public enum ValueSource {
 		/** Use the {@link Property#value()} directly */
 		Value,
@@ -85,6 +90,7 @@ public @interface Property {
 
 	/**
 	 * @return the source that should be used to obtain the value
+	 * @since 1.2
 	 */
 	ValueSource source() default ValueSource.Value;
 

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/package-info.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/package-info.java
@@ -17,7 +17,7 @@
  *******************************************************************************/
 
 @Export(attribute = "junit=4")
-@Version("1.1.0")
+@Version("1.2.0")
 package org.osgi.test.common.annotation;
 
 import org.osgi.annotation.bundle.Export;

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
@@ -124,17 +124,29 @@ public class PropertiesConverter {
 		String prop = null;
 		switch (entry.source()) {
 			case EnvironmentVariable :
-				if (value.length == 0 || !System.getenv()
+				if (value.length == 0) {
+					throw new RuntimeException("A property name must be supplied for source EnvironmentVariable");
+				} else if (!System.getenv()
 					.containsKey(value[0])) {
-					return value;
+					if (value.length == 1) {
+						throw new RuntimeException("There is no environment variable for name " + value[0]);
+					} else {
+						prop = value[1];
+					}
 				} else {
 					prop = System.getenv(value[0]);
 				}
 				break;
 			case SystemProperty :
-				if (value.length == 0 || !System.getProperties()
+				if (value.length == 0) {
+					throw new RuntimeException("A property name must be supplied for source SystemProperty");
+				} else if (!System.getProperties()
 					.containsKey(value[0])) {
-					return value;
+					if (value.length == 1) {
+						throw new RuntimeException("There is no system property for name " + value[0]);
+					} else {
+						prop = value[1];
+					}
 				} else {
 					prop = System.getProperty(value[0]);
 				}

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
@@ -1,0 +1,247 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit4.properties;
+
+import static org.osgi.test.common.annotation.Property.Type.Scalar;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.junit.runner.Description;
+import org.osgi.test.common.annotation.Property;
+import org.osgi.test.common.annotation.Property.Scalar;
+import org.osgi.test.common.annotation.Property.Type;
+
+public class PropertiesConverter {
+
+	public static Dictionary<String, Object> of(Description desc, Property[] entrys) {
+		Dictionary<String, Object> dictionary = new Hashtable<>();
+		for (Property entry : entrys) {
+			dictionary.put(entry.key(), toValue(desc, entry));
+		}
+		return dictionary;
+	}
+
+	private static Object toValue(Description desc, Property entry) {
+
+		boolean primitive = entry.type()
+			.equals(Type.PrimitiveArray);
+		String[] value = getRawValue(desc, entry);
+
+		Object result = createArray(entry.scalar(), primitive, value.length);
+		int i = 0;
+		for (String v : value) {
+			Object val = null;
+
+			if (v != null) {
+				switch (entry.scalar()) {
+					case Boolean :
+						Boolean booleanValue = Boolean.valueOf(v);
+						val = primitive ? booleanValue.booleanValue() : booleanValue;
+						break;
+
+					case Byte :
+						Byte byteVal = Byte.valueOf(v);
+						val = primitive ? byteVal.byteValue() : byteVal;
+						break;
+
+					case Character :
+						char charVal = v.charAt(0);
+						val = primitive ? charVal : Character.valueOf(charVal);
+						break;
+
+					case Double :
+						Double doubleVal = Double.valueOf(v);
+						val = primitive ? doubleVal.doubleValue() : doubleVal;
+						break;
+
+					case Float :
+						Float floatVal = Float.valueOf(v);
+						val = primitive ? floatVal.floatValue() : floatVal;
+						break;
+
+					case Integer :
+						Integer integerVal = Integer.valueOf(v);
+						val = primitive ? integerVal.intValue() : integerVal;
+						break;
+
+					case Long :
+						Long longVal = Long.valueOf(v);
+						val = primitive ? longVal.longValue() : longVal;
+						break;
+
+					case Short :
+						Short shortVal = Short.valueOf(v);
+						val = primitive ? shortVal.shortValue() : shortVal;
+						break;
+
+					case String :
+						val = v;
+						break;
+				}
+			}
+
+			if (Type.Scalar.equals(entry.type())) {
+				result = val;
+				break;
+			} else {
+				Array.set(result, i++, val);
+			}
+		}
+
+		switch (entry.type()) {
+			case Array :
+				return result;
+			case PrimitiveArray :
+				return result;
+			case Scalar :
+				return result;
+			case Collection :
+				return Arrays.asList((Object[]) result);
+			default :
+				throw new RuntimeException("conversion error - unknown type");
+		}
+
+	}
+
+	private static String[] getRawValue(Description desc, Property entry) {
+		String[] value = entry.value();
+		String prop = null;
+		switch (entry.source()) {
+			case EnvironmentVariable :
+				if (value.length == 0 || !System.getenv()
+					.containsKey(value[0])) {
+					return value;
+				} else {
+					prop = System.getenv(value[0]);
+				}
+				break;
+			case SystemProperty :
+				if (value.length == 0 || !System.getProperties()
+					.containsKey(value[0])) {
+					return value;
+				} else {
+					prop = System.getProperty(value[0]);
+				}
+				break;
+			case TestClass :
+				if (desc == null) {
+					throw new RuntimeException("No Description available to discover the test class");
+				}
+				return new String[] {
+					desc.getClassName()
+				};
+			case TestMethod :
+				if (desc == null) {
+					throw new RuntimeException("No Description available to discover the test method");
+				}
+				return new String[] {
+					desc.getMethodName()
+				};
+			case TestUniqueId :
+				if (desc == null) {
+					throw new RuntimeException("No Description available to discover the test unique id");
+				}
+				return new String[] {
+					desc.getDisplayName()
+				};
+			case Value :
+				return value;
+			default :
+				throw new RuntimeException("conversion error - unknown source");
+		}
+
+		return entry.type() == Scalar ? new String[] {
+			prop
+		} : prop.split("\\s*,\\s*");
+	}
+
+	private static Object createArray(Scalar scalar, boolean primitive, int length) {
+
+		switch (scalar) {
+			case Boolean :
+				if (primitive) {
+					return new boolean[length];
+				} else {
+					return new Boolean[length];
+				}
+
+			case Byte :
+				if (primitive) {
+					return new byte[length];
+				} else {
+					return new Byte[length];
+				}
+
+			case Character :
+				if (primitive) {
+					return new char[length];
+				} else {
+					return new Character[length];
+				}
+
+			case Double :
+				if (primitive) {
+					return new double[length];
+				} else {
+					return new Double[length];
+				}
+
+			case Float :
+				if (primitive) {
+					return new int[length];
+				} else {
+					return new Float[length];
+				}
+
+			case Integer :
+				if (primitive) {
+					return new int[length];
+				} else {
+					return new Integer[length];
+				}
+
+			case Long :
+				if (primitive) {
+					return new long[length];
+				} else {
+					return new Long[length];
+				}
+
+			case Short :
+				if (primitive) {
+					return new short[length];
+				} else {
+					return new Short[length];
+				}
+
+			case String :
+				if (primitive) {
+					throw new IllegalArgumentException(
+						"@Property Could not be Scalar=String and type=primitiveArray at the same time");
+				} else {
+					return new String[length];
+				}
+			default :
+				throw new RuntimeException("conversion error - unknown type");
+		}
+	}
+
+}

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
@@ -17,8 +17,6 @@
  *******************************************************************************/
 package org.osgi.test.junit4.properties;
 
-import static org.osgi.test.common.annotation.Property.Type.Scalar;
-
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Dictionary;
@@ -168,7 +166,7 @@ public class PropertiesConverter {
 				throw new RuntimeException("conversion error - unknown source");
 		}
 
-		return entry.type() == Scalar ? new String[] {
+		return entry.type() == Type.Scalar ? new String[] {
 			prop
 		} : prop.split("\\s*,\\s*");
 	}

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/package-info.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/package-info.java
@@ -15,21 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
-package org.osgi.test.common.annotation;
 
-import java.util.Dictionary;
-
-/**
- * The generic PropertiesConverter is unable to support all forms of property
- * conversion and should not be used. Use the JUnit version specific alternative
- * instead.
- */
-@Deprecated
-public class PropertiesConverter {
-
-	@Deprecated
-	public static Dictionary<String, Object> of(Property[] entrys) {
-		return org.osgi.test.junit4.properties.PropertiesConverter.of(null, entrys);
-	}
-
-}
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("1.0.0")
+package org.osgi.test.junit4.properties;

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationExtension.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationExtension.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.test.common.annotation.PropertiesConverter;
 import org.osgi.test.common.annotation.Property;
 import org.osgi.test.common.annotation.config.InjectConfiguration;
 import org.osgi.test.common.annotation.config.WithConfiguration;
@@ -56,6 +55,7 @@ import org.osgi.test.common.annotation.config.WithFactoryConfigurations;
 import org.osgi.test.common.dictionary.Dictionaries;
 import org.osgi.test.common.inject.TargetType;
 import org.osgi.test.junit5.inject.InjectingExtension;
+import org.osgi.test.junit5.properties.PropertiesConverter;
 import org.osgi.test.junit5.service.ServiceExtension;
 
 public class ConfigurationExtension extends InjectingExtension<InjectConfiguration>
@@ -170,7 +170,8 @@ public class ConfigurationExtension extends InjectingExtension<InjectConfigurati
 					configAnnotation.location());
 			}
 
-			updateConfigurationRespectNew(context, configuration, PropertiesConverter.of(configAnnotation.properties()),
+			updateConfigurationRespectNew(context, configuration,
+				PropertiesConverter.of(context, configAnnotation.properties()),
 				configBefore == null);
 
 			return new ConfigurationHolder(ConfigurationCopy.of(configuration), copyOfBefore);
@@ -198,7 +199,8 @@ public class ConfigurationExtension extends InjectingExtension<InjectConfigurati
 					configAnnotation.name(), configAnnotation.location());
 			}
 
-			updateConfigurationRespectNew(context, configuration, PropertiesConverter.of(configAnnotation.properties()),
+			updateConfigurationRespectNew(context, configuration,
+				PropertiesConverter.of(context, configAnnotation.properties()),
 				configBefore == null);
 
 			return new ConfigurationHolder(ConfigurationCopy.of(configuration), copyOfBefore);

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
@@ -19,19 +19,27 @@ package org.osgi.test.junit5.cm.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.osgi.test.common.annotation.Property.Scalar.Byte;
+import static org.osgi.test.common.annotation.Property.Type.PrimitiveArray;
+import static org.osgi.test.common.annotation.Property.ValueSource.EnvironmentVariable;
+import static org.osgi.test.common.annotation.Property.ValueSource.SystemProperty;
+import static org.osgi.test.common.annotation.Property.ValueSource.TestClass;
+import static org.osgi.test.common.annotation.Property.ValueSource.TestMethod;
+import static org.osgi.test.common.annotation.Property.ValueSource.TestUniqueId;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.test.assertj.dictionary.DictionaryAssert;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.common.annotation.Property;
-import org.osgi.test.common.annotation.Property.Scalar;
-import org.osgi.test.common.annotation.Property.Type;
 import org.osgi.test.common.annotation.config.InjectConfiguration;
 import org.osgi.test.common.annotation.config.WithConfiguration;
 import org.osgi.test.common.annotation.config.WithFactoryConfiguration;
@@ -277,8 +285,8 @@ public class ConfigAnnotationTest {
 
 		@Test
 		@WithConfiguration(pid = "foo", properties = {
-			@Property(key = "testScalar", systemProperty = METHOD_NAME),
-			@Property(key = "testArray", systemProperty = ARRAY_NAME, type = Type.PrimitiveArray, scalar = Scalar.Byte)
+			@Property(key = "testScalar", value = METHOD_NAME, source = SystemProperty),
+			@Property(key = "testArray", value = ARRAY_NAME, source = SystemProperty, type = PrimitiveArray, scalar = Byte)
 		})
 		void testAnnotated(@InjectService
 		ConfigurationAdmin ca) throws Exception {
@@ -294,8 +302,8 @@ public class ConfigAnnotationTest {
 
 		@Test
 		void testInjected(@InjectConfiguration(withConfig = @WithConfiguration(pid = "foo", properties = {
-			@Property(key = "testScalar", systemProperty = METHOD_NAME),
-			@Property(key = "testArray", systemProperty = ARRAY_NAME, type = Type.PrimitiveArray, scalar = Scalar.Byte)
+			@Property(key = "testScalar", value = METHOD_NAME, source = SystemProperty),
+			@Property(key = "testArray", value = ARRAY_NAME, source = SystemProperty, type = PrimitiveArray, scalar = Byte)
 		}))
 		Configuration cs) throws Exception {
 			assertThat(cs).isNotNull();
@@ -309,12 +317,95 @@ public class ConfigAnnotationTest {
 
 		@Test
 		void testFallback(@InjectConfiguration(withConfig = @WithConfiguration(pid = "foo", properties = {
-			@Property(key = "testFallback", value = "default", systemProperty = "missing")
+			@Property(key = "testFallback", value = "default", source = SystemProperty)
 		}))
 		Configuration cs) throws Exception {
 			assertThat(cs).isNotNull();
 			assertThat(cs.getProperties()
 				.get("testFallback")).isEqualTo("default");
+		}
+	}
+
+	@Nested
+	class EnvironmentPropertyTests {
+
+		@Test
+		@WithConfiguration(pid = "foo", properties = {
+			@Property(key = "testScalar", value = "PATH", source = EnvironmentVariable)
+		})
+		void testAnnotated(@InjectService
+		ConfigurationAdmin ca) throws Exception {
+			Configuration cs = ConfigUtil.getConfigsByServicePid(ca, "foo");
+			assertThat(cs).isNotNull();
+			assertThat(cs.getProperties()
+				.get("testScalar")).isEqualTo(System.getenv("PATH"));
+		}
+
+		@Test
+		void testInjected(@InjectConfiguration(withConfig = @WithConfiguration(pid = "foo", properties = {
+			@Property(key = "testScalar", value = "PATH", source = EnvironmentVariable)
+		}))
+		Configuration cs) throws Exception {
+			assertThat(cs).isNotNull();
+			assertThat(cs).isNotNull();
+			assertThat(cs.getProperties()
+				.get("testScalar")).isEqualTo(System.getenv("PATH"));
+		}
+
+		@Test
+		void testFallback(@InjectConfiguration(withConfig = @WithConfiguration(pid = "foo", properties = {
+			@Property(key = "testFallback", value = "default", source = EnvironmentVariable)
+		}))
+		Configuration cs) throws Exception {
+			assertThat(cs).isNotNull();
+			assertThat(cs.getProperties()
+				.get("testFallback")).isEqualTo("default");
+		}
+	}
+
+	public static class TestIdAware implements BeforeTestExecutionCallback {
+		@Override
+		public void beforeTestExecution(ExtensionContext context) throws Exception {
+			((TestPropertyTests) context.getRequiredTestInstance()).uniqueId = context.getUniqueId();
+		}
+	}
+
+	@Nested
+	@ExtendWith(TestIdAware.class)
+	public class TestPropertyTests {
+
+		String uniqueId;
+
+		@Test
+		@WithConfiguration(pid = "foo", properties = {
+			@Property(key = "testName", source = TestClass), @Property(key = "testMethod", source = TestMethod),
+			@Property(key = "testId", source = TestUniqueId)
+		})
+		void testAnnotated(@InjectService
+		ConfigurationAdmin ca) throws Exception {
+			Configuration cs = ConfigUtil.getConfigsByServicePid(ca, "foo");
+			assertThat(cs).isNotNull();
+			assertThat(cs.getProperties()
+				.get("testName")).isEqualTo(TestPropertyTests.class.getName());
+			assertThat(cs.getProperties()
+				.get("testMethod")).isEqualTo("testAnnotated");
+			assertThat(cs.getProperties()
+				.get("testId")).isEqualTo(uniqueId);
+		}
+
+		@Test
+		void testInjected(@InjectConfiguration(withConfig = @WithConfiguration(pid = "foo", properties = {
+			@Property(key = "testName", source = TestClass), @Property(key = "testMethod", source = TestMethod),
+			@Property(key = "testId", source = TestUniqueId)
+		}))
+		Configuration cs) throws Exception {
+			assertThat(cs).isNotNull();
+			assertThat(cs.getProperties()
+				.get("testName")).isEqualTo(TestPropertyTests.class.getName());
+			assertThat(cs.getProperties()
+				.get("testMethod")).isEqualTo("testInjected");
+			assertThat(cs.getProperties()
+				.get("testId")).isEqualTo(uniqueId);
 		}
 	}
 }

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
@@ -317,7 +317,9 @@ public class ConfigAnnotationTest {
 
 		@Test
 		void testFallback(@InjectConfiguration(withConfig = @WithConfiguration(pid = "foo", properties = {
-			@Property(key = "testFallback", value = "default", source = SystemProperty)
+			@Property(key = "testFallback", value = {
+				"missing", "default"
+			}, source = SystemProperty)
 		}))
 		Configuration cs) throws Exception {
 			assertThat(cs).isNotNull();
@@ -354,7 +356,9 @@ public class ConfigAnnotationTest {
 
 		@Test
 		void testFallback(@InjectConfiguration(withConfig = @WithConfiguration(pid = "foo", properties = {
-			@Property(key = "testFallback", value = "default", source = EnvironmentVariable)
+			@Property(key = "testFallback", value = {
+				"missing", "default"
+			}, source = EnvironmentVariable)
 		}))
 		Configuration cs) throws Exception {
 			assertThat(cs).isNotNull();

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
@@ -17,191 +17,19 @@
  *******************************************************************************/
 package org.osgi.test.common.annotation;
 
-import static org.osgi.test.common.annotation.Property.NOT_SET;
-
-import java.lang.reflect.Array;
-import java.util.Arrays;
 import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.Properties;
 
-import org.osgi.test.common.annotation.Property.Scalar;
-import org.osgi.test.common.annotation.Property.Type;
-
+/**
+ * The generic PropertiesConverter is unable to support all forms of property
+ * conversion and should not be used. Use the JUnit version specific alternative
+ * instead.
+ */
+@Deprecated
 public class PropertiesConverter {
 
+	@Deprecated
 	public static Dictionary<String, Object> of(Property[] entrys) {
-		Dictionary<String, Object> dictionary = new Hashtable<>();
-		for (Property entry : entrys) {
-			dictionary.put(entry.key(), toValue(entry));
-		}
-		return dictionary;
-	}
-
-	private static Object toValue(Property entry) {
-
-		boolean primitive = entry.type()
-			.equals(Type.PrimitiveArray);
-		String[] value;
-		if (NOT_SET.equals(entry.systemProperty())) {
-			value = entry.value();
-		} else {
-			Properties sysProps = System.getProperties();
-			if (sysProps.containsKey(entry.systemProperty())) {
-				String prop = sysProps.getProperty(entry.systemProperty());
-				value = entry.type() == Type.Scalar ? new String[] {
-					prop
-				} : prop.split(",");
-			} else {
-				value = entry.value();
-			}
-		}
-
-		Object result = createArray(entry.scalar(), primitive, value.length);
-		int i = 0;
-		for (String v : value) {
-			Object val = null;
-
-			if (v != null) {
-				switch (entry.scalar()) {
-					case Boolean :
-						Boolean booleanValue = Boolean.valueOf(v);
-						val = primitive ? booleanValue.booleanValue() : booleanValue;
-						break;
-
-					case Byte :
-						Byte byteVal = Byte.valueOf(v);
-						val = primitive ? byteVal.byteValue() : byteVal;
-						break;
-
-					case Character :
-						char charVal = v.charAt(0);
-						val = primitive ? charVal : Character.valueOf(charVal);
-						break;
-
-					case Double :
-						Double doubleVal = Double.valueOf(v);
-						val = primitive ? doubleVal.doubleValue() : doubleVal;
-						break;
-
-					case Float :
-						Float floatVal = Float.valueOf(v);
-						val = primitive ? floatVal.floatValue() : floatVal;
-						break;
-
-					case Integer :
-						Integer integerVal = Integer.valueOf(v);
-						val = primitive ? integerVal.intValue() : integerVal;
-						break;
-
-					case Long :
-						Long longVal = Long.valueOf(v);
-						val = primitive ? longVal.longValue() : longVal;
-						break;
-
-					case Short :
-						Short shortVal = Short.valueOf(v);
-						val = primitive ? shortVal.shortValue() : shortVal;
-						break;
-
-					case String :
-						val = v;
-						break;
-				}
-			}
-
-			if (Type.Scalar.equals(entry.type())) {
-				result = val;
-				break;
-			} else {
-				Array.set(result, i++, val);
-			}
-		}
-
-		switch (entry.type()) {
-			case Array :
-				return result;
-			case PrimitiveArray :
-				return result;
-			case Scalar :
-				return result;
-			case Collection :
-				return Arrays.asList((Object[]) result);
-			default :
-				throw new RuntimeException("conversion error - unknown type");
-		}
-
-	}
-
-	private static Object createArray(Scalar scalar, boolean primitive, int length) {
-
-		switch (scalar) {
-			case Boolean :
-				if (primitive) {
-					return new boolean[length];
-				} else {
-					return new Boolean[length];
-				}
-
-			case Byte :
-				if (primitive) {
-					return new byte[length];
-				} else {
-					return new Byte[length];
-				}
-
-			case Character :
-				if (primitive) {
-					return new char[length];
-				} else {
-					return new Character[length];
-				}
-
-			case Double :
-				if (primitive) {
-					return new double[length];
-				} else {
-					return new Double[length];
-				}
-
-			case Float :
-				if (primitive) {
-					return new int[length];
-				} else {
-					return new Float[length];
-				}
-
-			case Integer :
-				if (primitive) {
-					return new int[length];
-				} else {
-					return new Integer[length];
-				}
-
-			case Long :
-				if (primitive) {
-					return new long[length];
-				} else {
-					return new Long[length];
-				}
-
-			case Short :
-				if (primitive) {
-					return new short[length];
-				} else {
-					return new Short[length];
-				}
-
-			case String :
-				if (primitive) {
-					throw new IllegalArgumentException(
-						"@Property Could not be Scalar=String and type=primitiveArray at the same time");
-				} else {
-					return new String[length];
-				}
-			default :
-				throw new RuntimeException("conversion error - unknown type");
-		}
+	    return org.osgi.test.junit5.properties.PropertiesConverter.of(null, entrys);
 	}
 
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
@@ -17,10 +17,13 @@
  *******************************************************************************/
 package org.osgi.test.common.annotation;
 
+import static org.osgi.test.common.annotation.Property.NOT_SET;
+
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.Properties;
 
 import org.osgi.test.common.annotation.Property.Scalar;
 import org.osgi.test.common.annotation.Property.Type;
@@ -39,9 +42,24 @@ public class PropertiesConverter {
 
 		boolean primitive = entry.type()
 			.equals(Type.PrimitiveArray);
-		Object result = createArray(entry.scalar(), primitive, entry.value().length);
+		String[] value;
+		if (NOT_SET.equals(entry.systemProperty())) {
+			value = entry.value();
+		} else {
+			Properties sysProps = System.getProperties();
+			if (sysProps.containsKey(entry.systemProperty())) {
+				String prop = sysProps.getProperty(entry.systemProperty());
+				value = entry.type() == Type.Scalar ? new String[] {
+					prop
+				} : prop.split(",");
+			} else {
+				value = entry.value();
+			}
+		}
+
+		Object result = createArray(entry.scalar(), primitive, value.length);
 		int i = 0;
-		for (String v : entry.value()) {
+		for (String v : value) {
 			Object val = null;
 
 			if (v != null) {

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/PropertiesConverter.java
@@ -21,8 +21,8 @@ import java.util.Dictionary;
 
 /**
  * The generic PropertiesConverter is unable to support all forms of property
- * conversion and should not be used. Use the JUnit version specific alternative
- * instead.
+ * conversion and should not be used. Use the JUnit 5 specific
+ * {@link org.osgi.test.junit5.properties.PropertiesConverter} instead.
  */
 @Deprecated
 public class PropertiesConverter {

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -55,6 +55,26 @@ public @interface Property {
 		PrimitiveArray
 	}
 
+	public enum ValueSource {
+		/** Use the {@link Property#value()} directly */
+		Value,
+		/**
+		 * Use the first {@link Property#value()} as a key in the System
+		 * Properties
+		 */
+		SystemProperty,
+		/**
+		 * Use the first {@link Property#value()} as a key in the Environment
+		 */
+		EnvironmentVariable,
+		/** Use the name of the test class */
+		TestClass,
+		/** Use the name of the test method */
+		TestMethod,
+		/** Use the test unique identifier */
+		TestUniqueId
+	}
+
 	String key();
 
 	String[] value() default "";
@@ -63,6 +83,9 @@ public @interface Property {
 
 	Type type() default Type.Scalar;
 
-	String systemProperty() default NOT_SET;
+	/**
+	 * @return the source that should be used to obtain the value
+	 */
+	ValueSource source() default ValueSource.Value;
 
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -63,4 +63,6 @@ public @interface Property {
 
 	Type type() default Type.Scalar;
 
+	String systemProperty() default NOT_SET;
+
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -65,11 +65,22 @@ public @interface Property {
 		Value,
 		/**
 		 * Use the first {@link Property#value()} as a key in the System
-		 * Properties
+		 * Properties. If the key does not exist then either:
+		 * <ul>
+		 * <li>Use the second {@link Property#value()} as the value</li>
+		 * <li>Throw an exception indicating that there is no property for the
+		 * supplied key</li>
+		 * </ul>
 		 */
 		SystemProperty,
 		/**
-		 * Use the first {@link Property#value()} as a key in the Environment
+		 * Use the first {@link Property#value()} as a key in the Environment If
+		 * the key does not exist then either:
+		 * <ul>
+		 * <li>Use the second {@link Property#value()} as the value</li>
+		 * <li>Throw an exception indicating that there is no property for the
+		 * supplied variable name</li>
+		 * </ul>
 		 */
 		EnvironmentVariable,
 		/** Use the name of the test class */

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -55,6 +55,11 @@ public @interface Property {
 		PrimitiveArray
 	}
 
+	/**
+	 * Indicates the source of the configuration value
+	 *
+	 * @since 1.2
+	 */
 	public enum ValueSource {
 		/** Use the {@link Property#value()} directly */
 		Value,
@@ -85,6 +90,7 @@ public @interface Property {
 
 	/**
 	 * @return the source that should be used to obtain the value
+	 * @since 1.2
 	 */
 	ValueSource source() default ValueSource.Value;
 

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/package-info.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/package-info.java
@@ -17,7 +17,7 @@
  *******************************************************************************/
 
 @Export(attribute = "junit=5", substitution = Substitution.NOIMPORT)
-@Version("1.1.1")
+@Version("1.2.0")
 package org.osgi.test.common.annotation;
 
 import org.osgi.annotation.bundle.Export;

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/PropertiesConverter.java
@@ -124,17 +124,29 @@ public class PropertiesConverter {
 		String prop = null;
 		switch (entry.source()) {
 			case EnvironmentVariable :
-				if (value.length == 0 || !System.getenv()
+				if (value.length == 0) {
+					throw new RuntimeException("A property name must be supplied for source EnvironmentVariable");
+				} else if (!System.getenv()
 					.containsKey(value[0])) {
-					return value;
+					if (value.length == 1) {
+						throw new RuntimeException("There is no environment variable for name " + value[0]);
+					} else {
+						prop = value[1];
+					}
 				} else {
 					prop = System.getenv(value[0]);
 				}
 				break;
 			case SystemProperty :
-				if (value.length == 0 || !System.getProperties()
+				if (value.length == 0) {
+					throw new RuntimeException("A property name must be supplied for source SystemProperty");
+				} else if (!System.getProperties()
 					.containsKey(value[0])) {
-					return value;
+					if (value.length == 1) {
+						throw new RuntimeException("There is no system property for name " + value[0]);
+					} else {
+						prop = value[1];
+					}
 				} else {
 					prop = System.getProperty(value[0]);
 				}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/PropertiesConverter.java
@@ -17,8 +17,6 @@
  *******************************************************************************/
 package org.osgi.test.junit5.properties;
 
-import static org.osgi.test.common.annotation.Property.Type.Scalar;
-
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Dictionary;
@@ -170,7 +168,7 @@ public class PropertiesConverter {
 				throw new RuntimeException("conversion error - unknown source");
 		}
 
-		return entry.type() == Scalar ? new String[] {
+		return entry.type() == Type.Scalar ? new String[] {
 			prop
 		} : prop.split("\\s*,\\s*");
 	}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/PropertiesConverter.java
@@ -1,0 +1,249 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.properties;
+
+import static org.osgi.test.common.annotation.Property.Type.Scalar;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.osgi.test.common.annotation.Property;
+import org.osgi.test.common.annotation.Property.Scalar;
+import org.osgi.test.common.annotation.Property.Type;
+
+public class PropertiesConverter {
+
+	public static Dictionary<String, Object> of(ExtensionContext context, Property[] entrys) {
+		Dictionary<String, Object> dictionary = new Hashtable<>();
+		for (Property entry : entrys) {
+			dictionary.put(entry.key(), toValue(context, entry));
+		}
+		return dictionary;
+	}
+
+	private static Object toValue(ExtensionContext context, Property entry) {
+
+		boolean primitive = entry.type()
+			.equals(Type.PrimitiveArray);
+		String[] value = getRawValue(context, entry);
+
+		Object result = createArray(entry.scalar(), primitive, value.length);
+		int i = 0;
+		for (String v : value) {
+			Object val = null;
+
+			if (v != null) {
+				switch (entry.scalar()) {
+					case Boolean :
+						Boolean booleanValue = Boolean.valueOf(v);
+						val = primitive ? booleanValue.booleanValue() : booleanValue;
+						break;
+
+					case Byte :
+						Byte byteVal = Byte.valueOf(v);
+						val = primitive ? byteVal.byteValue() : byteVal;
+						break;
+
+					case Character :
+						char charVal = v.charAt(0);
+						val = primitive ? charVal : Character.valueOf(charVal);
+						break;
+
+					case Double :
+						Double doubleVal = Double.valueOf(v);
+						val = primitive ? doubleVal.doubleValue() : doubleVal;
+						break;
+
+					case Float :
+						Float floatVal = Float.valueOf(v);
+						val = primitive ? floatVal.floatValue() : floatVal;
+						break;
+
+					case Integer :
+						Integer integerVal = Integer.valueOf(v);
+						val = primitive ? integerVal.intValue() : integerVal;
+						break;
+
+					case Long :
+						Long longVal = Long.valueOf(v);
+						val = primitive ? longVal.longValue() : longVal;
+						break;
+
+					case Short :
+						Short shortVal = Short.valueOf(v);
+						val = primitive ? shortVal.shortValue() : shortVal;
+						break;
+
+					case String :
+						val = v;
+						break;
+				}
+			}
+
+			if (Type.Scalar.equals(entry.type())) {
+				result = val;
+				break;
+			} else {
+				Array.set(result, i++, val);
+			}
+		}
+
+		switch (entry.type()) {
+			case Array :
+				return result;
+			case PrimitiveArray :
+				return result;
+			case Scalar :
+				return result;
+			case Collection :
+				return Arrays.asList((Object[]) result);
+			default :
+				throw new RuntimeException("conversion error - unknown type");
+		}
+
+	}
+
+	private static String[] getRawValue(ExtensionContext context, Property entry) {
+		String[] value = entry.value();
+		String prop = null;
+		switch (entry.source()) {
+			case EnvironmentVariable :
+				if (value.length == 0 || !System.getenv()
+					.containsKey(value[0])) {
+					return value;
+				} else {
+					prop = System.getenv(value[0]);
+				}
+				break;
+			case SystemProperty :
+				if (value.length == 0 || !System.getProperties()
+					.containsKey(value[0])) {
+					return value;
+				} else {
+					prop = System.getProperty(value[0]);
+				}
+				break;
+			case TestClass :
+				if (context == null) {
+					throw new RuntimeException("No ExtensionContext available to discover the test class");
+				}
+				return new String[] {
+					context.getRequiredTestClass()
+						.getName()
+				};
+			case TestMethod :
+				if (context == null) {
+					throw new RuntimeException("No ExtensionContext available to discover the test method");
+				}
+				return new String[] {
+					context.getRequiredTestMethod()
+						.getName()
+				};
+			case TestUniqueId :
+				if (context == null) {
+					throw new RuntimeException("No ExtensionContext available to discover the test unique id");
+				}
+				return new String[] {
+					context.getUniqueId()
+				};
+			case Value :
+				return value;
+			default :
+				throw new RuntimeException("conversion error - unknown source");
+		}
+
+		return entry.type() == Scalar ? new String[] {
+			prop
+		} : prop.split("\\s*,\\s*");
+	}
+
+	private static Object createArray(Scalar scalar, boolean primitive, int length) {
+
+		switch (scalar) {
+			case Boolean :
+				if (primitive) {
+					return new boolean[length];
+				} else {
+					return new Boolean[length];
+				}
+
+			case Byte :
+				if (primitive) {
+					return new byte[length];
+				} else {
+					return new Byte[length];
+				}
+
+			case Character :
+				if (primitive) {
+					return new char[length];
+				} else {
+					return new Character[length];
+				}
+
+			case Double :
+				if (primitive) {
+					return new double[length];
+				} else {
+					return new Double[length];
+				}
+
+			case Float :
+				if (primitive) {
+					return new int[length];
+				} else {
+					return new Float[length];
+				}
+
+			case Integer :
+				if (primitive) {
+					return new int[length];
+				} else {
+					return new Integer[length];
+				}
+
+			case Long :
+				if (primitive) {
+					return new long[length];
+				} else {
+					return new Long[length];
+				}
+
+			case Short :
+				if (primitive) {
+					return new short[length];
+				} else {
+					return new Short[length];
+				}
+
+			case String :
+				if (primitive) {
+					throw new IllegalArgumentException(
+						"@Property Could not be Scalar=String and type=primitiveArray at the same time");
+				} else {
+					return new String[length];
+				}
+			default :
+				throw new RuntimeException("conversion error - unknown type");
+		}
+	}
+
+}

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/package-info.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/package-info.java
@@ -15,21 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
-package org.osgi.test.common.annotation;
 
-import java.util.Dictionary;
-
-/**
- * The generic PropertiesConverter is unable to support all forms of property
- * conversion and should not be used. Use the JUnit version specific alternative
- * instead.
- */
-@Deprecated
-public class PropertiesConverter {
-
-	@Deprecated
-	public static Dictionary<String, Object> of(Property[] entrys) {
-		return org.osgi.test.junit4.properties.PropertiesConverter.of(null, entrys);
-	}
-
-}
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("1.0.0")
+package org.osgi.test.junit5.properties;


### PR DESCRIPTION
This commit adds the systemProperty member to the @Property annotation. If set then the System Properties will be queried using that property name, and the value used to set the configuration. If there is no matching System Property for the supplied key then the @Property annotation value member will be used instead. If the @Property is not of type Scalar then the value of the System Property will be split using ',' as a separator.


Fixes #614 