### PR TITLE
Support placeholders in configuration values

### DIFF
--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -91,6 +91,21 @@ public @interface Property {
 		TestUniqueId
 	}
 
+	/**
+	 * Used to provide an argument in the {@link Property#templateArguments()}.
+	 * {@link ValueArgument} values are resolved in the same way as
+	 * {@link Property} values but they are always of {@link Type#Scalar}
+	 *
+	 * @since 1.2
+	 */
+	public @interface ValueArgument {
+		String[] value() default "";
+
+		Scalar scalar() default Scalar.String;
+
+		ValueSource source() default ValueSource.Value;
+	}
+
 	String key();
 
 	String[] value() default "";
@@ -104,5 +119,23 @@ public @interface Property {
 	 * @since 1.2
 	 */
 	ValueSource source() default ValueSource.Value;
+
+	/**
+	 * If any template arguments are set then the resolved value of this
+	 * {@link Property} annotation will be used as a template in
+	 * {@link String#format} with the resolved {@link ValueArgument} values used
+	 * as arguments.
+	 * <p>
+	 * Note that any defaulting or processing according to the {@link #source()}
+	 * will happen <em>before</em> the formatting is applied, so template
+	 * arguments cannot be used, for example, to change the name of a system
+	 * property. Conversely, the scalar conversion will happen <em>after</em>
+	 * the template is applied, meaning that numeric values can be assembled
+	 * from multiple template arguments.
+	 *
+	 * @return the arguments that should be used with the template
+	 * @since 1.2
+	 */
+	ValueArgument[] templateArguments() default {};
 
 }

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -93,12 +93,12 @@ public @interface Property {
 
 	/**
 	 * Used to provide an argument in the {@link Property#templateArguments()}.
-	 * {@link ValueArgument} values are resolved in the same way as
+	 * {@link TemplateArgument} values are resolved in the same way as
 	 * {@link Property} values but they are always of {@link Type#Scalar}
 	 *
 	 * @since 1.2
 	 */
-	public @interface ValueArgument {
+	public @interface TemplateArgument {
 		String[] value() default "";
 
 		Scalar scalar() default Scalar.String;
@@ -123,7 +123,7 @@ public @interface Property {
 	/**
 	 * If any template arguments are set then the resolved value of this
 	 * {@link Property} annotation will be used as a template in
-	 * {@link String#format} with the resolved {@link ValueArgument} values used
+	 * {@link String#format} with the resolved {@link TemplateArgument} values used
 	 * as arguments.
 	 * <p>
 	 * Note that any defaulting or processing according to the {@link #source()}
@@ -136,6 +136,6 @@ public @interface Property {
 	 * @return the arguments that should be used with the template
 	 * @since 1.2
 	 */
-	ValueArgument[] templateArguments() default {};
+	TemplateArgument[] templateArguments() default {};
 
 }

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
@@ -26,6 +26,7 @@ import org.junit.runner.Description;
 import org.osgi.test.common.annotation.Property;
 import org.osgi.test.common.annotation.Property.Scalar;
 import org.osgi.test.common.annotation.Property.Type;
+import org.osgi.test.common.annotation.Property.ValueSource;
 
 public class PropertiesConverter {
 
@@ -41,60 +42,19 @@ public class PropertiesConverter {
 
 		boolean primitive = entry.type()
 			.equals(Type.PrimitiveArray);
-		String[] value = getRawValue(desc, entry);
+		String[] value = getRawValue(desc, entry.value(), entry.source(), entry.type());
+
+		Object[] templateParams = Arrays.stream(entry.templateArguments())
+			.map(ta -> getRawValue(desc, ta.value(), ta.source(), Type.Scalar)[0])
+			.toArray();
 
 		Object result = createArray(entry.scalar(), primitive, value.length);
 		int i = 0;
 		for (String v : value) {
-			Object val = null;
-
-			if (v != null) {
-				switch (entry.scalar()) {
-					case Boolean :
-						Boolean booleanValue = Boolean.valueOf(v);
-						val = primitive ? booleanValue.booleanValue() : booleanValue;
-						break;
-
-					case Byte :
-						Byte byteVal = Byte.valueOf(v);
-						val = primitive ? byteVal.byteValue() : byteVal;
-						break;
-
-					case Character :
-						char charVal = v.charAt(0);
-						val = primitive ? charVal : Character.valueOf(charVal);
-						break;
-
-					case Double :
-						Double doubleVal = Double.valueOf(v);
-						val = primitive ? doubleVal.doubleValue() : doubleVal;
-						break;
-
-					case Float :
-						Float floatVal = Float.valueOf(v);
-						val = primitive ? floatVal.floatValue() : floatVal;
-						break;
-
-					case Integer :
-						Integer integerVal = Integer.valueOf(v);
-						val = primitive ? integerVal.intValue() : integerVal;
-						break;
-
-					case Long :
-						Long longVal = Long.valueOf(v);
-						val = primitive ? longVal.longValue() : longVal;
-						break;
-
-					case Short :
-						Short shortVal = Short.valueOf(v);
-						val = primitive ? shortVal.shortValue() : shortVal;
-						break;
-
-					case String :
-						val = v;
-						break;
-				}
+			if (v != null && templateParams.length > 0) {
+				v = String.format(v, templateParams);
 			}
+			Object val = convertScalar(entry.scalar(), v);
 
 			if (Type.Scalar.equals(entry.type())) {
 				result = val;
@@ -119,10 +79,43 @@ public class PropertiesConverter {
 
 	}
 
-	private static String[] getRawValue(Description desc, Property entry) {
-		String[] value = entry.value();
+	private static Object convertScalar(Scalar scalar, String v) {
+		if (v != null) {
+			switch (scalar) {
+				case Boolean :
+					return Boolean.valueOf(v);
+
+				case Byte :
+					return Byte.valueOf(v);
+
+				case Character :
+					return v.charAt(0);
+
+				case Double :
+					return Double.valueOf(v);
+
+				case Float :
+					return Float.valueOf(v);
+
+				case Integer :
+					return Integer.valueOf(v);
+
+				case Long :
+					return Long.valueOf(v);
+
+				case Short :
+					return Short.valueOf(v);
+
+				case String :
+					return v;
+			}
+		}
+		return null;
+	}
+
+	private static String[] getRawValue(Description desc, String[] value, ValueSource source, Type type) {
 		String prop = null;
-		switch (entry.source()) {
+		switch (source) {
 			case EnvironmentVariable :
 				if (value.length == 0) {
 					throw new RuntimeException("A property name must be supplied for source EnvironmentVariable");
@@ -178,7 +171,7 @@ public class PropertiesConverter {
 				throw new RuntimeException("conversion error - unknown source");
 		}
 
-		return entry.type() == Type.Scalar ? new String[] {
+		return type == Type.Scalar ? new String[] {
 			prop
 		} : prop.split("\\s*,\\s*");
 	}

--- a/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit4/src/main/java/org/osgi/test/junit4/properties/PropertiesConverter.java
@@ -45,7 +45,7 @@ public class PropertiesConverter {
 		String[] value = getRawValue(desc, entry.value(), entry.source(), entry.type());
 
 		Object[] templateParams = Arrays.stream(entry.templateArguments())
-			.map(ta -> getRawValue(desc, ta.value(), ta.source(), Type.Scalar)[0])
+			.map(ta -> convertScalar(ta.scalar(), getRawValue(desc, ta.value(), ta.source(), Type.Scalar)[0]))
 			.toArray();
 
 		Object result = createArray(entry.scalar(), primitive, value.length);

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/common/annotation/config/WithFactoryConfiguration.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/common/annotation/config/WithFactoryConfiguration.java
@@ -59,7 +59,7 @@ public @interface WithFactoryConfiguration {
 	 *
 	 * @return The name
 	 */
-	String name();
+	String name() default Property.NOT_SET;
 
 	/**
 	 * The location of the Configuration.<br>

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/common/annotation/config/package-info.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/common/annotation/config/package-info.java
@@ -17,6 +17,6 @@
  *******************************************************************************/
 
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.1.1")
 
 package org.osgi.test.common.annotation.config;

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
@@ -169,6 +169,31 @@ public class ConfigAnnotationTest {
 
 	}
 
+	@Test
+	@WithFactoryConfiguration(factoryPid = FACTORY_CONFIGURATION_PID, properties = {
+		@Property(key = "foo", value = "bar")
+	})
+	@WithFactoryConfiguration(factoryPid = FACTORY_CONFIGURATION_PID, properties = {
+		@Property(key = "fizz", value = "buzz")
+	})
+	public void testMethodConfigurationFactoryUnboundNames() throws Exception {
+
+		Configuration[] cfgs = ca.listConfigurations("(foo=bar)");
+		assertThat(cfgs).isNotNull()
+			.hasSize(1);
+		assertThat(cfgs[0].getFactoryPid()).isEqualTo(FACTORY_CONFIGURATION_PID);
+		DictionaryAssert.assertThat(cfgs[0].getProperties())
+			.containsEntry("foo", "bar");
+
+		cfgs = ca.listConfigurations("(fizz=buzz)");
+		assertThat(cfgs[0].getFactoryPid()).isEqualTo(FACTORY_CONFIGURATION_PID);
+		assertThat(cfgs).isNotNull()
+			.hasSize(1);
+		DictionaryAssert.assertThat(cfgs[0].getProperties())
+			.containsEntry("fizz", "buzz");
+
+	}
+
 	@Nested
 	class LocationTests {
 

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
@@ -41,8 +41,8 @@ import org.osgi.test.assertj.dictionary.DictionaryAssert;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.common.annotation.Property;
 import org.osgi.test.common.annotation.Property.Scalar;
+import org.osgi.test.common.annotation.Property.TemplateArgument;
 import org.osgi.test.common.annotation.Property.Type;
-import org.osgi.test.common.annotation.Property.ValueArgument;
 import org.osgi.test.common.annotation.config.InjectConfiguration;
 import org.osgi.test.common.annotation.config.WithConfiguration;
 import org.osgi.test.common.annotation.config.WithFactoryConfiguration;
@@ -293,8 +293,8 @@ public class ConfigAnnotationTest {
 			@Property(key = "testTemplate", value = {
 				"Method : %s", "Easy As %2$s"
 			}, type = Type.Collection, templateArguments = {
-				@ValueArgument(value = METHOD_NAME, source = SystemProperty),
-				@ValueArgument(value = ARRAY_NAME, source = SystemProperty)
+				@TemplateArgument(value = METHOD_NAME, source = SystemProperty),
+				@TemplateArgument(value = ARRAY_NAME, source = SystemProperty)
 			})
 		})
 		void testAnnotated(@InjectService
@@ -319,8 +319,8 @@ public class ConfigAnnotationTest {
 			@Property(key = "testTemplate", value = {
 				"Method : %s", "Easy As %2$s"
 			}, type = Type.Collection, templateArguments = {
-				@ValueArgument(value = METHOD_NAME, source = SystemProperty),
-				@ValueArgument(value = ARRAY_NAME, source = SystemProperty)
+				@TemplateArgument(value = METHOD_NAME, source = SystemProperty),
+				@TemplateArgument(value = ARRAY_NAME, source = SystemProperty)
 			})
 		}))
 		Configuration cs) throws Exception {
@@ -343,9 +343,9 @@ public class ConfigAnnotationTest {
 			}, source = SystemProperty), @Property(key = "testTemplateFallback", value = {
 				"Method : %s", "Easy As %2$s"
 			}, type = Type.Collection, templateArguments = {
-				@ValueArgument(value = {
+				@TemplateArgument(value = {
 					"missing", "default2"
-				}, source = SystemProperty), @ValueArgument(value = {
+				}, source = SystemProperty), @TemplateArgument(value = {
 					"missing", "default3"
 				}, source = SystemProperty)
 			})
@@ -361,20 +361,25 @@ public class ConfigAnnotationTest {
 
 		@Test
 		@WithConfiguration(pid = "foo", properties = {
-			@Property(key = "testNumber", scalar = Scalar.Double, value = "%s.%s", templateArguments = {
-				@ValueArgument(value = {
+			@Property(key = "testNumber", scalar = Scalar.Double, value = "%d.%.0f", templateArguments = {
+				@TemplateArgument(value = {
 					"missing", "5"
-				}, source = SystemProperty),
-				@ValueArgument(value = "java.specification.version", source = SystemProperty)
+				}, source = SystemProperty, scalar = Scalar.Integer),
+				@TemplateArgument(value = "java.specification.version", source = SystemProperty, scalar = Scalar.Double)
 			})
 		})
 		void testNumeric(@InjectService
 		ConfigurationAdmin ca) throws Exception {
 			Configuration cs = ConfigUtil.getConfigsByServicePid(ca, "foo");
 			assertThat(cs).isNotNull();
+			String javaVersion = System.getProperty("java.specification.version");
+			int idx = javaVersion.indexOf('.');
+			if (idx >= 0) {
+				javaVersion = javaVersion.substring(0, idx);
+			}
 			assertThat(cs.getProperties()
 				.get("testNumber"))
-					.isEqualTo(Double.parseDouble("5." + System.getProperty("java.specification.version")));
+					.isEqualTo(Double.parseDouble("5." + javaVersion));
 		}
 	}
 
@@ -385,7 +390,7 @@ public class ConfigAnnotationTest {
 		@WithConfiguration(pid = "foo", properties = {
 			@Property(key = "testScalar", value = "PATH", source = EnvironmentVariable),
 			@Property(key = "testTemplate", value = "Easy As %s", templateArguments = {
-				@ValueArgument(value = "PATH", source = EnvironmentVariable)
+				@TemplateArgument(value = "PATH", source = EnvironmentVariable)
 			})
 		})
 		void testAnnotated(@InjectService
@@ -402,7 +407,7 @@ public class ConfigAnnotationTest {
 		void testInjected(@InjectConfiguration(withConfig = @WithConfiguration(pid = "foo", properties = {
 			@Property(key = "testScalar", value = "PATH", source = EnvironmentVariable),
 			@Property(key = "testTemplate", value = "Easy As %s", templateArguments = {
-				@ValueArgument(value = "PATH", source = EnvironmentVariable)
+				@TemplateArgument(value = "PATH", source = EnvironmentVariable)
 			})
 		}))
 		Configuration cs) throws Exception {
@@ -421,9 +426,9 @@ public class ConfigAnnotationTest {
 			}, source = EnvironmentVariable), @Property(key = "testTemplateFallback", value = {
 				"Method : %s", "Easy As %2$s"
 			}, type = Type.Collection, templateArguments = {
-				@ValueArgument(value = {
+				@TemplateArgument(value = {
 					"missing", "default2"
-				}, source = EnvironmentVariable), @ValueArgument(value = {
+				}, source = EnvironmentVariable), @TemplateArgument(value = {
 					"missing", "default3"
 				}, source = EnvironmentVariable)
 			})
@@ -457,8 +462,8 @@ public class ConfigAnnotationTest {
 			@Property(key = "testId", source = TestUniqueId), @Property(key = "testTemplate", value = {
 				"Class : %s", "Test : %2$s", "Id : %3$s"
 			}, type = Type.Collection, templateArguments = {
-				@ValueArgument(source = TestClass), @ValueArgument(source = TestMethod),
-				@ValueArgument(source = TestUniqueId)
+				@TemplateArgument(source = TestClass), @TemplateArgument(source = TestMethod),
+				@TemplateArgument(source = TestUniqueId)
 			})
 		})
 		void testAnnotated(@InjectService
@@ -483,8 +488,8 @@ public class ConfigAnnotationTest {
 			@Property(key = "testId", source = TestUniqueId), @Property(key = "testTemplate", value = {
 				"Class : %s", "Test : %2$s", "Id : %3$s"
 			}, type = Type.Collection, templateArguments = {
-				@ValueArgument(source = TestClass), @ValueArgument(source = TestMethod),
-				@ValueArgument(source = TestUniqueId)
+				@TemplateArgument(source = TestClass), @TemplateArgument(source = TestMethod),
+				@TemplateArgument(source = TestUniqueId)
 			})
 		}))
 		Configuration cs) throws Exception {

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/ConfigAnnotationTest.java
@@ -372,14 +372,10 @@ public class ConfigAnnotationTest {
 		ConfigurationAdmin ca) throws Exception {
 			Configuration cs = ConfigUtil.getConfigsByServicePid(ca, "foo");
 			assertThat(cs).isNotNull();
-			String javaVersion = System.getProperty("java.specification.version");
-			int idx = javaVersion.indexOf('.');
-			if (idx >= 0) {
-				javaVersion = javaVersion.substring(0, idx);
-			}
+			double javaVersion = Double.parseDouble(System.getProperty("java.specification.version"));
 			assertThat(cs.getProperties()
 				.get("testNumber"))
-					.isEqualTo(Double.parseDouble("5." + javaVersion));
+					.isEqualTo(Double.parseDouble("5." + Math.round(javaVersion)));
 		}
 	}
 

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -91,6 +91,21 @@ public @interface Property {
 		TestUniqueId
 	}
 
+	/**
+	 * Used to provide an argument in the {@link Property#templateArguments()}.
+	 * {@link ValueArgument} values are resolved in the same way as
+	 * {@link Property} values but they are always of {@link Type#Scalar}
+	 *
+	 * @since 1.2
+	 */
+	public @interface ValueArgument {
+		String[] value() default "";
+
+		Scalar scalar() default Scalar.String;
+
+		ValueSource source() default ValueSource.Value;
+	}
+
 	String key();
 
 	String[] value() default "";
@@ -104,5 +119,23 @@ public @interface Property {
 	 * @since 1.2
 	 */
 	ValueSource source() default ValueSource.Value;
+
+	/**
+	 * If any template arguments are set then the resolved value of this
+	 * {@link Property} annotation will be used as a template in
+	 * {@link String#format} with the resolved {@link ValueArgument} values used
+	 * as arguments.
+	 * <p>
+	 * Note that any defaulting or processing according to the {@link #source()}
+	 * will happen <em>before</em> the formatting is applied, so template
+	 * arguments cannot be used, for example, to change the name of a system
+	 * property. Conversely, the scalar conversion will happen <em>after</em>
+	 * the template is applied, meaning that numeric values can be assembled
+	 * from multiple template arguments.
+	 *
+	 * @return the arguments that should be used with the template
+	 * @since 1.2
+	 */
+	ValueArgument[] templateArguments() default {};
 
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/common/annotation/Property.java
@@ -93,12 +93,12 @@ public @interface Property {
 
 	/**
 	 * Used to provide an argument in the {@link Property#templateArguments()}.
-	 * {@link ValueArgument} values are resolved in the same way as
+	 * {@link TemplateArgument} values are resolved in the same way as
 	 * {@link Property} values but they are always of {@link Type#Scalar}
 	 *
 	 * @since 1.2
 	 */
-	public @interface ValueArgument {
+	public @interface TemplateArgument {
 		String[] value() default "";
 
 		Scalar scalar() default Scalar.String;
@@ -123,7 +123,7 @@ public @interface Property {
 	/**
 	 * If any template arguments are set then the resolved value of this
 	 * {@link Property} annotation will be used as a template in
-	 * {@link String#format} with the resolved {@link ValueArgument} values used
+	 * {@link String#format} with the resolved {@link TemplateArgument} values used
 	 * as arguments.
 	 * <p>
 	 * Note that any defaulting or processing according to the {@link #source()}
@@ -136,6 +136,6 @@ public @interface Property {
 	 * @return the arguments that should be used with the template
 	 * @since 1.2
 	 */
-	ValueArgument[] templateArguments() default {};
+	TemplateArgument[] templateArguments() default {};
 
 }

--- a/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/PropertiesConverter.java
+++ b/org.osgi.test.junit5/src/main/java/org/osgi/test/junit5/properties/PropertiesConverter.java
@@ -45,7 +45,7 @@ public class PropertiesConverter {
 		String[] value = getRawValue(context, entry.value(), entry.source(), entry.type());
 
 		Object[] templateParams = Arrays.stream(entry.templateArguments())
-			.map(ta -> getRawValue(context, ta.value(), ta.source(), Type.Scalar)[0])
+			.map(ta -> convertScalar(ta.scalar(), getRawValue(context, ta.value(), ta.source(), Type.Scalar)[0]))
 			.toArray();
 
 		Object result = createArray(entry.scalar(), primitive, value.length);


### PR DESCRIPTION
Sometimes it is not sufficient to use configuration values exactly as they exist in System Properties or other sources, or several properties need to be combined to create the configuration property. This commit adds support for Value Arguments to be included in the annotations. These arguments cause the Property value to be taken as a template string suitable for use with String.format, with the supplied arguments used to populate the template.

Fixes #812