### PR TITLE
Fix regresssion in annotation inheritance

### DIFF
--- a/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/AnnotationUtil.java
+++ b/org.osgi.test.junit5.cm/src/main/java/org/osgi/test/junit5/cm/AnnotationUtil.java
@@ -59,9 +59,9 @@ class AnnotationUtil {
 
 	private static void findAllAnnotationsMatching(AnnotatedElement annotatedElement, Predicate<Annotation> test,
 		ArrayList<? super Annotation> found, Set<Entry<AnnotatedElement, Annotation>> visited) {
-		Annotation[] declaredAnnotations = annotatedElement.getDeclaredAnnotations();
+		Annotation[] annotations = annotatedElement.getAnnotations();
 
-		for (Annotation ann : declaredAnnotations) {
+		for (Annotation ann : annotations) {
 			if (isJavaLangAnnotation(ann) || isJunitAnnotation(ann)) {
 				continue;
 			}

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/lifecycle/AbstractConfiguringClass.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/lifecycle/AbstractConfiguringClass.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.cm.test.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.osgi.service.cm.Configuration;
+import org.osgi.test.common.annotation.Property;
+import org.osgi.test.common.annotation.config.InjectConfiguration;
+import org.osgi.test.common.annotation.config.WithConfiguration;
+import org.osgi.test.common.annotation.config.WithFactoryConfiguration;
+
+
+@WithConfiguration(pid = AbstractConfiguringClass.CONFIG, properties = @Property(key = "location", value = "ca"))
+@WithFactoryConfiguration(factoryPid = AbstractConfiguringClass.CONFIG, name = AbstractConfiguringClass.CONFIG, properties = @Property(key = "location", value = "ca"))
+public class AbstractConfiguringClass {
+
+	public static final String	CONFIG							= "config";
+
+	@BeforeAll
+	static void beforeAll(@InjectConfiguration(CONFIG)
+	Configuration cm, @InjectConfiguration(CONFIG + "~" + CONFIG)
+	Configuration fcm) throws IOException {
+
+		assertNotNull(cm);
+		assertEquals(CONFIG, cm.getPid());
+		assertEquals("ca", cm.getProperties()
+			.get("location"));
+
+		assertNotNull(fcm);
+		assertEquals(CONFIG, fcm.getFactoryPid());
+		assertEquals("ca", fcm.getProperties()
+			.get("location"));
+
+	}
+}

--- a/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/lifecycle/ExtendingClassTest.java
+++ b/org.osgi.test.junit5.cm/src/test/java/org/osgi/test/junit5/cm/test/lifecycle/ExtendingClassTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.osgi.test.junit5.cm.test.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.osgi.service.cm.Configuration;
+import org.osgi.test.common.annotation.config.InjectConfiguration;
+
+public class ExtendingClassTest extends AbstractConfiguringClass {
+
+	@BeforeAll
+	static void chlidBeforeAll(@InjectConfiguration(CONFIG)
+	Configuration cm, @InjectConfiguration(CONFIG + "~" + CONFIG)
+	Configuration fcm) throws IOException {
+
+		assertNotNull(cm);
+		assertEquals(CONFIG, cm.getPid());
+		assertEquals("ca", cm.getProperties()
+			.get("location"));
+
+		assertNotNull(fcm);
+		assertEquals(CONFIG, fcm.getFactoryPid());
+		assertEquals("ca", fcm.getProperties()
+			.get("location"));
+	}
+
+	@Test
+	void test() {
+		// test assertions are all in ExtendingClassTest#childBeforeAll and
+		// AbstractConfiguringClass#beforeAll
+	}
+}


### PR DESCRIPTION
The WithConfiguration and WithFactoryConfiguration annotations should be inherited from parent classes if the annotations are marked @Inherited.

Fixes #817 