### PR TITLE
Ensure that configurations can be injected without calling update

### DIFF
--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/common/annotation/config/WithConfiguration.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/common/annotation/config/WithConfiguration.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.service.cm.Configuration;
 import org.osgi.test.common.annotation.Property;
 import org.osgi.test.junit5.cm.ConfigurationExtension;
 
@@ -62,8 +63,17 @@ public @interface WithConfiguration {
 	String location() default (Property.NOT_SET);
 
 	/**
-	 * Indicate the properties, that will be updated (if set) after selecting a
-	 * Configuration. If empty no update will be done.
+	 * Indicate the properties that will be used to update the defined
+	 * configuration.
+	 * <p>
+	 * When this annotation is used with
+	 * {@link InjectConfiguration#withConfig()} then leaving the properties
+	 * unset will result in the injection of a configuration that <em>has
+	 * not</em> had {@link Configuration#update(java.util.Dictionary)} called.
+	 * <p>
+	 * When used as a direct annotation leaving the properties unset has the
+	 * same effect as an empty array, and the configuration will be updated with
+	 * empty properties.
 	 *
 	 * @return The Properties.
 	 */

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/common/annotation/config/WithFactoryConfiguration.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/common/annotation/config/WithFactoryConfiguration.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.service.cm.Configuration;
 import org.osgi.test.common.annotation.Property;
 import org.osgi.test.junit5.cm.ConfigurationExtension;
 
@@ -55,7 +56,9 @@ public @interface WithFactoryConfiguration {
 	String factoryPid();
 
 	/**
-	 * The name of the Configuration.<br>
+	 * The name of the Configuration.
+	 * <p>
+	 * If not set then a generated name will be used
 	 *
 	 * @return The name
 	 */
@@ -69,8 +72,18 @@ public @interface WithFactoryConfiguration {
 	String location() default (Property.NOT_SET);
 
 	/**
-	 * Indicate the properties, that will be updated (if set) after selecting a
-	 * Configuration. If empty no update will be done.
+	 * Indicate the properties that will be used to update the defined factory
+	 * configuration.
+	 * <p>
+	 * When this annotation is used with
+	 * {@link InjectConfiguration#withFactoryConfig()} then leaving the
+	 * properties unset will result in the injection of a configuration that
+	 * <em>has not</em> had {@link Configuration#update(java.util.Dictionary)}
+	 * called.
+	 * <p>
+	 * When used as a direct annotation leaving the properties unset has the
+	 * same effect as an empty array, and the configuration will be updated with
+	 * empty properties.
 	 *
 	 * @return The Properties.
 	 */

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigUtil.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigUtil.java
@@ -95,6 +95,9 @@ public class ConfigUtil {
 	}
 
 	public static <K, V> Dictionary<K, V> copy(Dictionary<K, V> dictionary) {
+		if (dictionary == null) {
+			return null;
+		}
 		Dictionary<K, V> copy = new Hashtable<>();
 		Enumeration<K> keys = dictionary.keys();
 		while (keys.hasMoreElements()) {

--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationHolder.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/ConfigurationHolder.java
@@ -2,6 +2,8 @@ package org.osgi.test.junit5.cm;
 
 import java.util.Optional;
 
+import org.osgi.service.cm.Configuration;
+
 public class ConfigurationHolder {
 
 	public ConfigurationHolder(ConfigurationCopy configuration, Optional<ConfigurationCopy> beforeConfiguration) {
@@ -10,8 +12,19 @@ public class ConfigurationHolder {
 		this.beforeConfiguration = beforeConfiguration;
 	}
 
+	public ConfigurationHolder(Configuration cmConfiguration, Optional<ConfigurationCopy> beforeConfiguration) {
+		super();
+		this.configuration = ConfigurationCopy.of(cmConfiguration);
+		this.cmConfiguration = cmConfiguration;
+		this.beforeConfiguration = beforeConfiguration;
+	}
+
 	public ConfigurationCopy getConfiguration() {
 		return configuration;
+	}
+
+	public Configuration getCmConfiguration() {
+		return cmConfiguration;
 	}
 
 	public Optional<ConfigurationCopy> getBeforeConfiguration() {
@@ -19,6 +32,7 @@ public class ConfigurationHolder {
 	}
 
 	private ConfigurationCopy			configuration;
+	private Configuration				cmConfiguration;
 	private Optional<ConfigurationCopy>	beforeConfiguration;
 
 }

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/InjectWith.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/InjectWith.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package org.osgi.test.junit5.cm.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -84,4 +86,38 @@ public class InjectWith {
 			.isNotNull();
 	}
 
+	@Test
+	public void testInjectNoConfig(@InjectConfiguration("pid")
+	Configuration c, @InjectConfiguration("factory.pid~name")
+	Configuration fc) {
+		assertThat(c).isNull();
+		assertThat(fc).isNull();
+	}
+
+	@Test
+	public void testInjectNoUpdate(@InjectConfiguration(withConfig = @WithConfiguration(pid = "pid"))
+	Configuration c,
+		@InjectConfiguration(withFactoryConfig = @WithFactoryConfiguration(factoryPid = "factory.pid", name = "name"))
+		Configuration fc) throws Exception {
+		assertThat(c).isNotNull();
+		assertThat(c.getProperties()).isNull();
+		assertThat(fc).isNotNull();
+		assertThat(fc.getProperties()).isNull();
+	}
+
+	@Test
+	public void testInjectEmptyUpdate(
+		@InjectConfiguration(withConfig = @WithConfiguration(pid = "pid", properties = {}))
+		Configuration c,
+		@InjectConfiguration(withFactoryConfig = @WithFactoryConfiguration(factoryPid = "factory.pid", name = "name", properties = {}))
+		Configuration fc) throws Exception {
+		assertThat(c).isNotNull();
+		DictionaryAssert.assertThat(c.getProperties())
+			.isNotNull()
+			.isNotEmpty();
+		assertThat(fc).isNotNull();
+		DictionaryAssert.assertThat(fc.getProperties())
+			.isNotNull()
+			.isNotEmpty();
+	}
 }


### PR DESCRIPTION
Fixes #780 - it is supposed to be possible to inject configurations that have not been updated so that tests can view the pre and post update state of the system. This was not possible (despite being hinted at in the JavaDoc) as such configurations were always 'new' and therefore were updated with an empty dictionary. This commit fixes the check for this and avoids updating configurations with no properties set if, and only if, the configuration is being injected. It also then fixes a few places where the resulting null properties caused exceptions internally in the ConfigurationExtension.