### PR TITLE
Adjust compile versions for JUnit and AssertJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<bnd.version>6.4.0</bnd.version>
-		<junit-jupiter.compile.version>5.6.0</junit-jupiter.compile.version>
-		<junit-platform.compile.version>1.6.0</junit-platform.compile.version>
-		<junit-jupiter.version>5.9.2</junit-jupiter.version>
-		<junit-platform.version>1.9.2</junit-platform.version>
-		<assertj.compile.version>3.24.2</assertj.compile.version>
+		<junit-jupiter.compile.version>5.8.2</junit-jupiter.compile.version>
+		<junit-platform.compile.version>1.8.2</junit-platform.compile.version>
+		<junit-jupiter.version>5.10.2</junit-jupiter.version>
+		<junit-platform.version>1.10.2</junit-platform.version>
+		<assertj.compile.version>3.23.1</assertj.compile.version>
 		<assertj.version>3.24.2</assertj.version>
 		<mockito.version>4.11.0</mockito.version>
 		<awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
The compile versions of AssertJ and JUnit gave an inconsistent base version for JUnit Jupiter, and as AssertJ only optionally requires JUnit Jupiter (it really should be another module with a mandatory dependency 🙁) you can easily end up with broken dependency graphs at runtime. This commit changes the base for AssertJ back to 3.23.x and ups JUnit to 5.8.x, which is consistent. It means we lose a couple of JUnit versions, but 5.8.x has already been released for more than two years.

See #816 for more details